### PR TITLE
feat(web): mobile UX overhaul + 3D puzzle plank (scroll, declutter, 3D shelf, curation, physics)

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2391,7 +2391,8 @@
       "confirmRemove": "Remove",
       "photoRemoved": "Photo removed",
       "removeFailed": "Couldn't remove the photo",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "unsetCover": "Unset as cover"
     },
     "offerForSwap": "Offer for Swap",
     "offeredForSwap": "Offered for Swap",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2269,7 +2269,8 @@
     "breadcrumbLabel": "Breadcrumb",
     "crumbs": {
       "ownedCopies": "Owned Copies"
-    }
+    },
+    "plankReset": "Reset"
   },
   "copyInstance": {
     "notFound": "Copy not found",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2217,7 +2217,7 @@
         "subtitle": "Add a puzzle to the shared catalogue for everyone."
       },
       "puzzles": {
-        "title": "Puzzles",
+        "title": "Puzzles catalogue",
         "subtitle": "The shared puzzle catalogue."
       },
       "borrowed": {
@@ -2264,7 +2264,10 @@
         "browseCommunitySub": "Discover puzzles near you"
       }
     },
-    "breadcrumbLabel": "Breadcrumb"
+    "breadcrumbLabel": "Breadcrumb",
+    "crumbs": {
+      "ownedCopies": "Owned Copies"
+    }
   },
   "copyInstance": {
     "notFound": "Copy not found",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -27,7 +27,9 @@
     "description": "Oops! The page you're looking for doesn't exist.",
     "message": "The page you're trying to access might have been moved, deleted, or you entered the wrong URL.",
     "backToHome": "Back to Home",
-    "browsePuzzles": "Browse Puzzles"
+    "browsePuzzles": "Browse Puzzles",
+    "backToDashboard": "Back to Dashboard",
+    "backToAdmin": "Back to Admin"
   },
   "navigation": {
     "home": "Home",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -696,7 +696,26 @@
     },
     "shelf": {
       "title": "{name}'s Shelf",
-      "meta": "{count, plural, one {# on display} other {# on display}}"
+      "meta": "{count, plural, one {# on display} other {# on display}}",
+      "arrangeDialog": {
+        "title": "Arrange Shelf",
+        "description": "Select and order up to {max} copies to feature on your profile shelf.",
+        "loading": "Loading copies…",
+        "noCopies": "You have no puzzle copies yet.",
+        "pickSection": "Your collection",
+        "maxHint": "Maximum {max} copies selected.",
+        "orderSection": "Selected ({count}/{max})",
+        "moveUp": "Move up",
+        "moveDown": "Move down",
+        "remove": "Remove",
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving…",
+        "saved": "Shelf saved",
+        "saveError": "Failed to save shelf",
+        "untitled": "Untitled"
+      },
+      "arrangeShelf": "Arrange shelf"
     },
     "trustLevels": {
       "beginner": "Beginner",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2355,7 +2355,7 @@
     "exchangesCount": "{count} exchanges",
     "noSwaps": "No swaps or trades for this puzzle yet.",
     "you": "you",
-    "finishedIn": "finished in {days, plural, one {# day} other {# days}}",
+    "finishedIn": "finished in {duration}",
     "communityRating": "Community Rating",
     "communityRatings": "{count} community ratings",
     "comments": "Comments",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -696,7 +696,26 @@
     },
     "shelf": {
       "title": "De Plank van {name}",
-      "meta": "{count, plural, one {# uitgestald} other {# uitgestald}}"
+      "meta": "{count, plural, one {# uitgestald} other {# uitgestald}}",
+      "arrangeDialog": {
+        "title": "Plank indelen",
+        "description": "Selecteer en orden maximaal {max} kopieën om te tonen op je profielplank.",
+        "loading": "Kopieën laden…",
+        "noCopies": "Je hebt nog geen puzzelkopieën.",
+        "pickSection": "Je collectie",
+        "maxHint": "Maximaal {max} kopieën geselecteerd.",
+        "orderSection": "Geselecteerd ({count}/{max})",
+        "moveUp": "Omhoog",
+        "moveDown": "Omlaag",
+        "remove": "Verwijderen",
+        "cancel": "Annuleren",
+        "save": "Opslaan",
+        "saving": "Opslaan…",
+        "saved": "Plank opgeslagen",
+        "saveError": "Opslaan mislukt",
+        "untitled": "Naamloos"
+      },
+      "arrangeShelf": "Plank indelen"
     },
     "trustLevels": {
       "beginner": "Beginner",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -27,7 +27,9 @@
     "description": "Oeps! De pagina die je zoekt bestaat niet.",
     "message": "De pagina die je probeert te openen is mogelijk verplaatst, verwijderd, of je hebt een verkeerde URL ingevoerd.",
     "backToHome": "Terug naar Home",
-    "browsePuzzles": "Puzzels Bladeren"
+    "browsePuzzles": "Puzzels Bladeren",
+    "backToDashboard": "Terug naar dashboard",
+    "backToAdmin": "Terug naar beheer"
   },
   "navigation": {
     "home": "Home",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2355,7 +2355,7 @@
     "exchangesCount": "{count} ruilen",
     "noSwaps": "Nog geen ruilen of handel voor deze puzzel.",
     "you": "jij",
-    "finishedIn": "voltooid in {days, plural, one {# dag} other {# dagen}}",
+    "finishedIn": "voltooid in {duration}",
     "communityRating": "Communitybeoordeling",
     "communityRatings": "{count} communitybeoordelingen",
     "comments": "Reacties",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2217,7 +2217,7 @@
         "subtitle": "Voeg een puzzel toe aan de gedeelde catalogus voor iedereen."
       },
       "puzzles": {
-        "title": "Puzzels",
+        "title": "Puzzelcatalogus",
         "subtitle": "De gedeelde puzzelcatalogus."
       },
       "borrowed": {
@@ -2264,7 +2264,10 @@
         "browseCommunitySub": "Ontdek puzzels bij jou in de buurt"
       }
     },
-    "breadcrumbLabel": "Broodkruimel"
+    "breadcrumbLabel": "Broodkruimel",
+    "crumbs": {
+      "ownedCopies": "Exemplaren"
+    }
   },
   "copyInstance": {
     "notFound": "Exemplaar niet gevonden",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2391,7 +2391,8 @@
       "confirmRemove": "Verwijderen",
       "photoRemoved": "Foto verwijderd",
       "removeFailed": "Kon de foto niet verwijderen",
-      "cancel": "Annuleren"
+      "cancel": "Annuleren",
+      "unsetCover": "Omslag verwijderen"
     },
     "offerForSwap": "Aanbieden voor ruil",
     "offeredForSwap": "Aangeboden voor ruil",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2269,7 +2269,8 @@
     "breadcrumbLabel": "Broodkruimel",
     "crumbs": {
       "ownedCopies": "Exemplaren"
-    }
+    },
+    "plankReset": "Herstellen"
   },
   "copyInstance": {
     "notFound": "Exemplaar niet gevonden",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2391,7 +2391,8 @@
       "confirmRemove": "Remove",
       "photoRemoved": "Photo removed",
       "removeFailed": "Couldn't remove the photo",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "unsetCover": "Unset as cover"
     },
     "offerForSwap": "Offer for Swap",
     "offeredForSwap": "Offered for Swap",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2269,7 +2269,8 @@
     "breadcrumbLabel": "Breadcrumb",
     "crumbs": {
       "ownedCopies": "Owned Copies"
-    }
+    },
+    "plankReset": "Reset"
   },
   "copyInstance": {
     "notFound": "Copy not found",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2217,7 +2217,7 @@
         "subtitle": "Add a puzzle to the shared catalogue for everyone."
       },
       "puzzles": {
-        "title": "Puzzles",
+        "title": "Puzzles catalogue",
         "subtitle": "The shared puzzle catalogue."
       },
       "borrowed": {
@@ -2264,7 +2264,10 @@
         "browseCommunitySub": "Discover puzzles near you"
       }
     },
-    "breadcrumbLabel": "Breadcrumb"
+    "breadcrumbLabel": "Breadcrumb",
+    "crumbs": {
+      "ownedCopies": "Owned Copies"
+    }
   },
   "copyInstance": {
     "notFound": "Copy not found",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -27,7 +27,9 @@
     "description": "Oops! The page you're looking for doesn't exist.",
     "message": "The page you're trying to access might have been moved, deleted, or you entered the wrong URL.",
     "backToHome": "Back to Home",
-    "browsePuzzles": "Browse Puzzles"
+    "browsePuzzles": "Browse Puzzles",
+    "backToDashboard": "Back to Dashboard",
+    "backToAdmin": "Back to Admin"
   },
   "navigation": {
     "home": "Home",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -696,7 +696,26 @@
     },
     "shelf": {
       "title": "{name}'s Shelf",
-      "meta": "{count, plural, one {# on display} other {# on display}}"
+      "meta": "{count, plural, one {# on display} other {# on display}}",
+      "arrangeDialog": {
+        "title": "Arrange Shelf",
+        "description": "Select and order up to {max} copies to feature on your profile shelf.",
+        "loading": "Loading copies…",
+        "noCopies": "You have no puzzle copies yet.",
+        "pickSection": "Your collection",
+        "maxHint": "Maximum {max} copies selected.",
+        "orderSection": "Selected ({count}/{max})",
+        "moveUp": "Move up",
+        "moveDown": "Move down",
+        "remove": "Remove",
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving…",
+        "saved": "Shelf saved",
+        "saveError": "Failed to save shelf",
+        "untitled": "Untitled"
+      },
+      "arrangeShelf": "Arrange shelf"
     },
     "trustLevels": {
       "beginner": "Beginner",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2355,7 +2355,7 @@
     "exchangesCount": "{count} exchanges",
     "noSwaps": "No swaps or trades for this puzzle yet.",
     "you": "you",
-    "finishedIn": "finished in {days, plural, one {# day} other {# days}}",
+    "finishedIn": "finished in {duration}",
     "communityRating": "Community Rating",
     "communityRatings": "{count} community ratings",
     "comments": "Comments",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.9",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
+    "@react-three/rapier": "^2.1.0",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.15",
     "@tanstack/react-router-ssr-query": "^1.167.1",

--- a/apps/web/src/components/NotFound.tsx
+++ b/apps/web/src/components/NotFound.tsx
@@ -9,41 +9,88 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
 import { useTranslations } from "use-intl";
 
-// Ported from app/not-found.tsx. The Next server component used getTranslations();
-// Start renders this as the router notFoundComponent (a client island), so it reads
-// the same "notFound" namespace via use-intl instead.
-export function NotFound() {
+// The shared 404 card — chrome-free. TanStack renders a route's notFoundComponent
+// inside that route's layout <Outlet />, so each context (marketing / app / admin)
+// supplies its own shell around this; only the action row differs per context.
+export function NotFoundContent({ actions }: { actions?: ReactNode }) {
   const t = useTranslations("notFound");
 
   return (
-    <div className="mk-root font-mk-sans">
-      <MarketingHeader />
-      <div className="min-h-screen bg-background flex items-center justify-center px-4">
-        <Card className="w-full max-w-md text-center">
-          <CardHeader className="space-y-4">
-            <div className="mx-auto w-24 h-24 bg-muted rounded-full flex items-center justify-center">
-              <TriangleAlert className="w-12 h-12 text-muted-foreground" />
-            </div>
-            <CardTitle className="text-3xl font-bold">{t("title")}</CardTitle>
-            <CardDescription className="text-lg">
-              {t("description")}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-muted-foreground">{t("message")}</p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button asChild>
-                <Link href="/">{t("backToHome")}</Link>
-              </Button>
-              <Button variant="outline" asChild>
-                <Link href="/browse">{t("browsePuzzles")}</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+    <div className="flex min-h-[60vh] items-center justify-center px-4 py-10">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader className="space-y-4">
+          <div className="bg-muted mx-auto flex h-24 w-24 items-center justify-center rounded-full">
+            <TriangleAlert className="text-muted-foreground h-12 w-12" />
+          </div>
+          <CardTitle className="text-3xl font-bold">{t("title")}</CardTitle>
+          <CardDescription className="text-lg">
+            {t("description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground">{t("message")}</p>
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            {actions ?? (
+              <>
+                <Button asChild>
+                  <Link href="/">{t("backToHome")}</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/browse">{t("browsePuzzles")}</Link>
+                </Button>
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
     </div>
+  );
+}
+
+// Marketing 404 — wraps the content in the marketing chrome itself. Used as the
+// ROOT notFoundComponent (unmatched top-level paths), where no layout shell exists.
+export function NotFound() {
+  return (
+    <div className="mk-root font-mk-sans bg-background min-h-screen">
+      <MarketingHeader />
+      <NotFoundContent />
+    </div>
+  );
+}
+
+// App 404 — rendered inside the dashboard shell (the _dashboard layout's Outlet),
+// so it needs no chrome of its own; just app-appropriate actions.
+export function AppNotFound() {
+  const t = useTranslations("notFound");
+  return (
+    <NotFoundContent
+      actions={
+        <>
+          <Button asChild>
+            <Link href="/dashboard">{t("backToDashboard")}</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/browse">{t("browsePuzzles")}</Link>
+          </Button>
+        </>
+      }
+    />
+  );
+}
+
+// Admin 404 — rendered inside the admin shell's Outlet.
+export function AdminNotFound() {
+  const t = useTranslations("notFound");
+  return (
+    <NotFoundContent
+      actions={
+        <Button asChild>
+          <Link href="/admin">{t("backToAdmin")}</Link>
+        </Button>
+      }
+    />
   );
 }

--- a/apps/web/src/components/common/puzzle-plank-3d/drag-math.test.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/drag-math.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { clampThrowVelocity, MAX_THROW_SPEED } from "./drag-math";
+
+describe("clampThrowVelocity", () => {
+  it("passes through a slow throw unchanged", () => {
+    expect(clampThrowVelocity([1, 0, -1])).toEqual([1, 0, -1]);
+  });
+  it("scales an over-fast throw down to MAX_THROW_SPEED, preserving direction", () => {
+    const v = clampThrowVelocity([0, 0, -100]);
+    expect(Math.hypot(...v)).toBeCloseTo(MAX_THROW_SPEED, 5);
+    expect(v[2]).toBeLessThan(0); // same direction
+    expect(v[0]).toBe(0);
+    expect(v[1]).toBe(0);
+  });
+  it("returns zero for a zero vector (no divide-by-zero)", () => {
+    expect(clampThrowVelocity([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+});

--- a/apps/web/src/components/common/puzzle-plank-3d/drag-math.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/drag-math.ts
@@ -1,0 +1,11 @@
+export type Vec3 = [number, number, number];
+
+/** Cap a throw so a flick can't launch a box across the scene; preserves direction. */
+export const MAX_THROW_SPEED = 6;
+
+export function clampThrowVelocity(v: Vec3): Vec3 {
+  const speed = Math.hypot(v[0], v[1], v[2]);
+  if (speed === 0 || speed <= MAX_THROW_SPEED) return v;
+  const k = MAX_THROW_SPEED / speed;
+  return [v[0] * k, v[1] * k, v[2] * k];
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/index.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/index.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import {
+  PuzzlePlank,
+  type PuzzlePlankBox,
+} from "@/components/common/puzzle-plank";
+import {
+  resolveCssColor,
+  resolveHeadingFont,
+} from "@/components/marketing/plank-3d/palette";
+import { useTheme } from "next-themes";
+import * as React from "react";
+import type { PlankSceneProps } from "./scene";
+
+const PlankScene = React.lazy(() => import("./scene"));
+
+function supportsWebGL(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    return !!(canvas.getContext("webgl2") || canvas.getContext("webgl"));
+  } catch {
+    return false;
+  }
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(false);
+  React.useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}
+
+/** Render-nothing error boundary: any 3D failure leaves the CSS plank. */
+class SceneBoundary extends React.Component<
+  { children: React.ReactNode; onError?: () => void },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  componentDidCatch() {
+    this.props.onError?.();
+  }
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+export function PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] }) {
+  const container = React.useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = React.useState(false);
+  const [sceneReady, setSceneReady] = React.useState(false);
+  const [visible, setVisible] = React.useState(true);
+  const [resolved, setResolved] = React.useState<
+    PlankSceneProps["resolved"] | null
+  >(null);
+  const [headingFont, setHeadingFont] = React.useState("system-ui, sans-serif");
+  const reducedMotion = usePrefersReducedMotion();
+  const { resolvedTheme } = useTheme();
+  const theme: "light" | "dark" = resolvedTheme === "dark" ? "dark" : "light";
+
+  React.useEffect(() => {
+    setMounted(supportsWebGL());
+  }, []);
+
+  // Resolve CSS-var colors + font from the live DOM; re-resolve when the
+  // theme flips so box colors match the page's current palette.
+  React.useEffect(() => {
+    const el = container.current;
+    if (!el || !mounted) return;
+    setResolved(
+      boxes.map((b) => ({
+        c1: resolveCssColor(b.c1 ?? "var(--jigsaw-primary)", el),
+        c2: resolveCssColor(b.c2 ?? "var(--jigsaw-primary)", el),
+      })),
+    );
+    setHeadingFont(resolveHeadingFont(el, "--font-heading"));
+  }, [boxes, mounted, theme]);
+
+  // Pause the render loop when the widget is offscreen.
+  React.useEffect(() => {
+    const el = container.current;
+    if (!el || !mounted) return;
+    const io = new IntersectionObserver(([entry]) =>
+      setVisible(entry.isIntersecting),
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [mounted]);
+
+  // Empty boxes → nothing to render.
+  if (boxes.length === 0) return null;
+
+  const showScene = mounted && resolved !== null;
+
+  return (
+    <div
+      ref={container}
+      style={{ position: "relative", width: "100%", height: "100%" }}
+      aria-hidden="true"
+    >
+      {/* CSS plank: fallback shown until the scene's first frame, or permanently
+          when WebGL is unavailable or the scene boundary catches an error. */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transition: "opacity .45s ease",
+          opacity: sceneReady ? 0 : 1,
+          pointerEvents: sceneReady ? "none" : undefined,
+        }}
+      >
+        <PuzzlePlank boxes={boxes} />
+      </div>
+
+      {showScene && (
+        <SceneBoundary onError={() => setSceneReady(false)}>
+          <React.Suspense fallback={null}>
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                pointerEvents: "none",
+                transition: "opacity .45s ease",
+                opacity: sceneReady ? 1 : 0,
+              }}
+            >
+              <PlankScene
+                boxes={boxes}
+                resolved={resolved}
+                headingFont={headingFont}
+                theme={theme}
+                reducedMotion={reducedMotion}
+                visible={visible}
+                onFirstFrame={() => setSceneReady(true)}
+                eventSource={container}
+              />
+            </div>
+          </React.Suspense>
+        </SceneBoundary>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/index.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/index.tsx
@@ -8,8 +8,11 @@ import {
   resolveCssColor,
   resolveHeadingFont,
 } from "@/components/marketing/plank-3d/palette";
+import { Button } from "@/components/ui/button";
+import { RotateCcw } from "lucide-react";
 import { useTheme } from "next-themes";
 import * as React from "react";
+import { useTranslations } from "use-intl";
 import type { PlankSceneProps } from "./scene";
 
 const PlankScene = React.lazy(() => import("./scene"));
@@ -74,6 +77,9 @@ export function PuzzlePlank3D({
     PlankSceneProps["resolved"] | null
   >(null);
   const [headingFont, setHeadingFont] = React.useState("system-ui, sans-serif");
+  // Bumped by the Reset button to snap the physics boxes back to their layout.
+  const [resetNonce, setResetNonce] = React.useState(0);
+  const t = useTranslations("shell");
   const reducedMotion = usePrefersReducedMotion();
   const { resolvedTheme } = useTheme();
   const theme: "light" | "dark" = resolvedTheme === "dark" ? "dark" : "light";
@@ -124,17 +130,19 @@ export function PuzzlePlank3D({
     visible,
     onFirstFrame: () => setSceneReady(true),
     eventSource: container,
+    resetNonce,
   };
 
   return (
     <div
       ref={container}
       style={{ position: "relative", width: "100%", height: "100%" }}
-      aria-hidden="true"
     >
       {/* CSS plank: fallback shown until the scene's first frame, or permanently
-          when WebGL is unavailable or the scene boundary catches an error. */}
+          when WebGL is unavailable or the scene boundary catches an error.
+          Decorative — hidden from assistive tech. */}
       <div
+        aria-hidden="true"
         style={{
           position: "absolute",
           inset: 0,
@@ -153,6 +161,7 @@ export function PuzzlePlank3D({
         <SceneBoundary onError={() => setSceneReady(false)}>
           <React.Suspense fallback={null}>
             <div
+              aria-hidden="true"
               style={{
                 position: "absolute",
                 inset: 0,
@@ -171,6 +180,23 @@ export function PuzzlePlank3D({
             </div>
           </React.Suspense>
         </SceneBoundary>
+      )}
+
+      {/* Reset control: only in the interactive physics scene, once it's live.
+          stopPropagation on pointer-down so the press isn't picked up by r3f as a
+          box grab (the canvas listens on this container as its event source). */}
+      {usePhysics && sceneReady && (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => setResetNonce((n) => n + 1)}
+          className="absolute right-2 bottom-2 z-10 gap-1.5 shadow-sm"
+        >
+          <RotateCcw className="size-3.5" />
+          {t("plankReset")}
+        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/common/puzzle-plank-3d/index.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/index.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 import type { PlankSceneProps } from "./scene";
 
 const PlankScene = React.lazy(() => import("./scene"));
+const PlankScenePhysics = React.lazy(() => import("./scene-physics"));
 
 function supportsWebGL(): boolean {
   try {
@@ -52,7 +53,19 @@ class SceneBoundary extends React.Component<
   }
 }
 
-export function PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] }) {
+export function PuzzlePlank3D({
+  boxes,
+  interactive = false,
+}: {
+  boxes: PuzzlePlankBox[];
+  /**
+   * When true, loads the rapier physics scene (grab/drag/throw) instead of
+   * the static scene. Only activates when WebGL is available and
+   * prefers-reduced-motion is not set. Defaults to false so all existing
+   * callers (dashboard, marketing hero) are unchanged.
+   */
+  interactive?: boolean;
+}) {
   const container = React.useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = React.useState(false);
   const [sceneReady, setSceneReady] = React.useState(false);
@@ -98,6 +111,20 @@ export function PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] }) {
   if (boxes.length === 0) return null;
 
   const showScene = mounted && resolved !== null;
+  // Use physics scene only when explicitly opted in, WebGL is available, and
+  // reduced-motion is not active. `mounted` already gates on WebGL.
+  const usePhysics = interactive && mounted && !reducedMotion;
+
+  const sceneProps: PlankSceneProps = {
+    boxes,
+    resolved: resolved ?? [],
+    headingFont,
+    theme,
+    reducedMotion,
+    visible,
+    onFirstFrame: () => setSceneReady(true),
+    eventSource: container,
+  };
 
   return (
     <div
@@ -129,21 +156,18 @@ export function PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] }) {
               style={{
                 position: "absolute",
                 inset: 0,
-                pointerEvents: "none",
+                // Physics scene needs pointer events for drag; static scene
+                // uses "none" so the surrounding page still scrolls freely.
+                pointerEvents: usePhysics ? "auto" : "none",
                 transition: "opacity .45s ease",
                 opacity: sceneReady ? 1 : 0,
               }}
             >
-              <PlankScene
-                boxes={boxes}
-                resolved={resolved}
-                headingFont={headingFont}
-                theme={theme}
-                reducedMotion={reducedMotion}
-                visible={visible}
-                onFirstFrame={() => setSceneReady(true)}
-                eventSource={container}
-              />
+              {usePhysics ? (
+                <PlankScenePhysics {...sceneProps} />
+              ) : (
+                <PlankScene {...sceneProps} />
+              )}
             </div>
           </React.Suspense>
         </SceneBoundary>

--- a/apps/web/src/components/common/puzzle-plank-3d/index.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/index.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "next-themes";
 import * as React from "react";
 import { useTranslations } from "use-intl";
 import type { PlankSceneProps } from "./scene";
+import { DEFAULT_WOOD_PARAMS, type WoodParams } from "./wood-texture";
 
 const PlankScene = React.lazy(() => import("./scene"));
 const PlankScenePhysics = React.lazy(() => import("./scene-physics"));
@@ -79,6 +80,9 @@ export function PuzzlePlank3D({
   const [headingFont, setHeadingFont] = React.useState("system-ui, sans-serif");
   // Bumped by the Reset button to snap the physics boxes back to their layout.
   const [resetNonce, setResetNonce] = React.useState(0);
+  // TEMPORARY: live wood-grain tuning via the on-screen tweaks panel.
+  const [woodParams, setWoodParams] =
+    React.useState<WoodParams>(DEFAULT_WOOD_PARAMS);
   const t = useTranslations("shell");
   const reducedMotion = usePrefersReducedMotion();
   const { resolvedTheme } = useTheme();
@@ -131,6 +135,7 @@ export function PuzzlePlank3D({
     onFirstFrame: () => setSceneReady(true),
     eventSource: container,
     resetNonce,
+    woodParams,
   };
 
   return (
@@ -197,6 +202,163 @@ export function PuzzlePlank3D({
           <RotateCcw className="size-3.5" />
           {t("plankReset")}
         </Button>
+      )}
+
+      {/* TEMPORARY wood-grain tuning panel — remove once the look is dialed in. */}
+      {showScene && sceneReady && (
+        <WoodTweaksPanel value={woodParams} onChange={setWoodParams} />
+      )}
+    </div>
+  );
+}
+
+// ——— TEMPORARY: wood-grain tweaks panel ———
+// A throwaway on-screen control surface so the wood-grain parameters can be
+// dialed in live in the browser. Once a good combination is found, update
+// DEFAULT_WOOD_PARAMS in wood-texture.ts and delete this component + its state.
+const WOOD_SLIDERS: Array<{
+  key: keyof WoodParams;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}> = [
+  { key: "grains", label: "Grains", min: 2, max: 28, step: 1 },
+  { key: "lineStrength", label: "Line", min: 0, max: 0.6, step: 0.01 },
+  { key: "streakStrength", label: "Streak", min: 0, max: 0.5, step: 0.01 },
+  { key: "toneStrength", label: "Tone", min: 0, max: 0.4, step: 0.01 },
+  { key: "warp", label: "Warp", min: 0, max: 0.25, step: 0.005 },
+  { key: "roughness", label: "Rough", min: 0.1, max: 1, step: 0.02 },
+];
+
+function WoodTweaksPanel({
+  value,
+  onChange,
+}: {
+  value: WoodParams;
+  onChange: (next: WoodParams) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  // Don't let presses inside the panel reach the r3f canvas (box grabs).
+  const stop = (e: React.PointerEvent) => e.stopPropagation();
+
+  return (
+    <div
+      onPointerDown={stop}
+      style={{
+        position: "absolute",
+        top: 8,
+        left: 8,
+        zIndex: 20,
+        fontFamily: "ui-monospace, monospace",
+        fontSize: 11,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          background: "rgba(20,18,42,0.85)",
+          color: "#fff",
+          border: "1px solid rgba(255,255,255,0.2)",
+          borderRadius: 6,
+          padding: "4px 8px",
+          cursor: "pointer",
+        }}
+      >
+        🪵 Wood {open ? "▲" : "▼"}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            marginTop: 6,
+            width: 220,
+            background: "rgba(20,18,42,0.92)",
+            color: "#fff",
+            border: "1px solid rgba(255,255,255,0.2)",
+            borderRadius: 8,
+            padding: 10,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            backdropFilter: "blur(4px)",
+          }}
+        >
+          {WOOD_SLIDERS.map((s) => (
+            <label
+              key={s.key}
+              style={{ display: "flex", flexDirection: "column", gap: 2 }}
+            >
+              <span
+                style={{ display: "flex", justifyContent: "space-between" }}
+              >
+                <span>{s.label}</span>
+                <span style={{ opacity: 0.8 }}>
+                  {Math.round(value[s.key] * 1000) / 1000}
+                </span>
+              </span>
+              <input
+                type="range"
+                min={s.min}
+                max={s.max}
+                step={s.step}
+                value={value[s.key]}
+                onChange={(e) =>
+                  onChange({ ...value, [s.key]: Number(e.target.value) })
+                }
+                style={{ width: "100%" }}
+              />
+            </label>
+          ))}
+
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => onChange(DEFAULT_WOOD_PARAMS)}
+              style={{
+                flex: 1,
+                background: "rgba(255,255,255,0.12)",
+                color: "#fff",
+                border: "1px solid rgba(255,255,255,0.2)",
+                borderRadius: 6,
+                padding: "4px 6px",
+                cursor: "pointer",
+              }}
+            >
+              Reset
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void navigator.clipboard?.writeText(JSON.stringify(value))
+              }
+              style={{
+                flex: 1,
+                background: "rgba(255,255,255,0.12)",
+                color: "#fff",
+                border: "1px solid rgba(255,255,255,0.2)",
+                borderRadius: 6,
+                padding: "4px 6px",
+                cursor: "pointer",
+              }}
+            >
+              Copy
+            </button>
+          </div>
+
+          <pre
+            style={{
+              margin: 0,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+              opacity: 0.85,
+              fontSize: 10,
+            }}
+          >
+            {JSON.stringify(value)}
+          </pre>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/common/puzzle-plank-3d/index.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/index.tsx
@@ -14,7 +14,6 @@ import { useTheme } from "next-themes";
 import * as React from "react";
 import { useTranslations } from "use-intl";
 import type { PlankSceneProps } from "./scene";
-import { DEFAULT_WOOD_PARAMS, type WoodParams } from "./wood-texture";
 
 const PlankScene = React.lazy(() => import("./scene"));
 const PlankScenePhysics = React.lazy(() => import("./scene-physics"));
@@ -80,9 +79,6 @@ export function PuzzlePlank3D({
   const [headingFont, setHeadingFont] = React.useState("system-ui, sans-serif");
   // Bumped by the Reset button to snap the physics boxes back to their layout.
   const [resetNonce, setResetNonce] = React.useState(0);
-  // TEMPORARY: live wood-grain tuning via the on-screen tweaks panel.
-  const [woodParams, setWoodParams] =
-    React.useState<WoodParams>(DEFAULT_WOOD_PARAMS);
   const t = useTranslations("shell");
   const reducedMotion = usePrefersReducedMotion();
   const { resolvedTheme } = useTheme();
@@ -135,7 +131,6 @@ export function PuzzlePlank3D({
     onFirstFrame: () => setSceneReady(true),
     eventSource: container,
     resetNonce,
-    woodParams,
   };
 
   return (
@@ -202,163 +197,6 @@ export function PuzzlePlank3D({
           <RotateCcw className="size-3.5" />
           {t("plankReset")}
         </Button>
-      )}
-
-      {/* TEMPORARY wood-grain tuning panel — remove once the look is dialed in. */}
-      {showScene && sceneReady && (
-        <WoodTweaksPanel value={woodParams} onChange={setWoodParams} />
-      )}
-    </div>
-  );
-}
-
-// ——— TEMPORARY: wood-grain tweaks panel ———
-// A throwaway on-screen control surface so the wood-grain parameters can be
-// dialed in live in the browser. Once a good combination is found, update
-// DEFAULT_WOOD_PARAMS in wood-texture.ts and delete this component + its state.
-const WOOD_SLIDERS: Array<{
-  key: keyof WoodParams;
-  label: string;
-  min: number;
-  max: number;
-  step: number;
-}> = [
-  { key: "grains", label: "Grains", min: 2, max: 28, step: 1 },
-  { key: "lineStrength", label: "Line", min: 0, max: 0.6, step: 0.01 },
-  { key: "streakStrength", label: "Streak", min: 0, max: 0.5, step: 0.01 },
-  { key: "toneStrength", label: "Tone", min: 0, max: 0.4, step: 0.01 },
-  { key: "warp", label: "Warp", min: 0, max: 0.25, step: 0.005 },
-  { key: "roughness", label: "Rough", min: 0.1, max: 1, step: 0.02 },
-];
-
-function WoodTweaksPanel({
-  value,
-  onChange,
-}: {
-  value: WoodParams;
-  onChange: (next: WoodParams) => void;
-}) {
-  const [open, setOpen] = React.useState(false);
-  // Don't let presses inside the panel reach the r3f canvas (box grabs).
-  const stop = (e: React.PointerEvent) => e.stopPropagation();
-
-  return (
-    <div
-      onPointerDown={stop}
-      style={{
-        position: "absolute",
-        top: 8,
-        left: 8,
-        zIndex: 20,
-        fontFamily: "ui-monospace, monospace",
-        fontSize: 11,
-      }}
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        style={{
-          background: "rgba(20,18,42,0.85)",
-          color: "#fff",
-          border: "1px solid rgba(255,255,255,0.2)",
-          borderRadius: 6,
-          padding: "4px 8px",
-          cursor: "pointer",
-        }}
-      >
-        🪵 Wood {open ? "▲" : "▼"}
-      </button>
-
-      {open && (
-        <div
-          style={{
-            marginTop: 6,
-            width: 220,
-            background: "rgba(20,18,42,0.92)",
-            color: "#fff",
-            border: "1px solid rgba(255,255,255,0.2)",
-            borderRadius: 8,
-            padding: 10,
-            display: "flex",
-            flexDirection: "column",
-            gap: 8,
-            backdropFilter: "blur(4px)",
-          }}
-        >
-          {WOOD_SLIDERS.map((s) => (
-            <label
-              key={s.key}
-              style={{ display: "flex", flexDirection: "column", gap: 2 }}
-            >
-              <span
-                style={{ display: "flex", justifyContent: "space-between" }}
-              >
-                <span>{s.label}</span>
-                <span style={{ opacity: 0.8 }}>
-                  {Math.round(value[s.key] * 1000) / 1000}
-                </span>
-              </span>
-              <input
-                type="range"
-                min={s.min}
-                max={s.max}
-                step={s.step}
-                value={value[s.key]}
-                onChange={(e) =>
-                  onChange({ ...value, [s.key]: Number(e.target.value) })
-                }
-                style={{ width: "100%" }}
-              />
-            </label>
-          ))}
-
-          <div style={{ display: "flex", gap: 6 }}>
-            <button
-              type="button"
-              onClick={() => onChange(DEFAULT_WOOD_PARAMS)}
-              style={{
-                flex: 1,
-                background: "rgba(255,255,255,0.12)",
-                color: "#fff",
-                border: "1px solid rgba(255,255,255,0.2)",
-                borderRadius: 6,
-                padding: "4px 6px",
-                cursor: "pointer",
-              }}
-            >
-              Reset
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                void navigator.clipboard?.writeText(JSON.stringify(value))
-              }
-              style={{
-                flex: 1,
-                background: "rgba(255,255,255,0.12)",
-                color: "#fff",
-                border: "1px solid rgba(255,255,255,0.2)",
-                borderRadius: 6,
-                padding: "4px 6px",
-                cursor: "pointer",
-              }}
-            >
-              Copy
-            </button>
-          </div>
-
-          <pre
-            style={{
-              margin: 0,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-all",
-              opacity: 0.85,
-              fontSize: 10,
-            }}
-          >
-            {JSON.stringify(value)}
-          </pre>
-        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/common/puzzle-plank-3d/layout.test.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/layout.test.ts
@@ -1,0 +1,34 @@
+import { BOX_SCALE, PX } from "@/components/marketing/plank-3d/box";
+import { describe, expect, it } from "vitest";
+import { GAP, layoutRow } from "./layout";
+
+const w = (px: number) => px * PX * BOX_SCALE;
+
+describe("layoutRow", () => {
+  it("returns no slots and zero width for an empty list", () => {
+    expect(layoutRow([])).toEqual({ slots: [], rowWidth: 0 });
+  });
+
+  it("centers a single box on x=0", () => {
+    const { slots, rowWidth } = layoutRow([{ width: 116 }]);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].x).toBeCloseTo(0, 6);
+    expect(rowWidth).toBeCloseTo(w(116), 6);
+  });
+
+  it("defaults missing width to 116", () => {
+    expect(layoutRow([{}])[0 as never]).toBeUndefined(); // guard: result is an object, not array
+    const { rowWidth } = layoutRow([{}]);
+    expect(rowWidth).toBeCloseTo(w(116), 6);
+  });
+
+  it("lays out two boxes left->right, centered, separated by GAP", () => {
+    const { slots, rowWidth } = layoutRow([{ width: 100 }, { width: 100 }]);
+    const wb = w(100);
+    expect(rowWidth).toBeCloseTo(wb * 2 + GAP, 6);
+    // centered: total span = 2*wb + GAP; first center at -(span/2)+wb/2
+    expect(slots[0].x).toBeCloseTo(-(wb + GAP) / 2, 6);
+    expect(slots[1].x).toBeCloseTo((wb + GAP) / 2, 6);
+    expect(slots[1].x - slots[0].x).toBeCloseTo(wb + GAP, 6);
+  });
+});

--- a/apps/web/src/components/common/puzzle-plank-3d/layout.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/layout.ts
@@ -1,0 +1,38 @@
+import type { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import { BOX_SCALE, PX } from "@/components/marketing/plank-3d/box";
+
+/** World-space gap between neighbouring boxes on the shelf row. */
+export const GAP = 0.12;
+
+export interface RowSlot {
+  /** World-space x of the box center. */
+  x: number;
+}
+
+export interface RowLayout {
+  slots: RowSlot[];
+  /** Total world width spanned by the boxes + gaps. */
+  rowWidth: number;
+}
+
+/** World width of one box from its CSS-pixel width (matches box.tsx scaling). */
+function boxWorldWidth(box: PuzzlePlankBox): number {
+  return (box.width ?? 116) * PX * BOX_SCALE;
+}
+
+/**
+ * Lay boxes out in a single row, centered on x=0, left→right in list order,
+ * separated by GAP. Deterministic; no randomness. Pure.
+ */
+export function layoutRow(boxes: PuzzlePlankBox[]): RowLayout {
+  if (boxes.length === 0) return { slots: [], rowWidth: 0 };
+  const widths = boxes.map(boxWorldWidth);
+  const rowWidth = widths.reduce((a, b) => a + b, 0) + GAP * (boxes.length - 1);
+  const slots: RowSlot[] = [];
+  let cursor = -rowWidth / 2;
+  for (const wb of widths) {
+    slots.push({ x: cursor + wb / 2 });
+    cursor += wb + GAP;
+  }
+  return { slots, rowWidth };
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -1,0 +1,503 @@
+"use client";
+
+import type { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import {
+  BOX_DEPTH,
+  boxWorldSize,
+  PuzzleBox,
+} from "@/components/marketing/plank-3d/box";
+import {
+  LIGHTING,
+  type LightingPreset,
+} from "@/components/marketing/plank-3d/palette";
+import { ContactShadows } from "@react-three/drei";
+import type {
+  DomEvent,
+  EventManager,
+  RootState,
+  RootStore,
+} from "@react-three/fiber";
+import { Canvas, events, useFrame, useThree } from "@react-three/fiber";
+import {
+  CuboidCollider,
+  Physics,
+  RigidBody,
+  type RapierRigidBody,
+} from "@react-three/rapier";
+import { easing } from "maath";
+import * as React from "react";
+import * as THREE from "three";
+import { clampThrowVelocity } from "./drag-math";
+import { layoutRow } from "./layout";
+import type { PlankSceneProps } from "./scene";
+
+// @dimforge/rapier3d-compat is a transitive peer; we reference its enum
+// values via numeric constants to avoid a direct (unresolvable) import.
+// RigidBodyType: Dynamic=0, Fixed=1, KinematicPositionBased=2
+const RB_DYNAMIC = 0 as Parameters<RapierRigidBody["setBodyType"]>[0];
+const RB_KINEMATIC_POS = 2 as Parameters<RapierRigidBody["setBodyType"]>[0];
+
+// ——— shelf constants (mirrors scene.tsx) ———
+const SHELF_THICKNESS = 0.14;
+const SHELF_DEPTH = 0.6;
+
+// ——— camera constants (mirrors scene.tsx) ———
+const FOV = 38;
+const CONTENT_HEADROOM = 0.4;
+const MIN_VIS_W = 2.0;
+const CAMERA_Y_LIFT = 0.3;
+// The yaw is baked into the camera position/lookAt; physics bodies live in
+// world-aligned space so they don't need to be wrapped in a rotated group.
+const FIXED_YAW = -(12 * Math.PI) / 180;
+
+// ——— drag ring-buffer size ———
+const DRAG_BUF = 4;
+
+// ——— world height helper ———
+function boxWorldHeight(box: PuzzlePlankBox): number {
+  return boxWorldSize(box).h;
+}
+
+// ——— Lights (identical to scene.tsx) ———
+function Lights({
+  preset,
+  reducedMotion,
+}: {
+  preset: LightingPreset;
+  reducedMotion: boolean;
+}) {
+  const key = React.useRef<THREE.DirectionalLight>(null);
+  const ambient = React.useRef<THREE.AmbientLight>(null);
+  const hemi = React.useRef<THREE.HemisphereLight>(null);
+  const rim = React.useRef<THREE.DirectionalLight>(null);
+
+  useFrame((_, delta) => {
+    if (!key.current || !ambient.current || !hemi.current || !rim.current)
+      return;
+    if (reducedMotion) {
+      key.current.intensity = preset.keyIntensity;
+      key.current.color.set(preset.keyColor);
+      ambient.current.intensity = preset.ambientIntensity;
+      ambient.current.color.set(preset.ambientColor);
+      hemi.current.intensity = preset.hemiIntensity;
+      rim.current.intensity = preset.rimIntensity;
+      return;
+    }
+    easing.damp(key.current, "intensity", preset.keyIntensity, 0.3, delta);
+    easing.dampC(key.current.color, preset.keyColor, 0.3, delta);
+    easing.damp(
+      ambient.current,
+      "intensity",
+      preset.ambientIntensity,
+      0.3,
+      delta,
+    );
+    easing.dampC(ambient.current.color, preset.ambientColor, 0.3, delta);
+    easing.damp(hemi.current, "intensity", preset.hemiIntensity, 0.3, delta);
+    easing.damp(rim.current, "intensity", preset.rimIntensity, 0.3, delta);
+  });
+
+  return (
+    <>
+      <directionalLight
+        ref={key}
+        position={[2.5, 5, 3.5]}
+        intensity={preset.keyIntensity}
+      />
+      <ambientLight ref={ambient} intensity={preset.ambientIntensity} />
+      <hemisphereLight
+        ref={hemi}
+        color="#ffffff"
+        groundColor="#d9c4a8"
+        intensity={preset.hemiIntensity}
+      />
+      <directionalLight
+        ref={rim}
+        position={[-3, 3.5, -2]}
+        color="#8b5cf6"
+        intensity={preset.rimIntensity}
+      />
+    </>
+  );
+}
+
+function FirstFrame({ onFirstFrame }: { onFirstFrame: () => void }) {
+  const fired = React.useRef(false);
+  useFrame(() => {
+    if (!fired.current) {
+      fired.current = true;
+      onFirstFrame();
+    }
+  });
+  return null;
+}
+
+// transformSafeEvents: pointer NDC computed from the canvas's live client rect.
+function transformSafeEvents(store: RootStore): EventManager<HTMLElement> {
+  return {
+    ...events(store),
+    compute(event: DomEvent, state: RootState) {
+      const rect = state.gl.domElement.getBoundingClientRect();
+      state.pointer.set(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        (-(event.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      state.raycaster.setFromCamera(state.pointer, state.camera);
+    },
+  };
+}
+
+// ——— Drag hook — inline because it needs access to scene state ———
+interface DragState {
+  bodyIndex: number;
+  grabOffset: THREE.Vector3; // offset from body origin to grab point
+  dragPlane: THREE.Plane; // camera-parallel plane through the grab point
+  buf: Array<{ pos: THREE.Vector3; t: number }>; // ring buffer for velocity
+  bufIdx: number;
+  canvas: HTMLCanvasElement;
+}
+
+function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
+  onPointerDown: (e: React.PointerEvent<HTMLElement>, index: number) => void;
+} {
+  const { camera, raycaster, pointer } = useThree();
+  const dragState = React.useRef<DragState | null>(null);
+  const canvas = useThree((s) => s.gl.domElement);
+
+  // Pointer-move on window during drag
+  React.useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const ds = dragState.current;
+      if (!ds) return;
+
+      // Recompute NDC from canvas bounds (same as transformSafeEvents)
+      const rect = canvas.getBoundingClientRect();
+      pointer.set(
+        ((e.clientX - rect.left) / rect.width) * 2 - 1,
+        (-(e.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      raycaster.setFromCamera(pointer, camera);
+
+      const hit = new THREE.Vector3();
+      raycaster.ray.intersectPlane(ds.dragPlane, hit);
+      if (!hit) return;
+
+      const body = rigidBodyRefs[ds.bodyIndex]?.current;
+      if (!body) return;
+
+      const targetPos = hit.clone().sub(ds.grabOffset);
+      body.setNextKinematicTranslation(targetPos);
+
+      // Push into ring buffer
+      const idx = ds.bufIdx % DRAG_BUF;
+      ds.buf[idx] = { pos: targetPos.clone(), t: e.timeStamp };
+      ds.bufIdx++;
+    };
+
+    const onUp = (e: PointerEvent) => {
+      const ds = dragState.current;
+      if (!ds) return;
+
+      const body = rigidBodyRefs[ds.bodyIndex]?.current;
+      if (body) {
+        // Compute velocity from ring buffer (last two valid samples)
+        const count = Math.min(ds.bufIdx, DRAG_BUF);
+        if (count >= 2) {
+          const newest = ds.buf[(ds.bufIdx - 1) % DRAG_BUF];
+          const older = ds.buf[(ds.bufIdx - 2) % DRAG_BUF];
+          if (newest && older) {
+            const dt = (newest.t - older.t) / 1000;
+            if (dt > 0) {
+              const rawVel: [number, number, number] = [
+                (newest.pos.x - older.pos.x) / dt,
+                (newest.pos.y - older.pos.y) / dt,
+                (newest.pos.z - older.pos.z) / dt,
+              ];
+              const vel = clampThrowVelocity(rawVel);
+              body.setBodyType(RB_DYNAMIC, true);
+              body.setLinvel({ x: vel[0], y: vel[1], z: vel[2] }, true);
+            } else {
+              body.setBodyType(RB_DYNAMIC, true);
+              body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+            }
+          } else {
+            body.setBodyType(RB_DYNAMIC, true);
+          }
+        } else {
+          body.setBodyType(RB_DYNAMIC, true);
+        }
+      }
+
+      // Restore scroll on touch
+      canvas.style.touchAction = "";
+      ds.canvas.releasePointerCapture(e.pointerId);
+      dragState.current = null;
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, [camera, canvas, pointer, raycaster, rigidBodyRefs]);
+
+  const onPointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLElement>, index: number) => {
+      e.stopPropagation();
+      const body = rigidBodyRefs[index]?.current;
+      if (!body) return;
+
+      // Capture the pointer so moves/ups fire even outside the canvas
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+      // Prevent page scroll while dragging
+      canvas.style.touchAction = "none";
+
+      // Switch to kinematic so we drive the position
+      body.setBodyType(RB_KINEMATIC_POS, true);
+
+      // Compute grab point in world space via raycaster
+      const rect = canvas.getBoundingClientRect();
+      pointer.set(
+        ((e.clientX - rect.left) / rect.width) * 2 - 1,
+        (-(e.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      raycaster.setFromCamera(pointer, camera);
+
+      // Drag plane: normal = camera forward, through the body's current position
+      const bodyPos = body.translation();
+      const bodyVec = new THREE.Vector3(bodyPos.x, bodyPos.y, bodyPos.z);
+      const camForward = new THREE.Vector3();
+      camera.getWorldDirection(camForward);
+      const dragPlane = new THREE.Plane().setFromNormalAndCoplanarPoint(
+        camForward,
+        bodyVec,
+      );
+
+      // Grab offset = hit point - body center (so box doesn't jump to cursor)
+      const hit = new THREE.Vector3();
+      raycaster.ray.intersectPlane(dragPlane, hit);
+      const grabOffset = hit.sub(bodyVec);
+
+      dragState.current = {
+        bodyIndex: index,
+        grabOffset,
+        dragPlane,
+        buf: [],
+        bufIdx: 0,
+        canvas: canvas,
+      };
+    },
+    [camera, canvas, pointer, raycaster, rigidBodyRefs],
+  );
+
+  return { onPointerDown };
+}
+
+// ——— Physics Arrangement ———
+function PhysicsArrangement({
+  boxes,
+  resolved,
+  headingFont,
+  lightingPreset,
+  reducedMotion,
+  onFirstFrame,
+}: {
+  boxes: PuzzlePlankBox[];
+  resolved: Array<{ c1: string; c2: string }>;
+  headingFont: string;
+  lightingPreset: LightingPreset;
+  reducedMotion: boolean;
+  onFirstFrame: () => void;
+}) {
+  const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
+  const size = useThree((s) => s.size);
+
+  const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
+
+  const maxBoxH = React.useMemo(
+    () => Math.max(...boxes.map(boxWorldHeight), 0.5),
+    [boxes],
+  );
+
+  // ——— cover-fit camera with yaw baked in ———
+  // Instead of wrapping content in a rotated group, we orbit the camera
+  // around the y-axis by FIXED_YAW so boxes appear at the same 12° angle
+  // as in the static scene while physics bodies live in world space.
+  const vFov = (FOV * Math.PI) / 180;
+  const aspect = size.width / size.height;
+  const framedH = maxBoxH + CONTENT_HEADROOM;
+  const contentH = Math.max(framedH, MIN_VIS_W / aspect);
+  const dist = contentH / 2 / Math.tan(vFov / 2);
+  const lookAtY = maxBoxH / 2;
+  const cameraY = lookAtY + CAMERA_Y_LIFT;
+
+  React.useLayoutEffect(() => {
+    // Orbit camera by FIXED_YAW around y-axis while targeting the shelf center
+    const camX = Math.sin(-FIXED_YAW) * dist;
+    const camZ = Math.cos(-FIXED_YAW) * dist;
+    camera.position.set(camX, cameraY, camZ);
+    camera.lookAt(0, lookAtY, 0);
+    camera.updateProjectionMatrix();
+  }, [camera, size, dist, cameraY, lookAtY]);
+
+  const shelfW = rowWidth + 0.4;
+
+  // Per-box rigid body refs for the drag hook
+  const rigidBodyRefs = React.useMemo(
+    () => boxes.map(() => React.createRef<RapierRigidBody>()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [boxes.length],
+  );
+
+  const { onPointerDown } = useBoxDrag(
+    rigidBodyRefs as React.RefObject<RapierRigidBody | null>[],
+  );
+
+  return (
+    <>
+      <FirstFrame onFirstFrame={onFirstFrame} />
+
+      {/* Fixed shelf board */}
+      <RigidBody type="fixed" colliders={false}>
+        <CuboidCollider
+          args={[shelfW / 2, SHELF_THICKNESS / 2, SHELF_DEPTH / 2]}
+          position={[
+            0,
+            -SHELF_THICKNESS / 2,
+            SHELF_DEPTH / 2 - BOX_DEPTH / 2 - 0.1,
+          ]}
+        />
+        <mesh
+          position={[
+            0,
+            -SHELF_THICKNESS / 2,
+            SHELF_DEPTH / 2 - BOX_DEPTH / 2 - 0.1,
+          ]}
+        >
+          <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
+          <meshStandardMaterial
+            color={lightingPreset.shelfColor}
+            roughness={0.7}
+          />
+        </mesh>
+      </RigidBody>
+
+      {/* Invisible ground plane to catch fallen boxes */}
+      <RigidBody type="fixed" colliders={false}>
+        <CuboidCollider
+          args={[shelfW * 3, 0.05, SHELF_DEPTH * 3]}
+          position={[0, -(SHELF_THICKNESS + maxBoxH * 2), 0]}
+        />
+      </RigidBody>
+
+      {/* Invisible side walls to keep boxes on the shelf */}
+      <RigidBody type="fixed" colliders={false}>
+        {/* Left wall */}
+        <CuboidCollider
+          args={[0.05, maxBoxH, SHELF_DEPTH]}
+          position={[-(shelfW / 2 + 0.05), maxBoxH / 2, 0]}
+        />
+        {/* Right wall */}
+        <CuboidCollider
+          args={[0.05, maxBoxH, SHELF_DEPTH]}
+          position={[shelfW / 2 + 0.05, maxBoxH / 2, 0]}
+        />
+        {/* Back wall */}
+        <CuboidCollider
+          args={[shelfW / 2, maxBoxH, 0.05]}
+          position={[0, maxBoxH / 2, -(SHELF_DEPTH / 2 + 0.05)]}
+        />
+        {/* Front wall */}
+        <CuboidCollider
+          args={[shelfW / 2, maxBoxH, 0.05]}
+          position={[0, maxBoxH / 2, SHELF_DEPTH / 2 + 0.05]}
+        />
+      </RigidBody>
+
+      {/* Dynamic puzzle boxes */}
+      {boxes.map((box, i) => {
+        const { w, h } = boxWorldSize(box);
+        const slot = slots[i];
+        if (!slot) return null;
+        return (
+          <RigidBody
+            key={i}
+            ref={rigidBodyRefs[i]}
+            type="dynamic"
+            position={[slot.x, h / 2, 0]}
+            colliders={false}
+            restitution={0.1}
+            friction={0.8}
+            linearDamping={0.5}
+            angularDamping={0.8}
+          >
+            <CuboidCollider args={[w / 2, h / 2, BOX_DEPTH / 2]} />
+            <group
+              onPointerDown={(e) =>
+                onPointerDown(
+                  e as unknown as React.PointerEvent<HTMLElement>,
+                  i,
+                )
+              }
+            >
+              <PuzzleBox
+                box={box}
+                slot={{
+                  x: slot.x,
+                  c1: resolved[i]?.c1 ?? "#6048e8",
+                  c2: resolved[i]?.c2 ?? "#494e92",
+                }}
+                index={i}
+                headingFont={headingFont}
+                sizeScale={1}
+                anchored={false}
+              />
+            </group>
+          </RigidBody>
+        );
+      })}
+
+      <ContactShadows
+        position={[0, 0.001, 0]}
+        opacity={lightingPreset.shadowOpacity}
+        scale={rowWidth + 1}
+        blur={2.2}
+        far={1.2}
+        resolution={256}
+      />
+    </>
+  );
+}
+
+export default function PlankScenePhysics(props: PlankSceneProps) {
+  const lightingPreset = LIGHTING[props.theme];
+  return (
+    <Canvas
+      dpr={[1, 2]}
+      frameloop={props.visible ? "always" : "never"}
+      gl={{ alpha: true, antialias: true }}
+      style={{ pointerEvents: "auto", background: "transparent" }}
+      camera={{ fov: FOV }}
+      eventSource={props.eventSource as unknown as React.RefObject<HTMLElement>}
+      events={transformSafeEvents}
+      resize={{ offsetSize: true }}
+    >
+      <Lights preset={lightingPreset} reducedMotion={props.reducedMotion} />
+      <Physics
+        gravity={[0, -9.81, 0]}
+        paused={!props.visible || props.reducedMotion}
+      >
+        <PhysicsArrangement
+          boxes={props.boxes}
+          resolved={props.resolved}
+          headingFont={props.headingFont}
+          lightingPreset={lightingPreset}
+          reducedMotion={props.reducedMotion}
+          onFirstFrame={props.onFirstFrame}
+        />
+      </Physics>
+    </Canvas>
+  );
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -30,6 +30,7 @@ import * as THREE from "three";
 import { clampThrowVelocity } from "./drag-math";
 import { layoutRow } from "./layout";
 import type { PlankSceneProps } from "./scene";
+import { useWoodTexture } from "./wood-texture";
 
 // @dimforge/rapier3d-compat is a transitive peer; we reference its enum
 // values via numeric constants to avoid a direct (unresolvable) import.
@@ -366,6 +367,9 @@ function PhysicsArrangement({
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
+  // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
+
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
   const maxBoxH = React.useMemo(
@@ -474,10 +478,7 @@ function PhysicsArrangement({
           ]}
         >
           <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
-          <meshStandardMaterial
-            color={lightingPreset.shelfColor}
-            roughness={0.7}
-          />
+          <meshStandardMaterial map={woodTexture} roughness={0.62} />
         </mesh>
       </RigidBody>
 

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -30,7 +30,11 @@ import * as THREE from "three";
 import { clampThrowVelocity } from "./drag-math";
 import { layoutRow } from "./layout";
 import type { PlankSceneProps } from "./scene";
-import { useWoodTexture } from "./wood-texture";
+import {
+  DEFAULT_WOOD_PARAMS,
+  useWoodTexture,
+  type WoodParams,
+} from "./wood-texture";
 
 // @dimforge/rapier3d-compat is a transitive peer; we reference its enum
 // values via numeric constants to avoid a direct (unresolvable) import.
@@ -356,6 +360,7 @@ function PhysicsArrangement({
   lightingPreset,
   onFirstFrame,
   resetNonce = 0,
+  woodParams,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
@@ -363,12 +368,13 @@ function PhysicsArrangement({
   lightingPreset: LightingPreset;
   onFirstFrame: () => void;
   resetNonce?: number;
+  woodParams: WoodParams;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
   // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
-  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor, woodParams);
 
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
@@ -478,7 +484,10 @@ function PhysicsArrangement({
           ]}
         >
           <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
-          <meshStandardMaterial map={woodTexture} roughness={0.62} />
+          <meshStandardMaterial
+            map={woodTexture}
+            roughness={woodParams.roughness}
+          />
         </mesh>
       </RigidBody>
 
@@ -590,6 +599,7 @@ export default function PlankScenePhysics(props: PlankSceneProps) {
           lightingPreset={lightingPreset}
           onFirstFrame={props.onFirstFrame}
           resetNonce={props.resetNonce}
+          woodParams={props.woodParams ?? DEFAULT_WOOD_PARAMS}
         />
       </Physics>
     </Canvas>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -46,9 +46,9 @@ const FOV = 38;
 const CONTENT_HEADROOM = 0.4;
 const MIN_VIS_W = 2.0;
 const CAMERA_Y_LIFT = 0.3;
-// The yaw is baked into the camera position/lookAt; physics bodies live in
-// world-aligned space so they don't need to be wrapped in a rotated group.
-const FIXED_YAW = -(12 * Math.PI) / 180;
+// In-app planks render FACE-ON (no yaw) — the camera looks straight on. The
+// angled, depth-y look is reserved for the marketing hero background.
+const FIXED_YAW = 0;
 
 // ——— drag ring-buffer size ———
 const DRAG_BUF = 4;

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -403,11 +403,24 @@ function PhysicsArrangement({
     [boxes.length],
   );
 
+  // Live per-box world heights: covers aspect-correct after the image loads, so
+  // each box reports its rendered height (onResolvedHeight) and the collider /
+  // rest position follow it. Falls back to the deterministic boxWorldSize.h.
+  const [boxHeights, setBoxHeights] = React.useState<number[]>([]);
+  const reportHeight = React.useCallback((i: number, h: number) => {
+    setBoxHeights((prev) => {
+      if (prev[i] === h) return prev;
+      const next = prev.slice();
+      next[i] = h;
+      return next;
+    });
+  }, []);
+
   // Lowest each box center may be dragged (its half-height), so a held box never
   // sinks below the shelf top (y = 0).
   const boxMinY = React.useMemo(
-    () => boxes.map((b) => boxWorldSize(b).h / 2),
-    [boxes],
+    () => boxes.map((b, i) => (boxHeights[i] ?? boxWorldSize(b).h) / 2),
+    [boxes, boxHeights],
   );
 
   const { onPointerDown } = useBoxDrag(
@@ -423,7 +436,7 @@ function PhysicsArrangement({
       const body = rigidBodyRefs[i]?.current;
       const slot = slots[i];
       if (!body || !slot) return;
-      const { h } = boxWorldSize(box);
+      const h = boxHeights[i] ?? boxWorldSize(box).h;
       body.setTranslation({ x: slot.x, y: h / 2, z: 0 }, true);
       body.setRotation({ x: 0, y: 0, z: 0, w: 1 }, true);
       body.setLinvel({ x: 0, y: 0, z: 0 }, true);
@@ -496,7 +509,8 @@ function PhysicsArrangement({
 
       {/* Dynamic puzzle boxes */}
       {boxes.map((box, i) => {
-        const { w, h } = boxWorldSize(box);
+        const { w } = boxWorldSize(box);
+        const h = boxHeights[i] ?? boxWorldSize(box).h;
         const slot = slots[i];
         if (!slot) return null;
         return (
@@ -533,7 +547,7 @@ function PhysicsArrangement({
                 headingFont={headingFont}
                 sizeScale={1}
                 anchored={false}
-                fixedSize
+                onResolvedHeight={(hh) => reportHeight(i, hh)}
               />
             </group>
           </RigidBody>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -155,9 +155,13 @@ interface DragState {
   buf: Array<{ pos: THREE.Vector3; t: number }>; // ring buffer for velocity
   bufIdx: number;
   canvas: HTMLCanvasElement;
+  minY: number; // lowest the box center may go (its half-height) — keeps it above the shelf
 }
 
-function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
+function useBoxDrag(
+  rigidBodyRefs: React.RefObject<RapierRigidBody | null>[],
+  boxMinY: number[],
+): {
   onPointerDown: (e: React.PointerEvent<HTMLElement>, index: number) => void;
 } {
   const { camera, raycaster, pointer } = useThree();
@@ -190,6 +194,8 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       if (!body) return;
 
       const targetPos = hit.clone().sub(ds.grabOffset);
+      // Don't let a held box be dragged down into/through the shelf board.
+      targetPos.y = Math.max(targetPos.y, ds.minY);
       body.setNextKinematicTranslation(targetPos);
 
       // Push into ring buffer
@@ -332,9 +338,10 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
         buf: [],
         bufIdx: 0,
         canvas: canvas,
+        minY: boxMinY[index] ?? 0,
       };
     },
-    [camera, canvas, pointer, raycaster, rigidBodyRefs],
+    [camera, canvas, pointer, raycaster, rigidBodyRefs, boxMinY],
   );
 
   return { onPointerDown };
@@ -396,8 +403,16 @@ function PhysicsArrangement({
     [boxes.length],
   );
 
+  // Lowest each box center may be dragged (its half-height), so a held box never
+  // sinks below the shelf top (y = 0).
+  const boxMinY = React.useMemo(
+    () => boxes.map((b) => boxWorldSize(b).h / 2),
+    [boxes],
+  );
+
   const { onPointerDown } = useBoxDrag(
     rigidBodyRefs as React.RefObject<RapierRigidBody | null>[],
+    boxMinY,
   );
 
   // Reset: snap every box back to its resting layout slot (upright, still). Driven
@@ -518,6 +533,7 @@ function PhysicsArrangement({
                 headingFont={headingFont}
                 sizeScale={1}
                 anchored={false}
+                fixedSize
               />
             </group>
           </RigidBody>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -178,8 +178,12 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       );
       raycaster.setFromCamera(pointer, camera);
 
-      const hit = new THREE.Vector3();
-      raycaster.ray.intersectPlane(ds.dragPlane, hit);
+      // intersectPlane returns null when the ray is parallel to the plane; the
+      // pre-allocated target is always truthy, so we must guard the RETURN value.
+      const hit = raycaster.ray.intersectPlane(
+        ds.dragPlane,
+        new THREE.Vector3(),
+      );
       if (!hit) return;
 
       const body = rigidBodyRefs[ds.bodyIndex]?.current;
@@ -230,15 +234,38 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
 
       // Restore scroll on touch
       canvas.style.touchAction = "";
-      ds.canvas.releasePointerCapture(e.pointerId);
+      try {
+        ds.canvas.releasePointerCapture(e.pointerId);
+      } catch {
+        // Capture may already be gone (e.g. after a cancel); ignore.
+      }
+      dragState.current = null;
+    };
+
+    // The browser fires pointercancel (NOT pointerup) when it steals the gesture
+    // (pinch-zoom, OS interruption). Without this, touchAction would stay "none"
+    // and the page would be stuck unscrollable. Drop the box in place, no throw.
+    const onCancel = () => {
+      const ds = dragState.current;
+      if (!ds) return;
+      const body = rigidBodyRefs[ds.bodyIndex]?.current;
+      if (body) {
+        body.setBodyType(RB_DYNAMIC, true);
+        body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      }
+      canvas.style.touchAction = "";
       dragState.current = null;
     };
 
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
     return () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      // Defensive: if we unmount mid-drag, never leave the page unscrollable.
+      canvas.style.touchAction = "";
     };
   }, [camera, canvas, pointer, raycaster, rigidBodyRefs]);
 
@@ -248,8 +275,13 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       const body = rigidBodyRefs[index]?.current;
       if (!body) return;
 
-      // Capture the pointer so moves/ups fire even outside the canvas
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      // Capture the pointer on the CANVAS (e.target is a three.js Object3D, not a
+      // DOM node) so moves/ups fire even when the cursor leaves the canvas.
+      try {
+        canvas.setPointerCapture(e.nativeEvent.pointerId);
+      } catch {
+        // Capture is best-effort; the window-level listeners cover the drag anyway.
+      }
 
       // Prevent page scroll while dragging
       canvas.style.touchAction = "none";
@@ -275,9 +307,15 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
         bodyVec,
       );
 
-      // Grab offset = hit point - body center (so box doesn't jump to cursor)
-      const hit = new THREE.Vector3();
-      raycaster.ray.intersectPlane(dragPlane, hit);
+      // Grab offset = hit point - body center (so box doesn't jump to cursor).
+      // Guard the RETURN value: null when the ray is parallel to the plane.
+      const hit = raycaster.ray.intersectPlane(dragPlane, new THREE.Vector3());
+      if (!hit) {
+        // Degenerate grab — revert the kinematic switch + scroll lock, don't drag.
+        body.setBodyType(RB_DYNAMIC, true);
+        canvas.style.touchAction = "";
+        return;
+      }
       const grabOffset = hit.sub(bodyVec);
 
       dragState.current = {

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -233,7 +233,7 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       }
 
       // Restore scroll on touch
-      canvas.style.touchAction = "";
+      canvas.style.removeProperty("touch-action");
       try {
         ds.canvas.releasePointerCapture(e.pointerId);
       } catch {
@@ -253,7 +253,7 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
         body.setBodyType(RB_DYNAMIC, true);
         body.setLinvel({ x: 0, y: 0, z: 0 }, true);
       }
-      canvas.style.touchAction = "";
+      canvas.style.removeProperty("touch-action");
       dragState.current = null;
     };
 
@@ -265,7 +265,7 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onCancel);
       // Defensive: if we unmount mid-drag, never leave the page unscrollable.
-      canvas.style.touchAction = "";
+      canvas.style.removeProperty("touch-action");
     };
   }, [camera, canvas, pointer, raycaster, rigidBodyRefs]);
 
@@ -284,7 +284,7 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       }
 
       // Prevent page scroll while dragging
-      canvas.style.touchAction = "none";
+      canvas.style.setProperty("touch-action", "none");
 
       // Switch to kinematic so we drive the position
       body.setBodyType(RB_KINEMATIC_POS, true);
@@ -313,7 +313,7 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       if (!hit) {
         // Degenerate grab — revert the kinematic switch + scroll lock, don't drag.
         body.setBodyType(RB_DYNAMIC, true);
-        canvas.style.touchAction = "";
+        canvas.style.removeProperty("touch-action");
         return;
       }
       const grabOffset = hit.sub(bodyVec);
@@ -339,14 +339,12 @@ function PhysicsArrangement({
   resolved,
   headingFont,
   lightingPreset,
-  reducedMotion,
   onFirstFrame,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
   headingFont: string;
   lightingPreset: LightingPreset;
-  reducedMotion: boolean;
   onFirstFrame: () => void;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
@@ -532,7 +530,6 @@ export default function PlankScenePhysics(props: PlankSceneProps) {
           resolved={props.resolved}
           headingFont={props.headingFont}
           lightingPreset={lightingPreset}
-          reducedMotion={props.reducedMotion}
           onFirstFrame={props.onFirstFrame}
         />
       </Physics>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -30,11 +30,7 @@ import * as THREE from "three";
 import { clampThrowVelocity } from "./drag-math";
 import { layoutRow } from "./layout";
 import type { PlankSceneProps } from "./scene";
-import {
-  DEFAULT_WOOD_PARAMS,
-  useWoodTexture,
-  type WoodParams,
-} from "./wood-texture";
+import { DEFAULT_WOOD_PARAMS, useWoodTexture } from "./wood-texture";
 
 // @dimforge/rapier3d-compat is a transitive peer; we reference its enum
 // values via numeric constants to avoid a direct (unresolvable) import.
@@ -48,7 +44,9 @@ const SHELF_DEPTH = 0.6;
 
 // ——— camera constants (mirrors scene.tsx) ———
 const FOV = 38;
-const CONTENT_HEADROOM = 0.4;
+// Generous headroom so the downward camera tilt never clips the top of a tall
+// (portrait) cover. Mirrors scene.tsx.
+const CONTENT_HEADROOM = 0.6;
 const MIN_VIS_W = 2.0;
 const CAMERA_Y_LIFT = 0.3;
 // In-app planks render FACE-ON (no yaw) — the camera looks straight on. The
@@ -360,7 +358,6 @@ function PhysicsArrangement({
   lightingPreset,
   onFirstFrame,
   resetNonce = 0,
-  woodParams,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
@@ -368,19 +365,36 @@ function PhysicsArrangement({
   lightingPreset: LightingPreset;
   onFirstFrame: () => void;
   resetNonce?: number;
-  woodParams: WoodParams;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
   // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
-  const woodTexture = useWoodTexture(lightingPreset.shelfColor, woodParams);
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
 
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
+  // Live per-box world heights: covers aspect-correct after the image loads, so
+  // each box reports its rendered height (onResolvedHeight) and the collider,
+  // rest position, drag floor, and camera framing all follow it. Falls back to
+  // the deterministic boxWorldSize.h until the image resolves.
+  const [boxHeights, setBoxHeights] = React.useState<number[]>([]);
+  const reportHeight = React.useCallback((i: number, h: number) => {
+    setBoxHeights((prev) => {
+      if (prev[i] === h) return prev;
+      const next = prev.slice();
+      next[i] = h;
+      return next;
+    });
+  }, []);
+
+  // Max box world height across the row — drives framing. Uses the resolved
+  // heights so a portrait cover that resolves taller than the 1.4 default still
+  // gets framed fully (otherwise its top clips out of view).
   const maxBoxH = React.useMemo(
-    () => Math.max(...boxes.map(boxWorldHeight), 0.5),
-    [boxes],
+    () =>
+      Math.max(...boxes.map((b, i) => boxHeights[i] ?? boxWorldHeight(b)), 0.5),
+    [boxes, boxHeights],
   );
 
   // ——— cover-fit camera with yaw baked in ———
@@ -418,19 +432,6 @@ function PhysicsArrangement({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [boxes.length],
   );
-
-  // Live per-box world heights: covers aspect-correct after the image loads, so
-  // each box reports its rendered height (onResolvedHeight) and the collider /
-  // rest position follow it. Falls back to the deterministic boxWorldSize.h.
-  const [boxHeights, setBoxHeights] = React.useState<number[]>([]);
-  const reportHeight = React.useCallback((i: number, h: number) => {
-    setBoxHeights((prev) => {
-      if (prev[i] === h) return prev;
-      const next = prev.slice();
-      next[i] = h;
-      return next;
-    });
-  }, []);
 
   // Lowest each box center may be dragged (its half-height), so a held box never
   // sinks below the shelf top (y = 0).
@@ -486,7 +487,7 @@ function PhysicsArrangement({
           <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
           <meshStandardMaterial
             map={woodTexture}
-            roughness={woodParams.roughness}
+            roughness={DEFAULT_WOOD_PARAMS.roughness}
           />
         </mesh>
       </RigidBody>
@@ -599,7 +600,6 @@ export default function PlankScenePhysics(props: PlankSceneProps) {
           lightingPreset={lightingPreset}
           onFirstFrame={props.onFirstFrame}
           resetNonce={props.resetNonce}
-          woodParams={props.woodParams ?? DEFAULT_WOOD_PARAMS}
         />
       </Physics>
     </Canvas>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -394,7 +394,13 @@ function PhysicsArrangement({
     camera.updateProjectionMatrix();
   }, [camera, size, dist, cameraY, lookAtY]);
 
-  const shelfW = rowWidth + 0.4;
+  // Plank spans ~95% of the visible width at the shelf plane (face-on, so the
+  // visible world width there is contentH * aspect). This gives boxes plenty of
+  // room to be dragged sideways now that the left/right walls are gone; the
+  // floor below still catches any box pushed off an edge. Never narrower than
+  // the box row itself.
+  const visibleW = contentH * aspect;
+  const shelfW = Math.max(visibleW * 0.95, rowWidth + 0.4);
 
   // Per-box rigid body refs for the drag hook
   const rigidBodyRefs = React.useMemo(
@@ -483,18 +489,10 @@ function PhysicsArrangement({
         />
       </RigidBody>
 
-      {/* Invisible side walls to keep boxes on the shelf */}
+      {/* Invisible front/back walls keep boxes on the shelf along the depth
+          axis. No left/right walls — boxes can be dragged off the ends of the
+          (now wide) plank and tumble to the floor, which feels more physical. */}
       <RigidBody type="fixed" colliders={false}>
-        {/* Left wall */}
-        <CuboidCollider
-          args={[0.05, maxBoxH, SHELF_DEPTH]}
-          position={[-(shelfW / 2 + 0.05), maxBoxH / 2, 0]}
-        />
-        {/* Right wall */}
-        <CuboidCollider
-          args={[0.05, maxBoxH, SHELF_DEPTH]}
-          position={[shelfW / 2 + 0.05, maxBoxH / 2, 0]}
-        />
         {/* Back wall */}
         <CuboidCollider
           args={[shelfW / 2, maxBoxH, 0.05]}

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -297,11 +297,18 @@ function useBoxDrag(rigidBodyRefs: React.RefObject<RapierRigidBody | null>[]): {
       );
       raycaster.setFromCamera(pointer, camera);
 
-      // Drag plane: normal = camera forward, through the body's current position
+      // Drag plane through the body, VERTICAL (contains world-up) and facing the
+      // camera horizontally. Using the camera's full forward made a tilted plane
+      // where cursor moves mapped to a confusing diagonal; flattening the normal
+      // to the horizontal decouples the axes: left/right slides the box along the
+      // shelf, up/down lifts it.
       const bodyPos = body.translation();
       const bodyVec = new THREE.Vector3(bodyPos.x, bodyPos.y, bodyPos.z);
       const camForward = new THREE.Vector3();
       camera.getWorldDirection(camForward);
+      camForward.y = 0;
+      if (camForward.lengthSq() < 1e-6) camForward.set(0, 0, 1); // near top-down fallback
+      camForward.normalize();
       const dragPlane = new THREE.Plane().setFromNormalAndCoplanarPoint(
         camForward,
         bodyVec,

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -340,12 +340,14 @@ function PhysicsArrangement({
   headingFont,
   lightingPreset,
   onFirstFrame,
+  resetNonce = 0,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
   headingFont: string;
   lightingPreset: LightingPreset;
   onFirstFrame: () => void;
+  resetNonce?: number;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
@@ -390,6 +392,24 @@ function PhysicsArrangement({
   const { onPointerDown } = useBoxDrag(
     rigidBodyRefs as React.RefObject<RapierRigidBody | null>[],
   );
+
+  // Reset: snap every box back to its resting layout slot (upright, still). Driven
+  // by resetNonce so it fires only on an explicit reset, never on data refreshes.
+  React.useEffect(() => {
+    if (!resetNonce) return; // 0 = initial mount, nothing to reset
+    boxes.forEach((box, i) => {
+      const body = rigidBodyRefs[i]?.current;
+      const slot = slots[i];
+      if (!body || !slot) return;
+      const { h } = boxWorldSize(box);
+      body.setTranslation({ x: slot.x, y: h / 2, z: 0 }, true);
+      body.setRotation({ x: 0, y: 0, z: 0, w: 1 }, true);
+      body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+    });
+    // Intentionally only resetNonce — boxes/slots/refs are stable for a given layout.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetNonce]);
 
   return (
     <>
@@ -466,8 +486,10 @@ function PhysicsArrangement({
             colliders={false}
             restitution={0.1}
             friction={0.8}
-            linearDamping={0.5}
-            angularDamping={0.8}
+            // Lower damping so boxes respond livelier to grabs/throws and tumble
+            // more naturally (higher damping felt sluggish/static).
+            linearDamping={0.3}
+            angularDamping={0.4}
           >
             <CuboidCollider args={[w / 2, h / 2, BOX_DEPTH / 2]} />
             <group
@@ -531,6 +553,7 @@ export default function PlankScenePhysics(props: PlankSceneProps) {
           headingFont={props.headingFont}
           lightingPreset={lightingPreset}
           onFirstFrame={props.onFirstFrame}
+          resetNonce={props.resetNonce}
         />
       </Physics>
     </Canvas>

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -1,9 +1,8 @@
 import type { PuzzlePlankBox } from "@/components/common/puzzle-plank";
 import {
   BOX_DEPTH,
-  BOX_SCALE,
+  boxWorldSize,
   PuzzleBox,
-  PX,
 } from "@/components/marketing/plank-3d/box";
 import {
   LIGHTING,
@@ -37,11 +36,9 @@ const CAMERA_Y_LIFT = 0.3;
 // Fixed yaw so boxes read as 3D (no parallax-driven component here).
 const FIXED_YAW = -(12 * Math.PI) / 180;
 
-// ——— world height of one box (mirrors box.tsx logic) ———
+// ——— world height of one box (delegates to the shared helper) ———
 function boxWorldHeight(box: PuzzlePlankBox): number {
-  const widthPx = box.width ?? 116;
-  const hPx = box.cover ? widthPx / 1.4 : (box.height ?? 144);
-  return hPx * PX * BOX_SCALE;
+  return boxWorldSize(box).h;
 }
 
 /** Damps all light parameters toward the active theme preset. */

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -20,11 +20,7 @@ import { easing } from "maath";
 import * as React from "react";
 import * as THREE from "three";
 import { layoutRow } from "./layout";
-import {
-  DEFAULT_WOOD_PARAMS,
-  useWoodTexture,
-  type WoodParams,
-} from "./wood-texture";
+import { DEFAULT_WOOD_PARAMS, useWoodTexture } from "./wood-texture";
 
 // ——— shelf constants ———
 const SHELF_THICKNESS = 0.14;
@@ -32,8 +28,10 @@ const SHELF_DEPTH = 0.6;
 
 // ——— camera constants ———
 const FOV = 38;
-// Headroom added above the tallest box when computing the framed height.
-const CONTENT_HEADROOM = 0.4;
+// Headroom added above the tallest box when computing the framed height. Kept
+// generous so the gentle downward camera tilt never clips the top of a tall
+// (portrait) cover.
+const CONTENT_HEADROOM = 0.6;
 // Minimum visible world width so a 1-2 box row isn't hugely zoomed.
 const MIN_VIS_W = 2.0;
 // Camera sits slightly above the look-at point for a gentle downward gaze.
@@ -174,7 +172,6 @@ function Arrangement({
   lightingPreset,
   reducedMotion,
   onFirstFrame,
-  woodParams,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
@@ -182,20 +179,34 @@ function Arrangement({
   lightingPreset: LightingPreset;
   reducedMotion: boolean;
   onFirstFrame: () => void;
-  woodParams: WoodParams;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
   // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
-  const woodTexture = useWoodTexture(lightingPreset.shelfColor, woodParams);
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
 
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
+  // Live per-box world heights: cover boxes aspect-correct after their image
+  // loads (a portrait cover can resolve much taller than the 1.4 default), so
+  // each box reports its rendered height and the camera framing follows it.
+  // Without this the camera frames the default height and tall covers clip.
+  const [boxHeights, setBoxHeights] = React.useState<number[]>([]);
+  const reportHeight = React.useCallback((i: number, h: number) => {
+    setBoxHeights((prev) => {
+      if (prev[i] === h) return prev;
+      const next = prev.slice();
+      next[i] = h;
+      return next;
+    });
+  }, []);
+
   // Max box world height across the row — drives framing.
   const maxBoxH = React.useMemo(
-    () => Math.max(...boxes.map(boxWorldHeight), 0.5),
-    [boxes],
+    () =>
+      Math.max(...boxes.map((b, i) => boxHeights[i] ?? boxWorldHeight(b)), 0.5),
+    [boxes, boxHeights],
   );
 
   // ——— cover-fit camera: frame the row with headroom ———
@@ -238,7 +249,7 @@ function Arrangement({
             <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
             <meshStandardMaterial
               map={woodTexture}
-              roughness={woodParams.roughness}
+              roughness={DEFAULT_WOOD_PARAMS.roughness}
             />
           </mesh>
 
@@ -254,6 +265,7 @@ function Arrangement({
               index={i}
               headingFont={headingFont}
               sizeScale={1}
+              onResolvedHeight={(h) => reportHeight(i, h)}
             />
           ))}
 
@@ -284,8 +296,6 @@ export interface PlankSceneProps {
   /** Bumped to snap the physics boxes back to their resting layout (ignored by
    *  the static scene). */
   resetNonce?: number;
-  /** Temporary: live wood-grain tuning from the tweaks panel. */
-  woodParams?: WoodParams;
 }
 
 export default function PlankScene(props: PlankSceneProps) {
@@ -309,7 +319,6 @@ export default function PlankScene(props: PlankSceneProps) {
         lightingPreset={lightingPreset}
         reducedMotion={props.reducedMotion}
         onFirstFrame={props.onFirstFrame}
-        woodParams={props.woodParams ?? DEFAULT_WOOD_PARAMS}
       />
     </Canvas>
   );

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -20,7 +20,11 @@ import { easing } from "maath";
 import * as React from "react";
 import * as THREE from "three";
 import { layoutRow } from "./layout";
-import { useWoodTexture } from "./wood-texture";
+import {
+  DEFAULT_WOOD_PARAMS,
+  useWoodTexture,
+  type WoodParams,
+} from "./wood-texture";
 
 // ——— shelf constants ———
 const SHELF_THICKNESS = 0.14;
@@ -170,6 +174,7 @@ function Arrangement({
   lightingPreset,
   reducedMotion,
   onFirstFrame,
+  woodParams,
 }: {
   boxes: PuzzlePlankBox[];
   resolved: Array<{ c1: string; c2: string }>;
@@ -177,12 +182,13 @@ function Arrangement({
   lightingPreset: LightingPreset;
   reducedMotion: boolean;
   onFirstFrame: () => void;
+  woodParams: WoodParams;
 }) {
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
   // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
-  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor, woodParams);
 
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
@@ -230,7 +236,10 @@ function Arrangement({
             ]}
           >
             <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
-            <meshStandardMaterial map={woodTexture} roughness={0.62} />
+            <meshStandardMaterial
+              map={woodTexture}
+              roughness={woodParams.roughness}
+            />
           </mesh>
 
           {boxes.map((box, i) => (
@@ -275,6 +284,8 @@ export interface PlankSceneProps {
   /** Bumped to snap the physics boxes back to their resting layout (ignored by
    *  the static scene). */
   resetNonce?: number;
+  /** Temporary: live wood-grain tuning from the tweaks panel. */
+  woodParams?: WoodParams;
 }
 
 export default function PlankScene(props: PlankSceneProps) {
@@ -298,6 +309,7 @@ export default function PlankScene(props: PlankSceneProps) {
         lightingPreset={lightingPreset}
         reducedMotion={props.reducedMotion}
         onFirstFrame={props.onFirstFrame}
+        woodParams={props.woodParams ?? DEFAULT_WOOD_PARAMS}
       />
     </Canvas>
   );

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -271,6 +271,9 @@ export interface PlankSceneProps {
   visible: boolean;
   onFirstFrame: () => void;
   eventSource: React.RefObject<HTMLDivElement | null>;
+  /** Bumped to snap the physics boxes back to their resting layout (ignored by
+   *  the static scene). */
+  resetNonce?: number;
 }
 
 export default function PlankScene(props: PlankSceneProps) {

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -33,8 +33,9 @@ const CONTENT_HEADROOM = 0.4;
 const MIN_VIS_W = 2.0;
 // Camera sits slightly above the look-at point for a gentle downward gaze.
 const CAMERA_Y_LIFT = 0.3;
-// Fixed yaw so boxes read as 3D (no parallax-driven component here).
-const FIXED_YAW = -(12 * Math.PI) / 180;
+// In-app planks render FACE-ON (no yaw) — the angled, depth-y look is reserved
+// for the marketing hero background. Box depth + lighting still read as 3D.
+const FIXED_YAW = 0;
 
 // ——— world height of one box (delegates to the shared helper) ———
 function boxWorldHeight(box: PuzzlePlankBox): number {

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -1,0 +1,302 @@
+import type { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import {
+  BOX_DEPTH,
+  BOX_SCALE,
+  PuzzleBox,
+  PX,
+} from "@/components/marketing/plank-3d/box";
+import {
+  LIGHTING,
+  type LightingPreset,
+} from "@/components/marketing/plank-3d/palette";
+import { ContactShadows } from "@react-three/drei";
+import type {
+  DomEvent,
+  EventManager,
+  RootState,
+  RootStore,
+} from "@react-three/fiber";
+import { Canvas, events, useFrame, useThree } from "@react-three/fiber";
+import { easing } from "maath";
+import * as React from "react";
+import * as THREE from "three";
+import { layoutRow } from "./layout";
+
+// ——— shelf constants ———
+const SHELF_THICKNESS = 0.14;
+const SHELF_DEPTH = 0.6;
+
+// ——— camera constants ———
+const FOV = 38;
+// Headroom added above the tallest box when computing the framed height.
+const CONTENT_HEADROOM = 0.4;
+// Minimum visible world width so a 1-2 box row isn't hugely zoomed.
+const MIN_VIS_W = 2.0;
+// Camera sits slightly above the look-at point for a gentle downward gaze.
+const CAMERA_Y_LIFT = 0.3;
+// Fixed yaw so boxes read as 3D (no parallax-driven component here).
+const FIXED_YAW = -(12 * Math.PI) / 180;
+
+// ——— world height of one box (mirrors box.tsx logic) ———
+function boxWorldHeight(box: PuzzlePlankBox): number {
+  const widthPx = box.width ?? 116;
+  const hPx = box.cover ? widthPx / 1.4 : (box.height ?? 144);
+  return hPx * PX * BOX_SCALE;
+}
+
+/** Damps all light parameters toward the active theme preset. */
+function Lights({
+  preset,
+  reducedMotion,
+}: {
+  preset: LightingPreset;
+  reducedMotion: boolean;
+}) {
+  const key = React.useRef<THREE.DirectionalLight>(null);
+  const ambient = React.useRef<THREE.AmbientLight>(null);
+  const hemi = React.useRef<THREE.HemisphereLight>(null);
+  const rim = React.useRef<THREE.DirectionalLight>(null);
+
+  useFrame((_, delta) => {
+    if (!key.current || !ambient.current || !hemi.current || !rim.current)
+      return;
+    if (reducedMotion) {
+      key.current.intensity = preset.keyIntensity;
+      key.current.color.set(preset.keyColor);
+      ambient.current.intensity = preset.ambientIntensity;
+      ambient.current.color.set(preset.ambientColor);
+      hemi.current.intensity = preset.hemiIntensity;
+      rim.current.intensity = preset.rimIntensity;
+      return;
+    }
+    easing.damp(key.current, "intensity", preset.keyIntensity, 0.3, delta);
+    easing.dampC(key.current.color, preset.keyColor, 0.3, delta);
+    easing.damp(
+      ambient.current,
+      "intensity",
+      preset.ambientIntensity,
+      0.3,
+      delta,
+    );
+    easing.dampC(ambient.current.color, preset.ambientColor, 0.3, delta);
+    easing.damp(hemi.current, "intensity", preset.hemiIntensity, 0.3, delta);
+    easing.damp(rim.current, "intensity", preset.rimIntensity, 0.3, delta);
+  });
+
+  return (
+    <>
+      <directionalLight
+        ref={key}
+        position={[2.5, 5, 3.5]}
+        intensity={preset.keyIntensity}
+      />
+      <ambientLight ref={ambient} intensity={preset.ambientIntensity} />
+      <hemisphereLight
+        ref={hemi}
+        color="#ffffff"
+        groundColor="#d9c4a8"
+        intensity={preset.hemiIntensity}
+      />
+      <directionalLight
+        ref={rim}
+        position={[-3, 3.5, -2]}
+        color="#8b5cf6"
+        intensity={preset.rimIntensity}
+      />
+    </>
+  );
+}
+
+function FirstFrame({ onFirstFrame }: { onFirstFrame: () => void }) {
+  const fired = React.useRef(false);
+  useFrame(() => {
+    if (!fired.current) {
+      fired.current = true;
+      onFirstFrame();
+    }
+  });
+  return null;
+}
+
+function Parallax({
+  children,
+  enabled,
+}: {
+  children: React.ReactNode;
+  enabled: boolean;
+}) {
+  const group = React.useRef<THREE.Group>(null);
+  const AMPLITUDE = 1.0;
+  useFrame((state, delta) => {
+    if (!group.current) return;
+    const target = enabled
+      ? [
+          state.pointer.y * 0.03 * AMPLITUDE,
+          state.pointer.x * 0.05 * AMPLITUDE,
+          0,
+        ]
+      : [0, 0, 0];
+    easing.dampE(
+      group.current.rotation,
+      target as [number, number, number],
+      0.4,
+      delta,
+    );
+  });
+  return <group ref={group}>{children}</group>;
+}
+
+// Pointer NDC from the canvas's live client rect so picking survives
+// CSS scale transforms.
+function transformSafeEvents(store: RootStore): EventManager<HTMLElement> {
+  return {
+    ...events(store),
+    compute(event: DomEvent, state: RootState) {
+      const rect = state.gl.domElement.getBoundingClientRect();
+      state.pointer.set(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        (-(event.clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      state.raycaster.setFromCamera(state.pointer, state.camera);
+    },
+  };
+}
+
+// Inner component: reads live canvas size, computes camera distance to
+// cover-fit the row, and renders the single shelf + boxes.
+function Arrangement({
+  boxes,
+  resolved,
+  headingFont,
+  lightingPreset,
+  reducedMotion,
+  onFirstFrame,
+}: {
+  boxes: PuzzlePlankBox[];
+  resolved: Array<{ c1: string; c2: string }>;
+  headingFont: string;
+  lightingPreset: LightingPreset;
+  reducedMotion: boolean;
+  onFirstFrame: () => void;
+}) {
+  const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
+  const size = useThree((s) => s.size);
+
+  const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
+
+  // Max box world height across the row — drives framing.
+  const maxBoxH = React.useMemo(
+    () => Math.max(...boxes.map(boxWorldHeight), 0.5),
+    [boxes],
+  );
+
+  // ——— cover-fit camera: frame the row with headroom ———
+  const vFov = (FOV * Math.PI) / 180;
+  const aspect = size.width / size.height;
+  // Framed height = tallest box + headroom; clamped so narrow viewports
+  // don't zoom in beyond MIN_VIS_W world units.
+  const framedH = maxBoxH + CONTENT_HEADROOM;
+  const contentH = Math.max(framedH, MIN_VIS_W / aspect);
+  const dist = contentH / 2 / Math.tan(vFov / 2);
+
+  // Camera y: look at the vertical center of the row (half maxBoxH above shelf),
+  // with a small lift for the downward gaze.
+  const lookAtY = maxBoxH / 2;
+  const cameraY = lookAtY + CAMERA_Y_LIFT;
+
+  React.useLayoutEffect(() => {
+    camera.position.set(0, cameraY, dist);
+    camera.lookAt(0, lookAtY, 0);
+    camera.updateProjectionMatrix();
+  }, [camera, size, dist, cameraY, lookAtY]);
+
+  // Shelf board width: row + margin so no bare board-ends are visible close up.
+  const shelfW = rowWidth + 0.4;
+
+  return (
+    <>
+      <FirstFrame onFirstFrame={onFirstFrame} />
+      <Parallax enabled={!reducedMotion}>
+        {/* Fixed yaw so boxes read as 3D without pointer-driven rotation */}
+        <group rotation={[0, FIXED_YAW, 0]}>
+          {/* Shelf board sits just below y=0 (box bases are at y=0) */}
+          <mesh
+            position={[
+              0,
+              -SHELF_THICKNESS / 2,
+              SHELF_DEPTH / 2 - BOX_DEPTH / 2 - 0.1,
+            ]}
+          >
+            <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
+            <meshStandardMaterial
+              color={lightingPreset.shelfColor}
+              roughness={0.7}
+            />
+          </mesh>
+
+          {boxes.map((box, i) => (
+            <PuzzleBox
+              key={i}
+              box={box}
+              slot={{
+                x: slots[i]?.x ?? 0,
+                c1: resolved[i]?.c1 ?? "#6048e8",
+                c2: resolved[i]?.c2 ?? "#494e92",
+              }}
+              index={i}
+              headingFont={headingFont}
+              sizeScale={1}
+            />
+          ))}
+
+          <ContactShadows
+            position={[0, 0.001, 0]}
+            opacity={lightingPreset.shadowOpacity}
+            scale={rowWidth + 1}
+            blur={2.2}
+            far={1.2}
+            resolution={256}
+          />
+        </group>
+      </Parallax>
+    </>
+  );
+}
+
+export interface PlankSceneProps {
+  boxes: PuzzlePlankBox[];
+  /** Pre-resolved per-box colors, parallel to boxes. */
+  resolved: Array<{ c1: string; c2: string }>;
+  headingFont: string;
+  theme: "light" | "dark";
+  reducedMotion: boolean;
+  visible: boolean;
+  onFirstFrame: () => void;
+  eventSource: React.RefObject<HTMLDivElement | null>;
+}
+
+export default function PlankScene(props: PlankSceneProps) {
+  const lightingPreset = LIGHTING[props.theme];
+  return (
+    <Canvas
+      dpr={[1, 2]}
+      frameloop={props.visible ? "always" : "never"}
+      gl={{ alpha: true, antialias: true }}
+      style={{ pointerEvents: "none", background: "transparent" }}
+      camera={{ fov: FOV }}
+      eventSource={props.eventSource as unknown as React.RefObject<HTMLElement>}
+      events={transformSafeEvents}
+      resize={{ offsetSize: true }}
+    >
+      <Lights preset={lightingPreset} reducedMotion={props.reducedMotion} />
+      <Arrangement
+        boxes={props.boxes}
+        resolved={props.resolved}
+        headingFont={props.headingFont}
+        lightingPreset={lightingPreset}
+        reducedMotion={props.reducedMotion}
+        onFirstFrame={props.onFirstFrame}
+      />
+    </Canvas>
+  );
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene.tsx
@@ -20,6 +20,7 @@ import { easing } from "maath";
 import * as React from "react";
 import * as THREE from "three";
 import { layoutRow } from "./layout";
+import { useWoodTexture } from "./wood-texture";
 
 // ——— shelf constants ———
 const SHELF_THICKNESS = 0.14;
@@ -180,6 +181,9 @@ function Arrangement({
   const camera = useThree((s) => s.camera) as THREE.PerspectiveCamera;
   const size = useThree((s) => s.size);
 
+  // Wood-grain texture for the shelf board, tinted from the theme shelf colour.
+  const woodTexture = useWoodTexture(lightingPreset.shelfColor);
+
   const { slots, rowWidth } = React.useMemo(() => layoutRow(boxes), [boxes]);
 
   // Max box world height across the row — drives framing.
@@ -226,10 +230,7 @@ function Arrangement({
             ]}
           >
             <boxGeometry args={[shelfW, SHELF_THICKNESS, SHELF_DEPTH]} />
-            <meshStandardMaterial
-              color={lightingPreset.shelfColor}
-              roughness={0.7}
-            />
+            <meshStandardMaterial map={woodTexture} roughness={0.62} />
           </mesh>
 
           {boxes.map((box, i) => (

--- a/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
@@ -1,0 +1,127 @@
+import * as React from "react";
+import * as THREE from "three";
+
+// ——— Procedural wood-grain texture ———
+// The shelf board used to be a flat single colour. This generates a warm,
+// semi-realistic wood-grain CanvasTexture from the theme's shelf colour so the
+// plank reads as a real wooden board — mirroring how box-art textures are
+// generated on a canvas (no binary asset, no licensing concerns). The grain
+// runs along the board's length (the texture's U axis), which is correct for
+// both the top face and the front edge of the box geometry.
+
+const TEX_W = 1024;
+const TEX_H = 512;
+// Grain lines across the board's narrow axis (depth on the top face). Tuned to
+// read as a plank without looking striped.
+const GRAINS = 11;
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  const full =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+// Cheap deterministic value noise (sin-hash). Good enough for grain warp and
+// tonal variation; no external dependency.
+function hash(x: number, y: number): number {
+  const s = Math.sin(x * 127.1 + y * 311.7) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+function smooth(t: number): number {
+  return t * t * (3 - 2 * t);
+}
+
+function valueNoise(x: number, y: number): number {
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  const xf = x - xi;
+  const yf = y - yi;
+  const tl = hash(xi, yi);
+  const tr = hash(xi + 1, yi);
+  const bl = hash(xi, yi + 1);
+  const br = hash(xi + 1, yi + 1);
+  const u = smooth(xf);
+  const v = smooth(yf);
+  return (tl + (tr - tl) * u) * (1 - v) + (bl + (br - bl) * u) * v;
+}
+
+function fbm(x: number, y: number): number {
+  let value = 0;
+  let amp = 0.5;
+  let freq = 1;
+  for (let i = 0; i < 4; i++) {
+    value += amp * valueNoise(x * freq, y * freq);
+    freq *= 2;
+    amp *= 0.5;
+  }
+  return value;
+}
+
+/** Build a wood-grain CanvasTexture tinted from `baseColor` (e.g. "#c98f4d"). */
+export function createWoodTexture(baseColor: string): THREE.CanvasTexture {
+  const [br, bg, bb] = hexToRgb(baseColor);
+  const canvas = document.createElement("canvas");
+  canvas.width = TEX_W;
+  canvas.height = TEX_H;
+  const ctx = canvas.getContext("2d")!;
+  const img = ctx.createImageData(TEX_W, TEX_H);
+  const data = img.data;
+
+  for (let y = 0; y < TEX_H; y++) {
+    const ny = y / TEX_H;
+    for (let x = 0; x < TEX_W; x++) {
+      const nx = x / TEX_W;
+
+      // Warp the grain lines so they wobble gently along the board length
+      // rather than running perfectly straight.
+      const warp = fbm(nx * 4, ny * 2) - 0.5;
+      const g = (ny + warp * 0.06) * GRAINS;
+      // Thin dark lines at each integer grain boundary.
+      const line = Math.pow(1 - Math.abs(Math.sin(g * Math.PI)), 3);
+      // Fine high-frequency streaks running with the grain.
+      const streak = fbm(nx * 3, ny * 44) - 0.5;
+      // Broad low-frequency tonal drift so the board isn't uniform.
+      const tone = fbm(nx * 1.5, ny * 1.5) - 0.5;
+
+      const brightness =
+        1 - line * 0.3 - Math.max(0, streak) * 0.16 + tone * 0.1;
+
+      const i = (y * TEX_W + x) * 4;
+      data[i] = Math.max(0, Math.min(255, br * brightness));
+      data[i + 1] = Math.max(0, Math.min(255, bg * brightness));
+      data[i + 2] = Math.max(0, Math.min(255, bb * brightness));
+      data[i + 3] = 255;
+    }
+  }
+
+  ctx.putImageData(img, 0, 0);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.anisotropy = 4;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+/**
+ * Memoize one wood texture per shelf colour and dispose it on unmount / change.
+ * Each <Canvas> tree calls this independently, so each gets its own GPU texture.
+ */
+export function useWoodTexture(baseColor: string): THREE.CanvasTexture {
+  const texture = React.useMemo(
+    () => createWoodTexture(baseColor),
+    [baseColor],
+  );
+  React.useEffect(() => () => texture.dispose(), [texture]);
+  return texture;
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
@@ -11,9 +11,33 @@ import * as THREE from "three";
 
 const TEX_W = 1024;
 const TEX_H = 512;
-// Grain lines across the board's narrow axis (depth on the top face). Tuned to
-// read as a plank without looking striped.
-const GRAINS = 11;
+
+// Tunable wood look. Exposed (with the temporary tweaks panel) so the grain can
+// be dialed in live; once a good combination is found these become the new
+// defaults and the panel is removed.
+export interface WoodParams {
+  /** Grain lines across the board's narrow axis. */
+  grains: number;
+  /** Depth of the dark grain lines (0 = none). */
+  lineStrength: number;
+  /** Strength of the fine streaks running with the grain. */
+  streakStrength: number;
+  /** Broad low-frequency lightness drift. */
+  toneStrength: number;
+  /** How much the grain lines wobble along the board length. */
+  warp: number;
+  /** Shelf material roughness (not part of the texture; matte ↔ sheen). */
+  roughness: number;
+}
+
+export const DEFAULT_WOOD_PARAMS: WoodParams = {
+  grains: 11,
+  lineStrength: 0.3,
+  streakStrength: 0.16,
+  toneStrength: 0.1,
+  warp: 0.06,
+  roughness: 0.62,
+};
 
 function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace("#", "");
@@ -66,7 +90,11 @@ function fbm(x: number, y: number): number {
 }
 
 /** Build a wood-grain CanvasTexture tinted from `baseColor` (e.g. "#c98f4d"). */
-export function createWoodTexture(baseColor: string): THREE.CanvasTexture {
+export function createWoodTexture(
+  baseColor: string,
+  params: WoodParams = DEFAULT_WOOD_PARAMS,
+): THREE.CanvasTexture {
+  const { grains, lineStrength, streakStrength, toneStrength, warp } = params;
   const [br, bg, bb] = hexToRgb(baseColor);
   const canvas = document.createElement("canvas");
   canvas.width = TEX_W;
@@ -82,8 +110,8 @@ export function createWoodTexture(baseColor: string): THREE.CanvasTexture {
 
       // Warp the grain lines so they wobble gently along the board length
       // rather than running perfectly straight.
-      const warp = fbm(nx * 4, ny * 2) - 0.5;
-      const g = (ny + warp * 0.06) * GRAINS;
+      const warpN = fbm(nx * 4, ny * 2) - 0.5;
+      const g = (ny + warpN * warp) * grains;
       // Thin dark lines at each integer grain boundary.
       const line = Math.pow(1 - Math.abs(Math.sin(g * Math.PI)), 3);
       // Fine high-frequency streaks running with the grain.
@@ -92,7 +120,10 @@ export function createWoodTexture(baseColor: string): THREE.CanvasTexture {
       const tone = fbm(nx * 1.5, ny * 1.5) - 0.5;
 
       const brightness =
-        1 - line * 0.3 - Math.max(0, streak) * 0.16 + tone * 0.1;
+        1 -
+        line * lineStrength -
+        Math.max(0, streak) * streakStrength +
+        tone * toneStrength;
 
       const i = (y * TEX_W + x) * 4;
       data[i] = Math.max(0, Math.min(255, br * brightness));
@@ -117,10 +148,17 @@ export function createWoodTexture(baseColor: string): THREE.CanvasTexture {
  * Memoize one wood texture per shelf colour and dispose it on unmount / change.
  * Each <Canvas> tree calls this independently, so each gets its own GPU texture.
  */
-export function useWoodTexture(baseColor: string): THREE.CanvasTexture {
+export function useWoodTexture(
+  baseColor: string,
+  params: WoodParams = DEFAULT_WOOD_PARAMS,
+): THREE.CanvasTexture {
+  const { grains, lineStrength, streakStrength, toneStrength, warp } = params;
   const texture = React.useMemo(
-    () => createWoodTexture(baseColor),
-    [baseColor],
+    () => createWoodTexture(baseColor, params),
+    // Depend on the primitive params (not the object identity) so live tweaks
+    // regenerate the canvas but stable renders don't.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [baseColor, grains, lineStrength, streakStrength, toneStrength, warp],
   );
   React.useEffect(() => () => texture.dispose(), [texture]);
   return texture;

--- a/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/wood-texture.ts
@@ -31,12 +31,12 @@ export interface WoodParams {
 }
 
 export const DEFAULT_WOOD_PARAMS: WoodParams = {
-  grains: 11,
-  lineStrength: 0.3,
-  streakStrength: 0.16,
-  toneStrength: 0.1,
-  warp: 0.06,
-  roughness: 0.62,
+  grains: 7,
+  lineStrength: 0.08,
+  streakStrength: 0.23,
+  toneStrength: 0.27,
+  warp: 0.105,
+  roughness: 0.66,
 };
 
 function hexToRgb(hex: string): [number, number, number] {

--- a/apps/web/src/components/copies/photo-lightbox.tsx
+++ b/apps/web/src/components/copies/photo-lightbox.tsx
@@ -94,6 +94,19 @@ export function PhotoLightbox({
     }
   };
 
+  // Clear the cover (omit coverImageId) so the copy falls back to the catalogue image.
+  const unsetCover = async () => {
+    setSettingCover(true);
+    try {
+      await setCopyCover({ copyId: copyId as Id<"ownedPuzzles"> });
+      toast.success(t("coverUpdated"));
+    } catch {
+      toast.error(t("coverFailed"));
+    } finally {
+      setSettingCover(false);
+    }
+  };
+
   const removePhoto = async () => {
     if (!photo) return;
     setRemoving(true);
@@ -229,10 +242,17 @@ export function PhotoLightbox({
             {/* Owner-only: choose this photo as the copy's cover, right where you're viewing it. */}
             {canSetCover &&
               (coverImageId === photo.id ? (
-                <div className="text-jigsaw-primary inline-flex items-center gap-1.5 text-sm font-semibold">
+                // Already the cover — clicking clears it back to the catalogue image.
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void unsetCover()}
+                  disabled={settingCover}
+                  className="w-full"
+                >
                   <Star className="h-4 w-4" fill="currentColor" />
-                  {t("currentCover")}
-                </div>
+                  {t("unsetCover")}
+                </Button>
               ) : (
                 <Button
                   variant="outline"

--- a/apps/web/src/components/dashboard-home/briefing-hero.tsx
+++ b/apps/web/src/components/dashboard-home/briefing-hero.tsx
@@ -77,7 +77,7 @@ function Headline({
         : null;
 
   return (
-    <p className="font-heading max-w-[860px] text-2xl leading-[1.4] font-semibold tracking-tight text-pretty md:text-3xl">
+    <p className="font-heading max-w-[860px] text-xl leading-snug font-semibold tracking-tight text-pretty md:text-3xl md:leading-[1.4]">
       {variant === null
         ? t("empty")
         : t.rich(variant, {
@@ -206,7 +206,7 @@ export function BriefingHero() {
 
   if (loading) {
     return (
-      <section className="flex flex-col gap-5">
+      <section className="flex flex-col gap-4 md:gap-5">
         <div className="max-w-[860px] space-y-3">
           <Skeleton className="h-8 w-full" />
           <Skeleton className="h-8 w-3/4" />
@@ -243,7 +243,7 @@ export function BriefingHero() {
       : null;
 
   return (
-    <section className="flex flex-col gap-5">
+    <section className="flex flex-col gap-4 md:gap-5">
       <Headline
         activeCount={active.length}
         pendingCount={pendingIncoming.length}

--- a/apps/web/src/components/dashboard-home/pulse-section.tsx
+++ b/apps/web/src/components/dashboard-home/pulse-section.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
@@ -163,9 +164,16 @@ function InMotionColumn({ exchanges }: { exchanges: ExchangeRow[] }) {
 
 // The SVG goal ring: a muted track with the brand-violet progress arc and the
 // big percentage in the middle.
-function GoalRing({ current, target }: { current: number; target: number }) {
+function GoalRing({
+  current,
+  target,
+  size = 148,
+}: {
+  current: number;
+  target: number;
+  size?: number;
+}) {
   const t = useTranslations("dashboard.pulse.goals");
-  const size = 148;
   const stroke = 13;
   const r = (size - stroke) / 2;
   const c = 2 * Math.PI * r;
@@ -173,7 +181,7 @@ function GoalRing({ current, target }: { current: number; target: number }) {
   const mid = size / 2;
 
   return (
-    <div className="relative size-[148px] shrink-0">
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
       <svg width={size} height={size} aria-hidden>
         <circle
           cx={mid}
@@ -235,6 +243,7 @@ function GoalBar({ goal }: { goal: GoalRow }) {
 
 function GoalsColumn({ goals }: { goals: GoalRow[] }) {
   const t = useTranslations("dashboard.pulse.goals");
+  const isMobile = useIsMobile();
 
   // Lead with the goal still being chased; fall back to any active goal,
   // then the newest one.
@@ -268,6 +277,7 @@ function GoalsColumn({ goals }: { goals: GoalRow[] }) {
             <GoalRing
               current={primary.currentCompletions}
               target={primary.targetCompletions}
+              size={isMobile ? 116 : 148}
             />
           </Link>
           {rest.length > 0 && (
@@ -371,7 +381,7 @@ function LatestColumn({
 
 function PulseSkeleton() {
   return (
-    <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+    <div className="grid gap-6 lg:gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
       {Array.from({ length: 3 }).map((_, i) => (
         <div key={i} className="space-y-4">
           <Skeleton className="h-8 w-2/3" />
@@ -406,7 +416,7 @@ export function PulseSection() {
   if (!member) return null;
 
   return (
-    <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+    <div className="grid gap-6 lg:gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
       <InMotionColumn exchanges={exchanges ?? []} />
       <GoalsColumn goals={goals ?? []} />
       <LatestColumn entries={feed ?? []} me={member} />

--- a/apps/web/src/components/dashboard-home/shelf-section.tsx
+++ b/apps/web/src/components/dashboard-home/shelf-section.tsx
@@ -39,7 +39,10 @@ function toPlankBox(
   index: number,
   isMobile: boolean,
 ): PuzzlePlankBox {
-  const cover = copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
+  // Prefer the copy's resolved cover (a user-uploaded/pinned photo) over the
+  // catalogue image so a copy with its own cover shows it, not placeholder art.
+  const cover =
+    copy.coverUrl ?? copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
   const [c1, c2] = BOX_GRADIENTS[index % BOX_GRADIENTS.length];
   const heights = isMobile ? MOBILE_BOX_HEIGHTS : BOX_HEIGHTS;
   return {

--- a/apps/web/src/components/dashboard-home/shelf-section.tsx
+++ b/apps/web/src/components/dashboard-home/shelf-section.tsx
@@ -5,6 +5,7 @@ import { PuzzlePlank, PuzzlePlankBox } from "@/components/common/puzzle-plank";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { BookOpen, ChevronRight } from "lucide-react";
@@ -28,9 +29,17 @@ const BOX_GRADIENTS: ReadonlyArray<readonly [string, string]> = [
 // Varied box heights so the shelf reads like a real, lived-in collection.
 const BOX_HEIGHTS = [148, 130, 156, 126, 142];
 
-function toPlankBox(copy: OwnedCopy, index: number): PuzzlePlankBox {
+// Shorter set for the cramped mobile dashboard (see sub-project ②).
+const MOBILE_BOX_HEIGHTS = [118, 104, 124, 100, 114];
+
+function toPlankBox(
+  copy: OwnedCopy,
+  index: number,
+  isMobile: boolean,
+): PuzzlePlankBox {
   const cover = copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
   const [c1, c2] = BOX_GRADIENTS[index % BOX_GRADIENTS.length];
+  const heights = isMobile ? MOBILE_BOX_HEIGHTS : BOX_HEIGHTS;
   return {
     title: copy.puzzle?.title ?? copy.snapshot?.title,
     series: copy.puzzle?.brand ?? copy.snapshot?.brand,
@@ -38,7 +47,10 @@ function toPlankBox(copy: OwnedCopy, index: number): PuzzlePlankBox {
     cover,
     c1,
     c2,
-    height: cover ? undefined : BOX_HEIGHTS[index % BOX_HEIGHTS.length],
+    // Narrower boxes on mobile; PuzzlePlank derives cover-box height from width,
+    // so this shortens the whole shelf. Desktop keeps the component default (116).
+    width: isMobile ? 92 : undefined,
+    height: cover ? undefined : heights[index % heights.length],
   };
 }
 
@@ -75,6 +87,7 @@ function StatRow({
 // ground, no stat cards.
 export function ShelfSection() {
   const t = useTranslations("dashboard.shelf");
+  const isMobile = useIsMobile();
   const { member, isMemberLoading } = useCurrentMember();
 
   const copies = useQuery(
@@ -176,8 +189,12 @@ export function ShelfSection() {
         <div className="grid items-center gap-10 lg:grid-cols-[1fr_252px]">
           {/* min-w-0 lets the grid column shrink so the plank swipes
               horizontally on narrow screens instead of blowing out. */}
-          <div className="min-w-0 overflow-x-auto px-2 pt-6 pb-5">
-            <PuzzlePlank boxes={owned.slice(0, 5).map(toPlankBox)} />
+          <div className="min-w-0 overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5">
+            <PuzzlePlank
+              boxes={owned
+                .slice(0, 5)
+                .map((copy, i) => toPlankBox(copy, i, isMobile))}
+            />
           </div>
           <div className="flex flex-col">
             {statRows.map((row) => (

--- a/apps/web/src/components/dashboard-home/shelf-section.tsx
+++ b/apps/web/src/components/dashboard-home/shelf-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Link } from "@/compat/link";
-import { PuzzlePlank, PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import { PuzzlePlank3D } from "@/components/common/puzzle-plank-3d";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
@@ -9,6 +10,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { BookOpen, ChevronRight } from "lucide-react";
+import { useMemo } from "react";
 import { useTranslations } from "use-intl";
 import { SectionHead } from "./section-head";
 import { useCurrentMember } from "./use-current-member";
@@ -105,6 +107,16 @@ export function ShelfSection() {
     member?._id ? { userId: member._id as Id<"users"> } : "skip",
   );
 
+  // Memoized so the 3D plank's color-resolution effect doesn't re-run on every
+  // reactive re-render of this dashboard (only when the copies/viewport change).
+  const plankBoxes = useMemo(
+    () =>
+      (copies ?? [])
+        .slice(0, 5)
+        .map((copy, i) => toPlankBox(copy, i, isMobile)),
+    [copies, isMobile],
+  );
+
   const loading =
     isMemberLoading ||
     (member != null &&
@@ -187,14 +199,8 @@ export function ShelfSection() {
         </div>
       ) : (
         <div className="grid items-center gap-10 lg:grid-cols-[1fr_252px]">
-          {/* min-w-0 lets the grid column shrink so the plank swipes
-              horizontally on narrow screens instead of blowing out. */}
-          <div className="min-w-0 overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5">
-            <PuzzlePlank
-              boxes={owned
-                .slice(0, 5)
-                .map((copy, i) => toPlankBox(copy, i, isMobile))}
-            />
+          <div className="h-[300px] min-w-0 md:h-[360px]">
+            <PuzzlePlank3D boxes={plankBoxes} />
           </div>
           <div className="flex flex-col">
             {statRows.map((row) => (

--- a/apps/web/src/components/dashboard-layout/mobile-quick-sheet.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-quick-sheet.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
   Plus,
   Search,
+  UserRound,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -48,6 +49,15 @@ const ACTIONS: Array<{
     subKey: "mobile.quick.browseCommunitySub",
     href: "/browse",
     icon: Search,
+  },
+  // A clear, labelled route to the member's own profile (the top-bar avatar
+  // also links here, but it's an unlabelled icon). Reuses the existing
+  // shell.pages.profile strings — no new translations.
+  {
+    titleKey: "pages.profile.title",
+    subKey: "pages.profile.subtitle",
+    href: "/profile",
+    icon: UserRound,
   },
 ];
 

--- a/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
@@ -120,9 +120,10 @@ function TabLink({
   return (
     <Link
       href={tab.href}
+      aria-label={t(`tabs.${tab.key}`)}
       aria-current={on ? "page" : undefined}
       className={cn(
-        "flex min-h-14 flex-col items-center justify-center gap-[3px] pt-[7px] pb-1.5",
+        "flex min-h-14 flex-col items-center justify-center",
         on ? "text-jigsaw-primary" : "text-muted-foreground",
       )}
     >
@@ -133,14 +134,6 @@ function TabLink({
             {badge > 9 ? "9+" : badge}
           </span>
         )}
-      </span>
-      <span
-        className={cn(
-          "text-[10.5px] tracking-[0.01em]",
-          on ? "font-bold" : "font-medium",
-        )}
-      >
-        {t(`tabs.${tab.key}`)}
       </span>
     </Link>
   );

--- a/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
@@ -76,7 +76,7 @@ export function MobileTabBar() {
         // `relative z-30` so the raised center button (which rises above the bar
         // via -mt) is never painted over / clipped by positioned page content
         // above it. overflow-visible keeps the button's top from being clipped.
-        className="relative z-30 grid shrink-0 grid-cols-5 items-stretch overflow-visible border-t bg-card pb-[env(safe-area-inset-bottom)] md:hidden"
+        className="fixed inset-x-0 bottom-0 z-30 grid shrink-0 grid-cols-5 items-stretch overflow-visible border-t bg-card pb-[env(safe-area-inset-bottom)] md:hidden"
       >
         {TABS.slice(0, 2).map((tab) => (
           <TabLink key={tab.key} tab={tab} active={active} />

--- a/apps/web/src/components/dashboard-layout/mobile-top-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-top-bar.tsx
@@ -45,7 +45,7 @@ export function MobileTopBar({ onOpenPalette }: { onOpenPalette: () => void }) {
   const title = meta && !isHome ? t(`pages.${meta.pageKey}.title`) : undefined;
 
   return (
-    <header className="shrink-0 border-b bg-card pt-[env(safe-area-inset-top)] md:hidden">
+    <header className="sticky top-0 z-30 shrink-0 border-b bg-card pt-[env(safe-area-inset-top)] md:hidden">
       <div className="flex h-14 items-center gap-1 pr-2 pl-1.5">
         {group ? (
           <Link

--- a/apps/web/src/components/dashboard-layout/route-meta.ts
+++ b/apps/web/src/components/dashboard-layout/route-meta.ts
@@ -59,7 +59,6 @@ export const NAV_GROUPS: ShellNavGroup[] = [
     icon: BookOpen,
     items: [
       { key: "myPuzzles", href: "/my-puzzles", icon: Puzzle },
-      { key: "puzzles", href: "/puzzles", icon: Shapes },
       { key: "collections", href: "/collections", icon: FolderOpen },
       { key: "completions", href: "/completions", icon: CircleCheck },
       { key: "goals", href: "/goals", icon: Target },
@@ -72,6 +71,9 @@ export const NAV_GROUPS: ShellNavGroup[] = [
     icon: Users,
     items: [
       { key: "browse", href: "/browse", icon: Search },
+      // The shared puzzle catalogue is discovery, not personal library — it lives
+      // alongside Browse under Community.
+      { key: "puzzles", href: "/puzzles", icon: Shapes },
       { key: "circles", href: "/circles", icon: Users },
       { key: "exchanges", href: "/trades", icon: ArrowLeftRight },
       { key: "messages", href: "/messages", icon: MessageSquare },
@@ -110,8 +112,9 @@ export const ROUTE_META: Record<string, ShellRouteMeta> = {
   "/my-puzzles": { pageKey: "myPuzzles", group: "library" },
   "/my-puzzles/add": { pageKey: "addPuzzle", group: "library" },
   "/my-puzzles/add/new": { pageKey: "createPuzzle", group: "library" },
-  "/copies": { pageKey: "copyInstance", group: "library" },
-  "/copies/$id": { pageKey: "copyInstance", group: "library" },
+  // Owner's own copy detail (gated): nav-highlights My Puzzles; the page publishes
+  // its own "My Library › My Puzzles › <name>" crumbs + title at runtime.
+  "/my-puzzles/$id": { pageKey: "myPuzzles", group: "library" },
   "/collections": { pageKey: "collections", group: "library" },
   "/completions": { pageKey: "completions", group: "library" },
   "/goals": { pageKey: "goals", group: "library" },
@@ -120,14 +123,18 @@ export const ROUTE_META: Record<string, ShellRouteMeta> = {
   // Community
   "/community": { pageKey: "community", variant: "landing" },
   "/browse": { pageKey: "browse", group: "community" },
+  // Anyone's owned copy detail: nav-highlights Community; the page publishes its
+  // own "Community › Owned Copies › <name>" crumbs + title at runtime.
+  "/copies": { pageKey: "copyInstance", group: "community" },
+  "/copies/$id": { pageKey: "copyInstance", group: "community" },
+  // The shared puzzle catalogue (discovery) + its contribute sub-route.
+  "/puzzles": { pageKey: "puzzles", group: "community" },
+  "/puzzles/$id": { pageKey: "puzzles", group: "community" },
+  "/puzzles/add": { pageKey: "contributePuzzle", group: "community" },
   "/circles": { pageKey: "circles", group: "community" },
   "/trades": { pageKey: "exchanges", group: "community" },
   "/messages": { pageKey: "messages", group: "community" },
   "/people": { pageKey: "people", group: "community" },
-
-  // The shared catalogue (in the library nav) and its contribute sub-route.
-  "/puzzles": { pageKey: "puzzles", group: "library" },
-  "/puzzles/add": { pageKey: "contributePuzzle", group: "library" },
 
   // Routes removed from the nav but still alive.
   "/borrowed": { pageKey: "borrowed", group: "library" },

--- a/apps/web/src/components/dashboard-layout/shell.tsx
+++ b/apps/web/src/components/dashboard-layout/shell.tsx
@@ -34,16 +34,16 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
     <ShellPreferencesProvider>
       <PageHeaderSlotProvider>
-        <SidebarProvider className="h-svh flex-col overflow-hidden">
+        <SidebarProvider className="flex-col md:h-svh md:overflow-hidden">
           <TopBar onOpenPalette={() => setPaletteOpen(true)} />
           <MobileTopBar onOpenPalette={() => setPaletteOpen(true)} />
-          <div className="flex min-h-0 flex-1">
+          <div className="flex flex-1 md:min-h-0">
             <AppSidebar />
-            <SidebarInset className="min-h-0 overflow-hidden md:peer-data-[variant=inset]:mt-0 md:peer-data-[variant=inset]:mr-3 md:peer-data-[variant=inset]:mb-3 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
+            <SidebarInset className="md:min-h-0 md:overflow-hidden md:peer-data-[variant=inset]:mt-0 md:peer-data-[variant=inset]:mr-3 md:peer-data-[variant=inset]:mb-3 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
               {/* ONE scroll region holds the page head + content, so content scrolls UNDER the
                   glass head (sticky top-0). Clipped to the card's rounded corners by SidebarInset's
                   overflow-hidden. */}
-              <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
+              <div className="flex-1 overflow-x-hidden md:min-h-0 md:overflow-y-auto md:[scrollbar-gutter:stable]">
                 <PageHead />
                 <ContentArea>{children}</ContentArea>
               </div>
@@ -81,7 +81,7 @@ function ContentArea({ children }: { children: React.ReactNode }) {
       className={cn(
         // Mobile: 18px top / 16px sides per the mobile spec, with extra
         // bottom clearance for the tab bar's raised center button.
-        "w-full px-4 pt-[18px] pb-8 md:p-6",
+        "w-full px-4 pt-[18px] pb-[calc(env(safe-area-inset-bottom)+84px)] md:p-6",
         !fullWidth && "mx-auto max-w-[1180px]",
       )}
     >

--- a/apps/web/src/components/dashboard-layout/user-footer.tsx
+++ b/apps/web/src/components/dashboard-layout/user-footer.tsx
@@ -22,6 +22,7 @@ import { useShellPreferences } from "./preferences";
 export function UserFooter() {
   const { user } = useUser();
   const { hideEmail } = useShellPreferences();
+  const t = useTranslations("shell");
 
   if (!user) {
     return null;
@@ -47,7 +48,14 @@ export function UserFooter() {
           <PreferencesPage />
         </UserButton.UserProfilePage>
       </UserButton>
-      <div className="grid min-w-0 flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+      {/* The identity block links to the member's own profile — the avatar
+          (Clerk UserButton) owns account management, so this is the only
+          in-shell route to /profile on desktop. */}
+      <Link
+        href="/profile"
+        title={t("pages.profile.title")}
+        className="grid min-w-0 flex-1 rounded-md px-1 py-0.5 text-left text-sm leading-tight transition-colors hover:bg-accent group-data-[collapsible=icon]:hidden"
+      >
         <span className="truncate font-medium">
           {user.firstName} {user.lastName}
         </span>
@@ -60,7 +68,7 @@ export function UserFooter() {
         >
           {email}
         </span>
-      </div>
+      </Link>
       <AdminBadge />
     </div>
   );

--- a/apps/web/src/components/marketing/fit-to-width.test.ts
+++ b/apps/web/src/components/marketing/fit-to-width.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { fitScale } from "./fit-to-width";
+
+describe("fitScale", () => {
+  it("scales down when the child is wider than the container", () => {
+    expect(fitScale(360, 500)).toBeCloseTo(0.72, 5);
+  });
+
+  it("never scales up past 1 when the container is wider", () => {
+    expect(fitScale(800, 500)).toBe(1);
+  });
+
+  it("returns 1 when widths are equal", () => {
+    expect(fitScale(500, 500)).toBe(1);
+  });
+
+  it("guards against a zero / unmeasured container width", () => {
+    expect(fitScale(0, 500)).toBe(1);
+  });
+
+  it("guards against a zero / unmeasured natural width", () => {
+    expect(fitScale(360, 0)).toBe(1);
+  });
+});

--- a/apps/web/src/components/marketing/fit-to-width.tsx
+++ b/apps/web/src/components/marketing/fit-to-width.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Largest scale ≤ 1 that fits a child of `naturalWidth` into `containerWidth`.
+ * Only ever scales DOWN — equal/larger containers return 1 (render untouched).
+ * Returns 1 for non-positive inputs (pre-measurement / unmeasured elements).
+ */
+export function fitScale(containerWidth: number, naturalWidth: number): number {
+  if (containerWidth <= 0 || naturalWidth <= 0) return 1;
+  return Math.min(1, containerWidth / naturalWidth);
+}
+
+/**
+ * Scales a fixed-size child DOWN to fit the width of this wrapper, and collapses
+ * the wrapper's rendered height to the scaled height so the shrunk child leaves
+ * no layout gap. `overflow: hidden` contains the child's un-transformed layout
+ * box (a CSS transform shrinks paint, not layout) so it can't widen the page.
+ *
+ * Used for the marketing JigPlank previews, which are intrinsically wider than a
+ * phone viewport. At widths ≥ the child's natural width, scale is 1 (untouched).
+ */
+export function FitToWidth({ children }: { children: React.ReactNode }) {
+  const outer = React.useRef<HTMLDivElement>(null);
+  const inner = React.useRef<HTMLDivElement>(null);
+  const [scale, setScale] = React.useState(1);
+  const [scaledHeight, setScaledHeight] = React.useState<number | null>(null);
+
+  React.useLayoutEffect(() => {
+    const outerEl = outer.current;
+    const innerEl = inner.current;
+    if (!outerEl || !innerEl) return;
+
+    const measure = () => {
+      // offsetWidth/Height report the UN-transformed layout box, so they give the
+      // child's natural size even while our scale transform is applied.
+      const next = fitScale(outerEl.clientWidth, innerEl.offsetWidth);
+      setScale(next);
+      setScaledHeight(innerEl.offsetHeight * next);
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(outerEl);
+    ro.observe(innerEl); // child can resize after images load (JigPlank re-measures)
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={outer}
+      style={{
+        width: "100%",
+        height: scaledHeight ?? undefined,
+        overflow: "hidden",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        ref={inner}
+        style={{
+          flex: "none",
+          transform: `scale(${scale})`,
+          transformOrigin: "top center",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/home/feature-rows.tsx
+++ b/apps/web/src/components/marketing/home/feature-rows.tsx
@@ -1,5 +1,6 @@
 import { MkBadge, type MkBadgeTone } from "@/components/marketing/badge";
 import { Container } from "@/components/marketing/container";
+import { FitToWidth } from "@/components/marketing/fit-to-width";
 import { JigPlank } from "@/components/marketing/plank";
 import { Reveal } from "@/components/marketing/reveal";
 import { Eyebrow, Section } from "@/components/marketing/section";
@@ -24,28 +25,30 @@ export function FeatureRows() {
     {
       key: "library",
       visual: (
-        <JigPlank
-          depth={16}
-          boxes={[
-            {
-              series: "Natuur",
-              title: "Boslicht",
-              pieceCount: 1000,
-              c1: "var(--mk-violet-400)",
-              c2: "var(--mk-violet-600)",
-              width: 96,
-            },
-            { cover: coverSand, title: "Zandsculpturen", width: 128 },
-            {
-              series: "Kunst",
-              title: "Sterrennacht",
-              pieceCount: 2000,
-              c1: "var(--mk-pink-400)",
-              c2: "var(--mk-pink-500)",
-              width: 100,
-            },
-          ]}
-        />
+        <FitToWidth>
+          <JigPlank
+            depth={16}
+            boxes={[
+              {
+                series: "Natuur",
+                title: "Boslicht",
+                pieceCount: 1000,
+                c1: "var(--mk-violet-400)",
+                c2: "var(--mk-violet-600)",
+                width: 96,
+              },
+              { cover: coverSand, title: "Zandsculpturen", width: 128 },
+              {
+                series: "Kunst",
+                title: "Sterrennacht",
+                pieceCount: 2000,
+                c1: "var(--mk-pink-400)",
+                c2: "var(--mk-pink-500)",
+                width: 100,
+              },
+            ]}
+          />
+        </FitToWidth>
       ),
     },
     { key: "lend", visual: <LendTrackVisual />, reverse: true },

--- a/apps/web/src/components/marketing/plank-3d/box-size.test.ts
+++ b/apps/web/src/components/marketing/plank-3d/box-size.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { BOX_SCALE, boxWorldSize, PX } from "./box";
+
+describe("boxWorldSize", () => {
+  it("derives width and height from a no-cover box", () => {
+    const { w, h } = boxWorldSize({ width: 116, height: 144 }, 1);
+    expect(w).toBeCloseTo(116 * PX * BOX_SCALE, 6);
+    expect(h).toBeCloseTo(144 * PX * BOX_SCALE, 6);
+  });
+  it("uses width/1.4 for a cover box height", () => {
+    const { h } = boxWorldSize({ width: 140, cover: "x.jpg" }, 1);
+    expect(h).toBeCloseTo((140 / 1.4) * PX * BOX_SCALE, 6);
+  });
+  it("applies sizeScale and defaults width to 116", () => {
+    const { w } = boxWorldSize({}, 2);
+    expect(w).toBeCloseTo(116 * PX * BOX_SCALE * 2, 6);
+  });
+});

--- a/apps/web/src/components/marketing/plank-3d/box.tsx
+++ b/apps/web/src/components/marketing/plank-3d/box.tsx
@@ -110,7 +110,7 @@ export function PuzzleBox({
   headingFont,
   sizeScale = 1,
   anchored = true,
-  fixedSize = false,
+  onResolvedHeight,
 }: {
   box: PlankBox;
   slot: BoxSlot;
@@ -126,12 +126,11 @@ export function PuzzleBox({
    */
   anchored?: boolean;
   /**
-   * When true, skip the post-load cover aspect-correction and render at the
-   * deterministic boxWorldSize height. The physics scene needs this so the
-   * rendered box matches its (statically-sized) CuboidCollider — otherwise a
-   * cover with aspect ≠ 1.4 ends up a different size than its physics body.
+   * Reports the box's world height whenever it changes (the cover aspect-corrects
+   * after the image loads). The physics scene uses this to size the collider to
+   * match the rendered box instead of a fixed 1.4 default.
    */
-  fixedSize?: boolean;
+  onResolvedHeight?: (worldHeight: number) => void;
 }) {
   const widthPx = box.width ?? 116;
   const worldScale = PX * BOX_SCALE * sizeScale;
@@ -154,20 +153,14 @@ export function PuzzleBox({
   // Height in CSS-plank pixels; corrected to the cover's real aspect when the
   // image loads (possibly long ago, on the cached entry).
   const [hPx, setHPx] = React.useState(() =>
-    fixedSize || entry.aspect == null ? defaultHPx : widthPx / entry.aspect,
+    entry.aspect != null ? widthPx / entry.aspect : defaultHPx,
   );
   const [edges, setEdges] = React.useState<CoverEdges | null>(entry.edges);
 
   React.useEffect(() => {
-    // fixedSize keeps the height at defaultHPx (== boxWorldSize, == the physics
-    // collider); only the edge-bleed strips still update from the cache.
-    if (!fixedSize) {
-      setHPx(entry.aspect != null ? widthPx / entry.aspect : defaultHPx);
-    }
+    setHPx(entry.aspect != null ? widthPx / entry.aspect : defaultHPx);
     setEdges(entry.edges);
-    const onAspect = (aspect: number) => {
-      if (!fixedSize) setHPx(widthPx / aspect);
-    };
+    const onAspect = (aspect: number) => setHPx(widthPx / aspect);
     const onEdges = (e: CoverEdges) => setEdges(e);
     entry.aspectSubs.add(onAspect);
     entry.edgeSubs.add(onEdges);
@@ -175,10 +168,16 @@ export function PuzzleBox({
       entry.aspectSubs.delete(onAspect);
       entry.edgeSubs.delete(onEdges);
     };
-  }, [entry, widthPx, defaultHPx, fixedSize]);
+  }, [entry, widthPx, defaultHPx]);
 
   const texture = entry.texture;
   const h = hPx * worldScale;
+
+  // Report the resolved world height so the physics scene can size the collider
+  // to match (covers aspect-correct after the image loads).
+  React.useEffect(() => {
+    onResolvedHeight?.(h);
+  }, [h, onResolvedHeight]);
 
   // Build CanvasTextures from the strip canvases when edges arrive. The strip
   // canvases are shared via the cache; the textures themselves are tiny

--- a/apps/web/src/components/marketing/plank-3d/box.tsx
+++ b/apps/web/src/components/marketing/plank-3d/box.tsx
@@ -110,6 +110,7 @@ export function PuzzleBox({
   headingFont,
   sizeScale = 1,
   anchored = true,
+  fixedSize = false,
 }: {
   box: PlankBox;
   slot: BoxSlot;
@@ -124,6 +125,13 @@ export function PuzzleBox({
    * <RigidBody> owns the world transform and a centered CuboidCollider matches.
    */
   anchored?: boolean;
+  /**
+   * When true, skip the post-load cover aspect-correction and render at the
+   * deterministic boxWorldSize height. The physics scene needs this so the
+   * rendered box matches its (statically-sized) CuboidCollider — otherwise a
+   * cover with aspect ≠ 1.4 ends up a different size than its physics body.
+   */
+  fixedSize?: boolean;
 }) {
   const widthPx = box.width ?? 116;
   const worldScale = PX * BOX_SCALE * sizeScale;
@@ -146,14 +154,20 @@ export function PuzzleBox({
   // Height in CSS-plank pixels; corrected to the cover's real aspect when the
   // image loads (possibly long ago, on the cached entry).
   const [hPx, setHPx] = React.useState(() =>
-    entry.aspect != null ? widthPx / entry.aspect : defaultHPx,
+    fixedSize || entry.aspect == null ? defaultHPx : widthPx / entry.aspect,
   );
   const [edges, setEdges] = React.useState<CoverEdges | null>(entry.edges);
 
   React.useEffect(() => {
-    setHPx(entry.aspect != null ? widthPx / entry.aspect : defaultHPx);
+    // fixedSize keeps the height at defaultHPx (== boxWorldSize, == the physics
+    // collider); only the edge-bleed strips still update from the cache.
+    if (!fixedSize) {
+      setHPx(entry.aspect != null ? widthPx / entry.aspect : defaultHPx);
+    }
     setEdges(entry.edges);
-    const onAspect = (aspect: number) => setHPx(widthPx / aspect);
+    const onAspect = (aspect: number) => {
+      if (!fixedSize) setHPx(widthPx / aspect);
+    };
     const onEdges = (e: CoverEdges) => setEdges(e);
     entry.aspectSubs.add(onAspect);
     entry.edgeSubs.add(onEdges);
@@ -161,7 +175,7 @@ export function PuzzleBox({
       entry.aspectSubs.delete(onAspect);
       entry.edgeSubs.delete(onEdges);
     };
-  }, [entry, widthPx, defaultHPx]);
+  }, [entry, widthPx, defaultHPx, fixedSize]);
 
   const texture = entry.texture;
   const h = hPx * worldScale;

--- a/apps/web/src/components/marketing/plank-3d/box.tsx
+++ b/apps/web/src/components/marketing/plank-3d/box.tsx
@@ -17,6 +17,19 @@ export const PX = 1 / 100;
 export const BOX_SCALE = 0.74;
 export const BOX_DEPTH = 0.18;
 
+/** World-space {w,h} of a box's front face (pre-aspect-correction), mirroring
+ *  the scaling PuzzleBox applies. Used by the bounded scene's framing and the
+ *  physics scene's colliders so they never drift from the visual size. */
+export function boxWorldSize(
+  box: Pick<PlankBox, "width" | "height" | "cover">,
+  sizeScale = 1,
+): { w: number; h: number } {
+  const widthPx = box.width ?? 116;
+  const worldScale = PX * BOX_SCALE * sizeScale;
+  const hPx = box.cover ? widthPx / 1.4 : (box.height ?? 144);
+  return { w: widthPx * worldScale, h: hPx * worldScale };
+}
+
 export interface BoxSlot {
   x: number;
   /** Resolved hex colors for this box. */
@@ -96,6 +109,7 @@ export function PuzzleBox({
   index,
   headingFont,
   sizeScale = 1,
+  anchored = true,
 }: {
   box: PlankBox;
   slot: BoxSlot;
@@ -103,10 +117,17 @@ export function PuzzleBox({
   headingFont: string;
   /** Deterministic per-instance footprint variation (texture is shared). */
   sizeScale?: number;
+  /**
+   * When true (default), the group self-positions at [slot.x, h/2, 0] with a
+   * per-box yaw — the static scene's behaviour.
+   * When false, the group is at local origin with no rotation so that a parent
+   * <RigidBody> owns the world transform and a centered CuboidCollider matches.
+   */
+  anchored?: boolean;
 }) {
   const widthPx = box.width ?? 116;
   const worldScale = PX * BOX_SCALE * sizeScale;
-  const w = widthPx * worldScale;
+  const { w } = boxWorldSize(box, sizeScale);
   const defaultHPx = box.cover ? widthPx / 1.4 : (box.height ?? 144);
 
   const { key, entry } = React.useMemo(
@@ -181,8 +202,15 @@ export function PuzzleBox({
   // Body color: use edge average for cover boxes when available, otherwise slot.c2.
   const bodyColor = edges ? edges.body : slot.c2;
 
+  // When anchored=false the parent RigidBody owns world transform; render at
+  // local origin so a centered CuboidCollider matches the visual exactly.
+  const groupPos: [number, number, number] = anchored
+    ? [slot.x, baseY, 0]
+    : [0, 0, 0];
+  const groupRot: [number, number, number] = anchored ? [0, yaw, 0] : [0, 0, 0];
+
   return (
-    <group position={[slot.x, baseY, 0]} rotation={[0, yaw, 0]}>
+    <group position={groupPos} rotation={groupRot}>
       <RoundedBox args={[w, h, BOX_DEPTH]} radius={0.015} smoothness={4}>
         <meshStandardMaterial
           color={bodyColor}

--- a/apps/web/src/components/marketing/plank-3d/palette.ts
+++ b/apps/web/src/components/marketing/plank-3d/palette.ts
@@ -35,10 +35,11 @@ export function resolveCssColor(input: string, scope: HTMLElement): string {
 }
 
 /** Resolve the marketing heading font stack for canvas text. */
-export function resolveHeadingFont(scope: HTMLElement): string {
-  const v = getComputedStyle(scope)
-    .getPropertyValue("--font-mk-heading")
-    .trim();
+export function resolveHeadingFont(
+  scope: HTMLElement,
+  varName = "--font-mk-heading",
+): string {
+  const v = getComputedStyle(scope).getPropertyValue(varName).trim();
   return v || "system-ui, sans-serif";
 }
 

--- a/apps/web/src/components/profile/arrange-shelf-dialog.tsx
+++ b/apps/web/src/components/profile/arrange-shelf-dialog.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { gateway, Id } from "@/gateway";
+import { cn } from "@/lib/utils";
+import { useMutation, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { ArrowDown, ArrowUp, Check, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useTranslations } from "use-intl";
+
+type OwnedCopy = FunctionReturnType<
+  typeof gateway.library.ownedByOwner
+>[number];
+
+const MAX_FEATURED = 6;
+
+// Owner-only dialog for curating the profile shelf. Presents a scrollable grid
+// of all owned copies as toggle buttons (aria-pressed); selected copies appear
+// in an ordered list with Move-up / Move-down / Remove controls. Save calls the
+// arrangeShelf mutation; Convex reactivity refreshes the shelf automatically.
+//
+// Accessibility: real <button>s throughout, aria-pressed for toggles, focus trap
+// provided by the Radix Dialog primitive. No drag-and-drop library.
+export function ArrangeShelfDialog({
+  ownerId,
+  currentFeaturedIds,
+  onClose,
+}: {
+  ownerId: Id<"users">;
+  currentFeaturedIds: Id<"ownedPuzzles">[];
+  onClose: () => void;
+}) {
+  const t = useTranslations("profile.shelf.arrangeDialog");
+
+  const copies = useQuery(gateway.library.ownedByOwner, {
+    ownerId,
+    includeUnavailable: true,
+  });
+
+  const arrange = useMutation(gateway.social.arrangeShelf);
+
+  // Selected copy ids in display order (the arrangement).
+  const [selected, setSelected] = useState<Id<"ownedPuzzles">[]>(
+    () => currentFeaturedIds,
+  );
+  const [saving, setSaving] = useState(false);
+
+  // Build a lookup for quick title resolution.
+  const copyMap = useMemo(() => {
+    const m = new Map<Id<"ownedPuzzles">, OwnedCopy>();
+    for (const c of copies ?? []) {
+      m.set(c._id as Id<"ownedPuzzles">, c);
+    }
+    return m;
+  }, [copies]);
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const atMax = selected.length >= MAX_FEATURED;
+
+  function handleToggle(copyId: Id<"ownedPuzzles">) {
+    setSelected((prev) => {
+      if (prev.includes(copyId)) {
+        return prev.filter((id) => id !== copyId);
+      }
+      if (prev.length >= MAX_FEATURED) return prev; // guard (button also disabled)
+      return [...prev, copyId];
+    });
+  }
+
+  function handleMoveUp(index: number) {
+    if (index === 0) return;
+    setSelected((prev) => {
+      const next = [...prev];
+      [next[index - 1], next[index]] = [next[index], next[index - 1]];
+      return next;
+    });
+  }
+
+  function handleMoveDown(index: number) {
+    setSelected((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const next = [...prev];
+      [next[index], next[index + 1]] = [next[index + 1], next[index]];
+      return next;
+    });
+  }
+
+  function handleRemove(copyId: Id<"ownedPuzzles">) {
+    setSelected((prev) => prev.filter((id) => id !== copyId));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await arrange({ copyIds: selected });
+      toast.success(t("saved"));
+      onClose();
+    } catch {
+      toast.error(t("saveError"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function copyTitle(copy: OwnedCopy): string {
+    return copy.puzzle?.title ?? copy.snapshot?.title ?? t("untitled");
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col gap-0 p-0">
+        <DialogHeader className="px-6 pt-6 pb-4">
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>
+            {t("description", { max: MAX_FEATURED })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 pb-4">
+          {/* Toggle grid: all owned copies */}
+          {copies === undefined ? (
+            <p className="text-muted-foreground text-sm">{t("loading")}</p>
+          ) : copies.length === 0 ? (
+            <p className="text-muted-foreground text-sm">{t("noCopies")}</p>
+          ) : (
+            <div>
+              <p className="text-muted-foreground mb-3 text-xs font-medium uppercase tracking-wide">
+                {t("pickSection")}
+              </p>
+              {atMax && (
+                <p className="text-muted-foreground mb-3 text-sm">
+                  {t("maxHint", { max: MAX_FEATURED })}
+                </p>
+              )}
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {copies.map((copy) => {
+                  const id = copy._id as Id<"ownedPuzzles">;
+                  const isSelected = selectedSet.has(id);
+                  const isDisabled = !isSelected && atMax;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      aria-pressed={isSelected}
+                      disabled={isDisabled}
+                      onClick={() => handleToggle(id)}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                        isSelected
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "hover:bg-accent border-transparent bg-muted",
+                        isDisabled && "cursor-not-allowed opacity-40",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex size-4 shrink-0 items-center justify-center rounded-sm border",
+                          isSelected
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-muted-foreground",
+                        )}
+                        aria-hidden
+                      >
+                        {isSelected && <Check className="size-3" />}
+                      </span>
+                      <span className="min-w-0 truncate">
+                        {copyTitle(copy)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Ordered selection list */}
+          {selected.length > 0 && (
+            <div>
+              <p className="text-muted-foreground mb-3 text-xs font-medium uppercase tracking-wide">
+                {t("orderSection", {
+                  count: selected.length,
+                  max: MAX_FEATURED,
+                })}
+              </p>
+              <ol className="flex flex-col gap-1.5">
+                {selected.map((copyId, index) => {
+                  const copy = copyMap.get(copyId);
+                  const title = copy ? copyTitle(copy) : copyId;
+                  return (
+                    <li
+                      key={copyId}
+                      className="bg-muted flex items-center gap-2 rounded-md px-3 py-2 text-sm"
+                    >
+                      <span className="text-muted-foreground w-5 shrink-0 text-xs tabular-nums">
+                        {index + 1}.
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{title}</span>
+                      <div className="flex shrink-0 gap-1">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="size-7"
+                          aria-label={t("moveUp")}
+                          disabled={index === 0}
+                          onClick={() => handleMoveUp(index)}
+                        >
+                          <ArrowUp className="size-3.5" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="size-7"
+                          aria-label={t("moveDown")}
+                          disabled={index === selected.length - 1}
+                          onClick={() => handleMoveDown(index)}
+                        >
+                          <ArrowDown className="size-3.5" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="size-7"
+                          aria-label={t("remove")}
+                          onClick={() => handleRemove(copyId)}
+                        >
+                          <X className="size-3.5" />
+                        </Button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="border-t px-6 py-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={saving}
+          >
+            {t("cancel")}
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={saving}>
+            {saving ? t("saving") : t("save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/profile/edit-profile-form.tsx
+++ b/apps/web/src/components/profile/edit-profile-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useUser } from "@/compat/clerk";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,10 +14,21 @@ import { toast } from "sonner";
 import { useTranslations } from "use-intl";
 import type { Member } from "./member-view";
 
+// Best-effort extraction of a human message from a Clerk API error (e.g. an
+// already-taken or too-short username), falling back to undefined.
+function clerkErrorMessage(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "errors" in err) {
+    const errs = (err as { errors?: Array<{ longMessage?: string }> }).errors;
+    return errs?.[0]?.longMessage;
+  }
+  return undefined;
+}
+
 // The inline editor behind the header's Edit Profile toggle: username,
-// location and bio as open labelled fields (no card), saved through the
-// identity gateway. The server rejects taken usernames; we surface that as a
-// toast and keep the form open so nothing is lost.
+// location and bio as open labelled fields (no card). Username's source of
+// truth is Clerk (updated here; mirrored to Convex by the user.updated
+// webhook); location/bio are saved straight to Convex via the identity gateway.
+// Clerk rejects taken/invalid usernames; we surface that as a toast.
 export function EditProfileForm({
   member,
   onDone,
@@ -25,6 +37,7 @@ export function EditProfileForm({
   onDone: () => void;
 }) {
   const t = useTranslations("profile");
+  const { user } = useUser();
   const updateProfile = useMutation(gateway.identity.updateProfile);
   const setProfileVisibility = useMutation(gateway.social.setProfileVisibility);
 
@@ -56,16 +69,22 @@ export function EditProfileForm({
   const handleSave = async () => {
     setSaving(true);
     try {
+      // Username -> Clerk (the source of truth); the user.updated webhook mirrors
+      // it into the Convex `users` cache. Only call when it actually changed.
+      const nextUsername = username.trim();
+      if (user && nextUsername !== (member.username ?? "")) {
+        await user.update({ username: nextUsername });
+      }
+      // Location/bio live only in Convex.
       await updateProfile({
         userId: member._id as Id<"users">,
-        username: username.trim() || undefined,
         location: location.trim() || undefined,
         bio: bio.trim() || undefined,
       });
       toast.success(t("saved"));
       onDone();
-    } catch {
-      toast.error(t("saveError"));
+    } catch (err) {
+      toast.error(clerkErrorMessage(err) ?? t("saveError"));
     } finally {
       setSaving(false);
     }

--- a/apps/web/src/components/profile/shelf-section.tsx
+++ b/apps/web/src/components/profile/shelf-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Link } from "@/compat/link";
-import { PuzzlePlank, PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+import { PuzzlePlank3D } from "@/components/common/puzzle-plank-3d";
 import { SectionHead } from "@/components/dashboard-home/section-head";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,6 +10,7 @@ import { gateway, Id } from "@/gateway";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { BookOpen } from "lucide-react";
+import { useMemo } from "react";
 import { useTranslations } from "use-intl";
 import type { Member } from "./member-view";
 
@@ -56,6 +58,13 @@ export function ProfileShelfSection({ member }: { member: Member }) {
   const firstName = member.name?.split(/\s+/)[0] ?? member.name;
   const title = t("title", { name: firstName });
 
+  // Memoized so the 3D plank's color-resolution effect doesn't re-run on every
+  // reactive re-render (only when the copies change).
+  const boxes = useMemo(
+    () => (copies ?? []).slice(0, 6).map(toPlankBox),
+    [copies],
+  );
+
   if (copies === undefined) {
     return (
       <section>
@@ -64,8 +73,6 @@ export function ProfileShelfSection({ member }: { member: Member }) {
       </section>
     );
   }
-
-  const boxes = copies.slice(0, 6).map(toPlankBox);
 
   return (
     <section>
@@ -84,8 +91,8 @@ export function ProfileShelfSection({ member }: { member: Member }) {
           </Button>
         </div>
       ) : (
-        <div className="min-w-0 overflow-x-auto px-2 pt-6 pb-6">
-          <PuzzlePlank boxes={boxes} />
+        <div className="h-[300px] min-w-0 md:h-[360px]">
+          <PuzzlePlank3D boxes={boxes} />
         </div>
       )}
     </section>

--- a/apps/web/src/components/profile/shelf-section.tsx
+++ b/apps/web/src/components/profile/shelf-section.tsx
@@ -9,9 +9,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
-import { BookOpen } from "lucide-react";
-import { useMemo } from "react";
+import { BookOpen, Settings2 } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "use-intl";
+import { ArrangeShelfDialog } from "./arrange-shelf-dialog";
 import type { Member } from "./member-view";
 
 type OwnedCopy = FunctionReturnType<
@@ -46,26 +47,48 @@ function toPlankBox(copy: OwnedCopy, index: number): PuzzlePlankBox {
 // "{FirstName}'s Shelf": the signature puzzle plank rendering the member's
 // real copies on their profile, capped at six boxes so the plank stays a
 // display shelf rather than a catalogue (My Puzzles is the catalogue).
+// When the viewer is the owner, an "Arrange shelf" button opens a dialog to
+// curate and reorder up to 6 copies (sub-project ④).
 export function ProfileShelfSection({ member }: { member: Member }) {
   const t = useTranslations("profile.shelf");
   const tDashboardShelf = useTranslations("dashboard.shelf");
+
+  const [arrangeOpen, setArrangeOpen] = useState(false);
+
+  // Determine whether the signed-in user is the profile owner.
+  const me = useQuery(gateway.identity.currentUser);
+  const isOwner = me?._id === member._id;
 
   const copies = useQuery(gateway.library.ownedByOwner, {
     ownerId: member._id as Id<"users">,
     includeUnavailable: true,
   });
 
+  // The curated shelf — empty list means uncurated (fall back to recent-6 below).
+  const featuredCopies = useQuery(gateway.social.featuredShelf, {
+    userId: member._id as Id<"users">,
+  });
+
   const firstName = member.name?.split(/\s+/)[0] ?? member.name;
   const title = t("title", { name: firstName });
 
-  // Memoized so the 3D plank's color-resolution effect doesn't re-run on every
-  // reactive re-render (only when the copies change).
-  const boxes = useMemo(
-    () => (copies ?? []).slice(0, 6).map(toPlankBox),
-    [copies],
+  // Current featured copy ids for seeding the arrange dialog.
+  const currentFeaturedIds = useMemo(
+    () => (featuredCopies ?? []).map((c) => c._id as Id<"ownedPuzzles">),
+    [featuredCopies],
   );
 
-  if (copies === undefined) {
+  // Memoized so the 3D plank's color-resolution effect doesn't re-run on every
+  // reactive re-render (only when the copies change). Use curated order when
+  // available; fall back to the most-recent 6.
+  const boxes = useMemo(() => {
+    if (featuredCopies !== undefined && featuredCopies.length > 0) {
+      return featuredCopies.slice(0, 6).map(toPlankBox);
+    }
+    return (copies ?? []).slice(0, 6).map(toPlankBox);
+  }, [copies, featuredCopies]);
+
+  if (copies === undefined || featuredCopies === undefined) {
     return (
       <section>
         <SectionHead title={title} icon={BookOpen} />
@@ -80,6 +103,19 @@ export function ProfileShelfSection({ member }: { member: Member }) {
         title={title}
         icon={BookOpen}
         meta={boxes.length > 0 ? t("meta", { count: boxes.length }) : undefined}
+        action={
+          isOwner ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setArrangeOpen(true)}
+              className="gap-1.5"
+            >
+              <Settings2 className="size-4" />
+              {t("arrangeShelf")}
+            </Button>
+          ) : undefined
+        }
       />
       {boxes.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-10 text-center">
@@ -94,6 +130,14 @@ export function ProfileShelfSection({ member }: { member: Member }) {
         <div className="h-[300px] min-w-0 md:h-[360px]">
           <PuzzlePlank3D boxes={boxes} />
         </div>
+      )}
+
+      {isOwner && arrangeOpen && (
+        <ArrangeShelfDialog
+          ownerId={member._id as Id<"users">}
+          currentFeaturedIds={currentFeaturedIds}
+          onClose={() => setArrangeOpen(false)}
+        />
       )}
     </section>
   );

--- a/apps/web/src/components/profile/shelf-section.tsx
+++ b/apps/web/src/components/profile/shelf-section.tsx
@@ -128,7 +128,7 @@ export function ProfileShelfSection({ member }: { member: Member }) {
         </div>
       ) : (
         <div className="h-[300px] min-w-0 md:h-[360px]">
-          <PuzzlePlank3D boxes={boxes} />
+          <PuzzlePlank3D boxes={boxes} interactive />
         </div>
       )}
 

--- a/apps/web/src/components/profile/shelf-section.tsx
+++ b/apps/web/src/components/profile/shelf-section.tsx
@@ -31,7 +31,10 @@ const BOX_GRADIENTS: ReadonlyArray<readonly [string, string]> = [
 const BOX_HEIGHTS = [148, 130, 156, 126, 142];
 
 function toPlankBox(copy: OwnedCopy, index: number): PuzzlePlankBox {
-  const cover = copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
+  // Prefer the copy's resolved cover (a user-uploaded/pinned photo) over the
+  // catalogue image so a copy with its own cover shows it, not placeholder art.
+  const cover =
+    copy.coverUrl ?? copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
   const [c1, c2] = BOX_GRADIENTS[index % BOX_GRADIENTS.length];
   return {
     title: copy.puzzle?.title ?? copy.snapshot?.title,

--- a/apps/web/src/components/puzzles/puzzle-card-shell.tsx
+++ b/apps/web/src/components/puzzles/puzzle-card-shell.tsx
@@ -43,6 +43,9 @@ export interface PuzzleCardShellProps {
   href?: string;
   /** When set, the cover image links to this href (the puzzle's view page). */
   imageHref?: string;
+  /** How the cover image fills its square: "cover" crops to fill (default),
+   *  "contain" shows the whole image letterboxed. */
+  imageFit?: "cover" | "contain";
   className?: string;
 }
 
@@ -73,6 +76,7 @@ export function PuzzleCardShell({
   selectable = false,
   href,
   imageHref,
+  imageFit = "cover",
   className,
 }: PuzzleCardShellProps) {
   const t = useTranslations("puzzles");
@@ -106,7 +110,10 @@ export function PuzzleCardShell({
             src={puzzle.imageUrl}
             alt={puzzle.title || "Puzzle"}
             fill
-            className="object-cover transition-transform group-hover:scale-105"
+            className={cn(
+              "transition-transform group-hover:scale-105",
+              imageFit === "contain" ? "object-contain" : "object-cover",
+            )}
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-jigsaw-primary/15 to-jigsaw-primary-accent/15 text-jigsaw-primary/50">

--- a/apps/web/src/components/puzzles/puzzle-card-shell.tsx
+++ b/apps/web/src/components/puzzles/puzzle-card-shell.tsx
@@ -106,7 +106,7 @@ export function PuzzleCardShell({
             src={puzzle.imageUrl}
             alt={puzzle.title || "Puzzle"}
             fill
-            className="object-cover transition-transform hover:scale-105"
+            className="object-cover transition-transform group-hover:scale-105"
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-jigsaw-primary/15 to-jigsaw-primary-accent/15 text-jigsaw-primary/50">
@@ -215,7 +215,9 @@ export function PuzzleCardShell({
   const card = (
     <Card
       className={cn(
-        "relative h-full gap-0 overflow-hidden p-0",
+        // `group` so the cover zooms on hover of the WHOLE card (the stretched-link
+        // overlay covers the image, so image-only :hover no longer fires).
+        "group relative h-full gap-0 overflow-hidden p-0",
         selected && "ring-2 ring-primary",
         (href || selectable) && "cursor-pointer",
         className,

--- a/apps/web/src/components/puzzles/puzzle-card-shell.tsx
+++ b/apps/web/src/components/puzzles/puzzle-card-shell.tsx
@@ -116,26 +116,29 @@ export function PuzzleCardShell({
         {overlay}
       </div>
     );
-    // Make the cover a link to the puzzle's view page, so a click on the image navigates without
-    // having to find the small action button.
-    return imageHref ? (
-      <Link
-        href={imageHref}
-        aria-label={puzzle.title}
-        className="focus-visible:ring-ring block rounded-t-lg focus-visible:ring-2 focus-visible:outline-none"
-      >
-        {inner}
-      </Link>
-    ) : (
-      inner
-    );
+    // The cover is no longer its own link — the whole card is clickable via the
+    // stretched title link below (so the image, title and empty card area all
+    // navigate, while the action buttons stay pressable above the overlay).
+    return inner;
   };
 
   const renderContent = () => (
     <div className="flex flex-1 flex-col p-4">
       <div className="mb-2">
         <h3 className="font-semibold text-sm line-clamp-2 mb-1">
-          {puzzle.title}
+          {imageHref ? (
+            // Stretched link: the ::after overlay spans the whole (relative) card, so
+            // clicking the image, title or any empty area navigates. Action buttons
+            // sit above it via `relative z-10` and stay pressable.
+            <Link
+              href={imageHref}
+              className="after:absolute after:inset-0 after:z-[1] after:content-[''] hover:underline focus-visible:underline focus-visible:outline-none"
+            >
+              {puzzle.title}
+            </Link>
+          ) : (
+            puzzle.title
+          )}
         </h3>
         {puzzle.brand && (
           <p className="text-xs text-muted-foreground mb-1">{puzzle.brand}</p>
@@ -178,11 +181,15 @@ export function PuzzleCardShell({
         </div>
       )}
 
-      {footer && <div className="mb-2">{footer}</div>}
+      {/* footer + actions sit ABOVE the stretched-link overlay (relative z-10) so their
+          own buttons/links remain clickable. */}
+      {footer && <div className="relative z-10 mb-2">{footer}</div>}
 
       {/* Pin the action row to the bottom so every card in a row shares one baseline, with a
           hairline divider separating it from the (top-packed) content. */}
-      {actions && <div className="mt-auto border-t pt-3">{actions}</div>}
+      {actions && (
+        <div className="relative z-10 mt-auto border-t pt-3">{actions}</div>
+      )}
     </div>
   );
 
@@ -208,7 +215,7 @@ export function PuzzleCardShell({
   const card = (
     <Card
       className={cn(
-        "h-full gap-0 overflow-hidden p-0",
+        "relative h-full gap-0 overflow-hidden p-0",
         selected && "ring-2 ring-primary",
         (href || selectable) && "cursor-pointer",
         className,

--- a/apps/web/src/components/ui/puzzle-card.tsx
+++ b/apps/web/src/components/ui/puzzle-card.tsx
@@ -41,6 +41,12 @@ interface PuzzleCardProps {
   variant?: "default" | "browse" | "collection" | "selection";
   onEdit?: (puzzleId: Id<"ownedPuzzles">) => void;
   onView?: (puzzleId: Id<"ownedPuzzles">) => void;
+  /**
+   * Base path the cover image links to (so it matches the Eye/view action):
+   * `${viewBasePath}/${ownedId}`. Defaults to "/copies"; My Puzzles passes
+   * "/my-puzzles" so the owner sees their own gated copy route.
+   */
+  viewBasePath?: string;
   onDelete?: (puzzleId: Id<"ownedPuzzles">) => void;
   onRemove?: (puzzleId: Id<"ownedPuzzles">) => void;
   onSelect?: (puzzleId: Id<"ownedPuzzles">) => void;
@@ -64,6 +70,7 @@ export function PuzzleCard({
   variant = "default",
   onEdit,
   onView,
+  viewBasePath = "/copies",
   onDelete,
   onRemove,
   onSelect,
@@ -282,7 +289,8 @@ export function PuzzleCard({
       actions={actions}
       // Clicking the cover opens the owned-copy view, mirroring the Eye action (only when a view
       // handler is wired — never in the selection picker, where the image toggles selection).
-      imageHref={onView ? `/copies/${ownedId}` : undefined}
+      // viewBasePath keeps the cover in step with the Eye target (e.g. "/my-puzzles" for own copies).
+      imageHref={onView ? `${viewBasePath}/${ownedId}` : undefined}
       className={className}
     />
   );

--- a/apps/web/src/components/ui/puzzle-card.tsx
+++ b/apps/web/src/components/ui/puzzle-card.tsx
@@ -47,6 +47,8 @@ interface PuzzleCardProps {
    * "/my-puzzles" so the owner sees their own gated copy route.
    */
   viewBasePath?: string;
+  /** Cover image fit: "cover" crops (default), "contain" shows the full image. */
+  imageFit?: "cover" | "contain";
   onDelete?: (puzzleId: Id<"ownedPuzzles">) => void;
   onRemove?: (puzzleId: Id<"ownedPuzzles">) => void;
   onSelect?: (puzzleId: Id<"ownedPuzzles">) => void;
@@ -71,6 +73,7 @@ export function PuzzleCard({
   onEdit,
   onView,
   viewBasePath = "/copies",
+  imageFit,
   onDelete,
   onRemove,
   onSelect,
@@ -172,6 +175,9 @@ export function PuzzleCard({
             type="checkbox"
             checked={isSelected}
             onChange={() => onSelect?.(ownedId)}
+            // The whole card already toggles selection; stop the click here from
+            // bubbling to the card so the toggle doesn't fire twice and cancel out.
+            onClick={(e) => e.stopPropagation()}
             className="h-4 w-4"
           />
         </div>
@@ -179,10 +185,24 @@ export function PuzzleCard({
     </>
   );
 
+  // Only render the action row (and its top border) when there is something to
+  // show — actual action buttons or the collection dropdown.
+  const hasActions =
+    showActions &&
+    !!(
+      onView ||
+      onLogSolve ||
+      onEdit ||
+      onDelete ||
+      onRemove ||
+      onRequestExchange ||
+      onMessage ||
+      onFavorite
+    );
   const actions =
-    showActions || showCollectionDropdown ? (
+    hasActions || showCollectionDropdown ? (
       <div className="flex items-center justify-between gap-2">
-        {showActions ? (
+        {hasActions ? (
           <div className="flex items-center gap-2">
             {onView && (
               <Button
@@ -283,6 +303,10 @@ export function PuzzleCard({
     <PuzzleCardShell
       puzzle={view}
       selected={isSelected}
+      // In the selection picker the whole card toggles selection (not just the
+      // checkbox); the checkbox stays as the visible state + keyboard target.
+      selectable={variant === "selection" && !!onSelect}
+      onSelect={onSelect ? () => onSelect(ownedId) : undefined}
       badges={badges}
       overlay={overlay}
       footer={loanBadge}
@@ -291,6 +315,7 @@ export function PuzzleCard({
       // handler is wired — never in the selection picker, where the image toggles selection).
       // viewBasePath keeps the cover in step with the Eye target (e.g. "/my-puzzles" for own copies).
       imageHref={onView ? `${viewBasePath}/${ownedId}` : undefined}
+      imageFit={imageFit}
       className={className}
     />
   );

--- a/apps/web/src/lib/humanize-duration.test.ts
+++ b/apps/web/src/lib/humanize-duration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { durationParts } from "./humanize-duration";
+
+describe("durationParts", () => {
+  it("keeps sub-hour durations in minutes (the old code rounded these to 0 days)", () => {
+    expect(durationParts(30)).toEqual({ value: 30, unit: "minute" });
+  });
+
+  it("never returns 0 — a near-zero duration floors to 1 minute", () => {
+    expect(durationParts(0)).toEqual({ value: 1, unit: "minute" });
+  });
+
+  it("shows hours for a 1-hour solve (the reported bug: was '0 days')", () => {
+    expect(durationParts(60)).toEqual({ value: 1, unit: "hour" });
+    expect(durationParts(120)).toEqual({ value: 2, unit: "hour" });
+  });
+
+  it("shows days between 1 day and 1 week", () => {
+    expect(durationParts(60 * 24)).toEqual({ value: 1, unit: "day" });
+    expect(durationParts(60 * 24 * 4)).toEqual({ value: 4, unit: "day" });
+  });
+
+  it("shows weeks between 1 week and ~1 month", () => {
+    expect(durationParts(60 * 24 * 7)).toEqual({ value: 1, unit: "week" });
+  });
+
+  it("caps at months for long durations", () => {
+    expect(durationParts(60 * 24 * 30)).toEqual({ value: 1, unit: "month" });
+    expect(durationParts(60 * 24 * 90)).toEqual({ value: 3, unit: "month" });
+  });
+});

--- a/apps/web/src/lib/humanize-duration.ts
+++ b/apps/web/src/lib/humanize-duration.ts
@@ -1,0 +1,35 @@
+// Pick the largest sensible time unit for a duration given in minutes, plus the rounded count in
+// that unit. Pair the result with Intl unit formatting (e.g. useFormatter().number(value, { style:
+// "unit", unit, unitDisplay: "long" })) so plurals + locale come for free — "2 hours", "1 day",
+// "4 days", "1 week", "1 month". Replaces the old "round to whole days" that collapsed a 1-hour
+// solve to "0 days".
+
+export type DurationUnit = "minute" | "hour" | "day" | "week" | "month";
+
+export interface DurationParts {
+  value: number;
+  unit: DurationUnit;
+}
+
+const MIN_PER_HOUR = 60;
+const MIN_PER_DAY = MIN_PER_HOUR * 24;
+const MIN_PER_WEEK = MIN_PER_DAY * 7;
+// ~1 month. Approximate on purpose — this is a humanized label, not an accounting figure.
+const MIN_PER_MONTH = MIN_PER_DAY * 30;
+
+/**
+ * Convert a duration in minutes to a {value, unit} pair using the largest unit that keeps the
+ * number small and readable. Sub-hour durations stay in minutes (min 1); months are the ceiling.
+ */
+export function durationParts(totalMinutes: number): DurationParts {
+  const m = Math.max(0, totalMinutes);
+  if (m < MIN_PER_HOUR)
+    return { value: Math.max(1, Math.round(m)), unit: "minute" };
+  if (m < MIN_PER_DAY)
+    return { value: Math.round(m / MIN_PER_HOUR), unit: "hour" };
+  if (m < MIN_PER_WEEK)
+    return { value: Math.round(m / MIN_PER_DAY), unit: "day" };
+  if (m < MIN_PER_MONTH)
+    return { value: Math.round(m / MIN_PER_WEEK), unit: "week" };
+  return { value: Math.round(m / MIN_PER_MONTH), unit: "month" };
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,7 +4,7 @@ import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 import { DefaultCatchBoundary } from "./components/DefaultCatchBoundary";
-import { NotFound } from "./components/NotFound";
+import { NotFoundContent } from "./components/NotFound";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -34,7 +34,11 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     defaultErrorComponent: DefaultCatchBoundary,
-    defaultNotFoundComponent: () => <NotFound />,
+    // Chrome-free: TanStack renders the matched layout chain and drops this into
+    // the deepest outlet, so a 404 picks up whichever shell it's under (app /
+    // admin / marketing). The root route's own notFoundComponent (marketing
+    // NotFound) covers truly top-level unmatched paths where no shell applies.
+    defaultNotFoundComponent: () => <NotFoundContent />,
     context: { queryClient, convexClient: convex, convexQueryClient },
     scrollRestoration: true,
     Wrap: ({ children }) => (

--- a/apps/web/src/routes/_dashboard/collections/$id/route.tsx
+++ b/apps/web/src/routes/_dashboard/collections/$id/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+// Param layout for a single collection. Its only job is to establish
+// `/collections/$id` as a real matchable route in the _dashboard chain so that
+// unmatched deeper paths (e.g. /collections/<id>/edit) fuzzy-match this segment
+// and render the app 404 inside the dashboard shell, instead of falling through
+// to the root route's marketing 404. The children (index, add-puzzles) render
+// through this Outlet unchanged.
+export const Route = createFileRoute("/_dashboard/collections/$id")({
+  component: () => <Outlet />,
+});

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "@/compat/navigation";
 import { availabilityToSharing } from "@/components/add-puzzle";
 import { EditCopyDialog } from "@/components/copies/edit-copy-dialog";
 import { PhotoLightbox } from "@/components/copies/photo-lightbox";
-import { usePageHeaderActions } from "@/components/dashboard-layout/page-header-slot";
+import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { EmptyState } from "@/components/library/empty-state";
 import { LogSolveDialog } from "@/components/solving/log-solve-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -34,7 +34,7 @@ import {
   Star,
   Tag,
 } from "lucide-react";
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import { useFormatter, useTranslations } from "use-intl";
 
@@ -56,11 +56,31 @@ export const Route = createFileRoute("/_dashboard/copies/$id")({
 
 function CopyInstancePage() {
   const { id } = Route.useParams();
+  return <CopyInstanceScreen copyId={id} owned={false} />;
+}
+
+// Shared copy-detail screen used by BOTH the public route (/copies/$id, owned=false)
+// and the owner route (/my-puzzles/$id, owned=true). `owned` drives the breadcrumb
+// framing and gates the owner route: viewing a copy you don't own under /my-puzzles
+// bounces to the public /copies view.
+export function CopyInstanceScreen({
+  copyId,
+  owned,
+}: {
+  copyId: string;
+  owned: boolean;
+}) {
+  const router = useRouter();
   const copy = useQuery(gateway.library.getCopyInstanceView, {
-    copyId: id as Id<"ownedPuzzles">,
+    copyId: copyId as Id<"ownedPuzzles">,
   });
 
-  if (copy === undefined) {
+  const notOwner = owned && copy != null && copy.viewerIsOwner === false;
+  useEffect(() => {
+    if (notOwner) router.push(`/copies/${copyId}`);
+  }, [notOwner, copyId, router]);
+
+  if (copy === undefined || notOwner) {
     return <CopyInstanceSkeleton />;
   }
 
@@ -68,7 +88,7 @@ function CopyInstancePage() {
     return <CopyInstanceNotFound />;
   }
 
-  return <CopyInstanceDetail copy={copy} copyId={id} />;
+  return <CopyInstanceDetail copy={copy} copyId={copyId} owned={owned} />;
 }
 
 function CopyInstanceSkeleton() {
@@ -126,12 +146,15 @@ function conditionDotClass(condition: string) {
 function CopyInstanceDetail({
   copy,
   copyId,
+  owned,
 }: {
   copy: CopyInstanceView;
   copyId: string;
+  owned: boolean;
 }) {
   const router = useRouter();
   const t = useTranslations("copyInstance");
+  const tShell = useTranslations("shell");
   const tPuzzles = useTranslations("puzzles");
   const tDifficulty = useTranslations("puzzles.puzzles.difficulty");
   const format = useFormatter();
@@ -166,17 +189,28 @@ function CopyInstanceDetail({
     }
   };
 
-  // Owner-only: publish the Edit action into the shell page head (top-right). Non-owners get no
-  // header action. Deps include the toggles the button closes over so the slot stays in sync.
-  usePageHeaderActions(
-    () =>
-      copy.viewerIsOwner ? (
+  // Publish the page head: the puzzle name as the title (replacing the generic
+  // "Owned copy"), the breadcrumb trail, and the owner-only Edit action. For the
+  // owner route (owned) the crumbs are left to the shell's auto trail (My Library ›
+  // My Puzzles › <name>, since /my-puzzles/$id's pageKey matches the nav item);
+  // the public route publishes an explicit Community › Owned Copies › <name> trail.
+  usePageHeader(
+    () => ({
+      title: snapshot.title,
+      crumbs: owned
+        ? undefined
+        : [
+            { label: tShell("groups.community.label"), href: "/community" },
+            { label: tShell("crumbs.ownedCopies"), href: "/browse" },
+          ],
+      actions: copy.viewerIsOwner ? (
         <Button variant="outline" onClick={() => setEditOpen(true)}>
           <Edit className="h-4 w-4" />
           {t("actions.edit")}
         </Button>
       ) : null,
-    [copy.viewerIsOwner, t],
+    }),
+    [snapshot.title, owned, copy.viewerIsOwner, t, tShell],
   );
 
   const formatDay = (timestamp: number) =>

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -1,3 +1,4 @@
+import { durationParts } from "@/lib/humanize-duration";
 import { pageTitle } from "@/lib/page-title";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -187,6 +188,13 @@ function CopyInstanceDetail({
 
   const formatMonth = (timestamp: number) =>
     format.dateTime(new Date(timestamp), { year: "numeric", month: "short" });
+
+  // Humanize a solve duration (minutes) to a localized "2 hours" / "1 day" / "1 week" via the
+  // largest sensible unit — Intl unit formatting handles plurals + locale.
+  const formatDuration = (minutes: number) => {
+    const { value, unit } = durationParts(minutes);
+    return format.number(value, { style: "unit", unit, unitDisplay: "long" });
+  };
 
   const acquisitionSourceLabel = (
     source?: "bought_new" | "bought_used" | "trade" | "gift",
@@ -397,8 +405,8 @@ function CopyInstanceDetail({
         <Stat value={stats.timesCompleted} label={t("statTimesCompleted")} />
         <Stat
           value={
-            stats.fastestFinishDays != null
-              ? t("statDaysValue", { days: stats.fastestFinishDays })
+            stats.fastestFinishMinutes != null
+              ? formatDuration(stats.fastestFinishMinutes)
               : "—"
           }
           label={t("statFastestFinish")}
@@ -471,8 +479,8 @@ function CopyInstanceDetail({
                   </>
                 }
                 sub={
-                  c.finishDays != null
-                    ? `${formatDay(c.occurredAt)} · ${t("finishedIn", { days: c.finishDays })}`
+                  c.finishMinutes != null
+                    ? `${formatDay(c.occurredAt)} · ${t("finishedIn", { duration: formatDuration(c.finishMinutes) })}`
                     : formatDay(c.occurredAt)
                 }
                 right={

--- a/apps/web/src/routes/_dashboard/dashboard.tsx
+++ b/apps/web/src/routes/_dashboard/dashboard.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_dashboard/dashboard")({
 
 function DashboardPage() {
   return (
-    <div className="flex w-full flex-col gap-8 md:gap-10">
+    <div className="flex w-full flex-col gap-6 md:gap-10">
       <BriefingHero />
       <ShelfSection />
       <PulseSection />

--- a/apps/web/src/routes/_dashboard/my-puzzles/$id.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/$id.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { pageTitle } from "@/lib/page-title";
+import { CopyInstanceScreen } from "@/routes/_dashboard/copies/$id";
+
+// The owner's view of their own copy. Same screen as /copies/$id but framed as
+// "My Library › My Puzzles › <name>" and gated: CopyInstanceScreen redirects to
+// the public /copies/$id when the viewer does not own this copy.
+export const Route = createFileRoute("/_dashboard/my-puzzles/$id")({
+  head: ({ match }) => ({
+    meta: [{ title: pageTitle(match.context, "myPuzzles") }],
+  }),
+  component: MyCopyPage,
+});
+
+function MyCopyPage() {
+  const { id } = Route.useParams();
+  return <CopyInstanceScreen copyId={id} owned />;
+}

--- a/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
@@ -285,6 +285,7 @@ function PuzzlesPage() {
                 variant="default"
                 showCollectionDropdown={true}
                 viewBasePath="/my-puzzles"
+                imageFit="contain"
                 onEdit={handleEditPuzzle}
                 onView={handleViewPuzzle}
                 onDelete={handleDeletePuzzle}

--- a/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
@@ -284,6 +284,7 @@ function PuzzlesPage() {
                 puzzle={puzzle}
                 variant="default"
                 showCollectionDropdown={true}
+                viewBasePath="/my-puzzles"
                 onEdit={handleEditPuzzle}
                 onView={handleViewPuzzle}
                 onDelete={handleDeletePuzzle}

--- a/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
@@ -156,7 +156,8 @@ function PuzzlesPage() {
   };
 
   const handleViewPuzzle = (ownedPuzzleId: Id<"ownedPuzzles">) => {
-    router.push(`/copies/${ownedPuzzleId}`);
+    // These are the member's OWN copies — open the owner-framed route.
+    router.push(`/my-puzzles/${ownedPuzzleId}`);
   };
 
   const handleLogSolve = (ownedPuzzleId: Id<"ownedPuzzles">) => {

--- a/apps/web/src/routes/_dashboard/puzzles/$id.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/$id.tsx
@@ -27,6 +27,7 @@ import {
   ArrowLeftRight,
   ChevronRight,
   MessageCircle,
+  Plus,
   Star,
 } from "lucide-react";
 import { useRef, useState } from "react";
@@ -236,7 +237,18 @@ function PuzzleDefinitionDetail({
 
           {/* Actions */}
           <div className="mt-5 flex flex-wrap gap-2.5">
-            <Button variant="brand" onClick={() => router.push("/browse")}>
+            {/* Opens the copy-mode add form (definition pre-filled; the member
+                fills in condition/availability/cover/notes for their copy). */}
+            <Button
+              variant="brand"
+              onClick={() =>
+                router.push(`/my-puzzles/add/new?puzzleId=${puzzleId}`)
+              }
+            >
+              <Plus className="h-4 w-4" />
+              {tPuzzles("addToLibrary")}
+            </Button>
+            <Button variant="outline" onClick={() => router.push("/browse")}>
               <ArrowLeftRight className="h-4 w-4" />
               {t("findCopyToSwap")}
             </Button>

--- a/apps/web/src/routes/_dashboard/puzzles/$id.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/$id.tsx
@@ -1,3 +1,4 @@
+import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { pageTitle } from "@/lib/page-title";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -113,6 +114,11 @@ function PuzzleDefinitionDetail({
     availableCopies,
     totalAvailable,
   } = view;
+
+  // Publish the puzzle name as the page-head title so the shell shows it (and the
+  // breadcrumb becomes "Community › Puzzles catalogue › <name>" — the route's
+  // pageKey "puzzles" matches the catalogue nav item, which renders the middle crumb).
+  usePageHeader(() => ({ title: definition.title }), [definition.title]);
 
   // The review composer is focused by the "Write a Review" action.
   const composerRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/routes/_dashboard/route.tsx
+++ b/apps/web/src/routes/_dashboard/route.tsx
@@ -1,5 +1,6 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 
+import { AppNotFound } from "@/components/NotFound";
 import { DashboardShell } from "@/components/dashboard-layout/shell";
 import { PageLoading } from "@/components/ui/loading";
 import { requireAuth } from "@/lib/require-auth";
@@ -13,6 +14,8 @@ import { requireAuth } from "@/lib/require-auth";
 export const Route = createFileRoute("/_dashboard")({
   beforeLoad: ({ context, location }) => requireAuth({ context, location }),
   pendingComponent: () => <PageLoading message="Loading dashboard..." />,
+  // 404 inside the app renders within the dashboard shell (this layout's Outlet).
+  notFoundComponent: AppNotFound,
   component: DashboardLayout,
 });
 

--- a/apps/web/src/routes/_public.tsx
+++ b/apps/web/src/routes/_public.tsx
@@ -1,5 +1,6 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 
+import { NotFoundContent } from "@/components/NotFound";
 import { MarketingFooter } from "@/components/marketing/footer";
 import { MarketingHeader } from "@/components/marketing/header";
 import { PageLoading } from "@/components/ui/loading";
@@ -10,6 +11,8 @@ import { PageLoading } from "@/components/ui/loading";
 // and lay out their own full-width sections.
 export const Route = createFileRoute("/_public")({
   pendingComponent: () => <PageLoading message="Loading..." />,
+  // 404 under a marketing route renders within this marketing shell (its Outlet).
+  notFoundComponent: () => <NotFoundContent />,
   component: PublicLayout,
 });
 

--- a/apps/web/src/routes/_public.tsx
+++ b/apps/web/src/routes/_public.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/_public")({
 
 function PublicLayout() {
   return (
-    <div className="mk-root font-mk-sans min-h-screen flex flex-col">
+    <div className="mk-root font-mk-sans min-h-screen flex flex-col overflow-x-clip">
       <MarketingHeader />
       <div className="flex-1">
         <Outlet />

--- a/apps/web/src/routes/_public/about.tsx
+++ b/apps/web/src/routes/_public/about.tsx
@@ -4,6 +4,7 @@ import { pageTitle } from "@/lib/page-title";
 
 import { Link } from "@/compat/link";
 import { Container } from "@/components/marketing/container";
+import { FitToWidth } from "@/components/marketing/fit-to-width";
 import { PageHero } from "@/components/marketing/page-hero";
 import { JigPlank } from "@/components/marketing/plank";
 import { Reveal } from "@/components/marketing/reveal";
@@ -49,29 +50,31 @@ function AboutPage() {
               </p>
             </Reveal>
             <Reveal delay={120} className="flex justify-center">
-              <div className="[filter:drop-shadow(0_24px_36px_rgb(40_30_80_/_.16))]">
-                <JigPlank
-                  depth={16}
-                  boxes={[
-                    {
-                      series: "Familie",
-                      title: "Keukentafel",
-                      pieceCount: 500,
-                      c1: "var(--mk-violet-400)",
-                      c2: "var(--mk-violet-600)",
-                      width: 100,
-                    },
-                    { cover: coverSand, title: "Zandsculpturen", width: 132 },
-                    {
-                      series: "Samen",
-                      title: "Eerste ruil",
-                      pieceCount: 1000,
-                      c1: "var(--mk-green-400)",
-                      c2: "var(--mk-green-600)",
-                      width: 104,
-                    },
-                  ]}
-                />
+              <div className="w-full [filter:drop-shadow(0_24px_36px_rgb(40_30_80_/_.16))]">
+                <FitToWidth>
+                  <JigPlank
+                    depth={16}
+                    boxes={[
+                      {
+                        series: "Familie",
+                        title: "Keukentafel",
+                        pieceCount: 500,
+                        c1: "var(--mk-violet-400)",
+                        c2: "var(--mk-violet-600)",
+                        width: 100,
+                      },
+                      { cover: coverSand, title: "Zandsculpturen", width: 132 },
+                      {
+                        series: "Samen",
+                        title: "Eerste ruil",
+                        pieceCount: 1000,
+                        c1: "var(--mk-green-400)",
+                        c2: "var(--mk-green-600)",
+                        width: 104,
+                      },
+                    ]}
+                  />
+                </FitToWidth>
               </div>
             </Reveal>
           </div>

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -1,6 +1,7 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 import { Link } from "@/compat/link";
+import { AdminNotFound } from "@/components/NotFound";
 import { HeaderLogo } from "@/components/common/header-logo";
 import { UserProfile } from "@/components/common/user-profile";
 import { PageLoading } from "@/components/ui/loading";
@@ -25,6 +26,8 @@ import { Home } from "lucide-react";
 export const Route = createFileRoute("/admin")({
   beforeLoad: ({ location }) => requireAdmin({ location }),
   pendingComponent: () => <PageLoading message="Loading admin panel..." />,
+  // 404 inside /admin renders within the admin shell (this layout's Outlet).
+  notFoundComponent: AdminNotFound,
   component: AdminLayout,
 });
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/")({
 // sustainability band, founders' quote and the closing CTA.
 function Home() {
   return (
-    <div className="mk-root font-mk-sans min-h-screen">
+    <div className="mk-root font-mk-sans min-h-screen overflow-x-clip">
       <MarketingHeader />
       <main>
         <Hero />

--- a/docs/superpowers/plans/2026-06-15-3d-plank-real-collections.md
+++ b/docs/superpowers/plans/2026-06-15-3d-plank-real-collections.md
@@ -1,0 +1,307 @@
+# 3D Plank Rendering Real Collections — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A contained, bounded WebGL 3D plank (`PuzzlePlank3D`) that renders a member's real puzzle copies on a single shelf board, with the existing CSS `PuzzlePlank` as fallback, used on the dashboard "Your Shelf" and the profile shelf.
+
+**Architecture:** New `apps/web/src/components/common/puzzle-plank-3d/` reusing the marketing scene's box renderer (`box.tsx`), box-art (`box-art.ts`), and palette (`palette.ts` `LIGHTING` + `resolveCssColor`). A pure `layoutRow` helper (unit-tested) positions the real boxes left→right in one row; `scene.tsx` renders a contained `<Canvas>` framed to that row; `index.tsx` orchestrates WebGL-detect / lazy-load / offscreen-pause / error-boundary with the CSS plank as the crossfade + fallback. One sequential intent (component → wiring); single worktree; atomic commits per task.
+
+**Tech Stack:** React, `@react-three/fiber`, `@react-three/drei`, `three`, `maath/easing`, `next-themes`, Tailwind, Vitest (pure-logic unit test only).
+
+**Reference files to read first (do NOT modify the marketing ones):** `apps/web/src/components/marketing/plank-3d/{index.tsx,scene.tsx,box.tsx,box-art.ts,palette.ts}` and `apps/web/src/components/common/puzzle-plank.tsx` (the CSS fallback + `PuzzlePlankBox` type).
+
+---
+
+## File Structure
+
+- Create: `apps/web/src/components/common/puzzle-plank-3d/layout.ts` — pure `layoutRow`.
+- Create: `apps/web/src/components/common/puzzle-plank-3d/layout.test.ts` — unit tests.
+- Create: `apps/web/src/components/common/puzzle-plank-3d/scene.tsx` — bounded single-row `<Canvas>` scene (default export).
+- Create: `apps/web/src/components/common/puzzle-plank-3d/index.tsx` — `PuzzlePlank3D` public component.
+- Modify: `apps/web/src/components/marketing/plank-3d/palette.ts` — generalize `resolveHeadingFont`.
+- Modify: `apps/web/src/components/dashboard-home/shelf-section.tsx` — swap to `PuzzlePlank3D` in a sized container.
+- Modify: `apps/web/src/components/profile/shelf-section.tsx` — swap to `PuzzlePlank3D` in a sized container.
+
+**Reused as-is (imported, not copied):** `box.tsx` (`PuzzleBox`, `PX`, `BOX_SCALE`, `BOX_DEPTH`, `BoxSlot`), `palette.ts` (`LIGHTING`, `resolveCssColor`). The app `PuzzlePlankBox` is structurally assignable to the marketing `PlankBox` that `PuzzleBox` expects.
+
+**Verify with** (from `apps/web`): `pnpm vitest run <file>` and `pnpm type-check` (ignore pre-existing `routeTree.gen` route-path noise; only the changed files matter).
+
+---
+
+## Task 1: `layoutRow` pure helper + tests (TDD)
+
+**Files:** Create `layout.ts`, `layout.test.ts` in `apps/web/src/components/common/puzzle-plank-3d/`.
+
+`layoutRow` converts an ordered box list into centered world-space x-positions on one row. World scale matches `box.tsx`: a box of `width` CSS-px occupies `width * PX * BOX_SCALE` world units (`PX = 1/100`, `BOX_SCALE = 0.74`). Default width when unset is 116 (same default as `PuzzleBox`). Use a fixed world gap between boxes. The row is centered on x=0.
+
+- [ ] **Step 1: Write the failing test** — `layout.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { GAP, layoutRow } from "./layout";
+import { BOX_SCALE, PX } from "@/components/marketing/plank-3d/box";
+
+const w = (px: number) => px * PX * BOX_SCALE;
+
+describe("layoutRow", () => {
+  it("returns no slots and zero width for an empty list", () => {
+    expect(layoutRow([])).toEqual({ slots: [], rowWidth: 0 });
+  });
+
+  it("centers a single box on x=0", () => {
+    const { slots, rowWidth } = layoutRow([{ width: 116 }]);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].x).toBeCloseTo(0, 6);
+    expect(rowWidth).toBeCloseTo(w(116), 6);
+  });
+
+  it("defaults missing width to 116", () => {
+    expect(layoutRow([{}])[0 as never]).toBeUndefined(); // guard: result is an object, not array
+    const { rowWidth } = layoutRow([{}]);
+    expect(rowWidth).toBeCloseTo(w(116), 6);
+  });
+
+  it("lays out two boxes left->right, centered, separated by GAP", () => {
+    const { slots, rowWidth } = layoutRow([{ width: 100 }, { width: 100 }]);
+    const wb = w(100);
+    expect(rowWidth).toBeCloseTo(wb * 2 + GAP, 6);
+    // centered: total span = 2*wb + GAP; first center at -(span/2)+wb/2
+    expect(slots[0].x).toBeCloseTo(-(wb + GAP) / 2, 6);
+    expect(slots[1].x).toBeCloseTo((wb + GAP) / 2, 6);
+    expect(slots[1].x - slots[0].x).toBeCloseTo(wb + GAP, 6);
+  });
+});
+```
+
+(Delete the stray `expect(...).toBeUndefined()` guard line if it complicates — it only documents that the return is an object. Keep the rest.)
+
+- [ ] **Step 2: Run it, expect FAIL** — `cd apps/web && pnpm vitest run src/components/common/puzzle-plank-3d/layout.test.ts` → cannot resolve `./layout`.
+
+- [ ] **Step 3: Implement `layout.ts`:**
+
+```ts
+import { BOX_SCALE, PX } from "@/components/marketing/plank-3d/box";
+import type { PuzzlePlankBox } from "@/components/common/puzzle-plank";
+
+/** World-space gap between neighbouring boxes on the shelf row. */
+export const GAP = 0.12;
+
+export interface RowSlot {
+  /** World-space x of the box center. */
+  x: number;
+}
+
+export interface RowLayout {
+  slots: RowSlot[];
+  /** Total world width spanned by the boxes + gaps. */
+  rowWidth: number;
+}
+
+/** World width of one box from its CSS-pixel width (matches box.tsx scaling). */
+function boxWorldWidth(box: PuzzlePlankBox): number {
+  return (box.width ?? 116) * PX * BOX_SCALE;
+}
+
+/**
+ * Lay boxes out in a single row, centered on x=0, left→right in list order,
+ * separated by GAP. Deterministic; no randomness. Pure.
+ */
+export function layoutRow(boxes: PuzzlePlankBox[]): RowLayout {
+  if (boxes.length === 0) return { slots: [], rowWidth: 0 };
+  const widths = boxes.map(boxWorldWidth);
+  const rowWidth = widths.reduce((a, b) => a + b, 0) + GAP * (boxes.length - 1);
+  const slots: RowSlot[] = [];
+  let cursor = -rowWidth / 2;
+  for (const wb of widths) {
+    slots.push({ x: cursor + wb / 2 });
+    cursor += wb + GAP;
+  }
+  return { slots, rowWidth };
+}
+```
+
+- [ ] **Step 4: Run it, expect PASS.**
+
+- [ ] **Step 5: Commit:** `git add` the two files; message `feat(web): add layoutRow helper for the 3D puzzle plank`.
+
+---
+
+## Task 2: Generalize `resolveHeadingFont` in the marketing palette
+
+**Files:** Modify `apps/web/src/components/marketing/plank-3d/palette.ts`.
+
+`resolveHeadingFont` hard-codes `--font-mk-heading`; the app component needs `--font-heading`. Add an optional param, keeping the default backward-compatible.
+
+- [ ] **Step 1: Edit.** Replace:
+
+```ts
+export function resolveHeadingFont(scope: HTMLElement): string {
+  const v = getComputedStyle(scope)
+    .getPropertyValue("--font-mk-heading")
+    .trim();
+  return v || "system-ui, sans-serif";
+}
+```
+
+with:
+
+```ts
+export function resolveHeadingFont(
+  scope: HTMLElement,
+  varName = "--font-mk-heading",
+): string {
+  const v = getComputedStyle(scope).getPropertyValue(varName).trim();
+  return v || "system-ui, sans-serif";
+}
+```
+
+- [ ] **Step 2: Type-check** (`cd apps/web && pnpm type-check`) — no new error in `palette.ts` or its marketing caller (`marketing/plank-3d/index.tsx`, which still calls it with one arg).
+
+- [ ] **Step 3: Commit:** `git add apps/web/src/components/marketing/plank-3d/palette.ts`; message `refactor(web): let resolveHeadingFont take a custom CSS var name`.
+
+---
+
+## Task 3: Bounded single-row scene (`scene.tsx`)
+
+**Files:** Create `apps/web/src/components/common/puzzle-plank-3d/scene.tsx`.
+
+Adapt the marketing `scene.tsx` down to a **contained single row**. Read the marketing `scene.tsx` for the reusable idioms (`Parallax`, `transformSafeEvents`, `FirstFrame`, `ContactShadows`, the `Lights` damping). Differences from marketing:
+
+- **No fog, no endless span, no repeat, no multi-row, no size jitter, no per-box spotlights.** One row of the real boxes.
+- A single shelf board mesh sized to `rowWidth + margin`.
+- Camera **cover-fits the row** (frame the row's bounding width and the max box height) with a small headroom, looking at the row center; slight downward gaze and the same `SHELF_YAW`-style gentle yaw is OPTIONAL — keep a small fixed yaw (e.g. `-12°`) so boxes read as 3D, but no parallax-driven rotation beyond the reused `Parallax` (reduced-motion → off).
+- Props interface:
+
+```tsx
+export interface PlankSceneProps {
+  boxes: PuzzlePlankBox[];
+  /** Pre-resolved per-box colors, parallel to boxes. */
+  resolved: Array<{ c1: string; c2: string }>;
+  headingFont: string;
+  theme: "light" | "dark";
+  reducedMotion: boolean;
+  visible: boolean;
+  onFirstFrame: () => void;
+  eventSource: React.RefObject<HTMLDivElement | null>;
+}
+```
+
+Implementation requirements (the specialist writes the three.js; these are the contracts):
+
+- Default-export a `PlankScene(props: PlankSceneProps)` returning a `<Canvas>` with `dpr={[1, 2]}`, `frameloop={visible ? "always" : "never"}`, `gl={{ alpha: true, antialias: true }}`, transparent background, `eventSource`/`events` from the reused `transformSafeEvents`, `resize={{ offsetSize: true }}` — exactly like marketing.
+- Use `LIGHTING[theme]` for lights (reuse the marketing `Lights` damping component or a trimmed copy) — but **no fog** and **no `Haze`**.
+- An `Arrangement` inner component that reads `useThree().size`, calls `layoutRow(boxes)` for slot x-positions and `rowWidth`, computes camera distance to cover-fit (frame height = `maxBoxWorldHeight + headroom`, min visible width so a 1–2 box row isn't hugely zoomed), positions the camera, and renders:
+  - one shelf board `mesh` (`boxGeometry` sized `[rowWidth + 0.4, SHELF_THICKNESS, SHELF_DEPTH]`, `meshStandardMaterial` `color={LIGHTING[theme].shelfColor}`), reusing `SHELF_THICKNESS=0.14`, `SHELF_DEPTH=0.6` constants;
+  - `boxes.map((box, i) => <PuzzleBox box={box} slot={{ x: slots[i].x, c1: resolved[i].c1, c2: resolved[i].c2 }} index={i} headingFont={headingFont} sizeScale={1} />)`;
+  - a single `ContactShadows` under the row (`scale={rowWidth + 1}`, `opacity={LIGHTING[theme].shadowOpacity}`);
+  - wrap the group in the reused `Parallax` (enabled `!reducedMotion`) and a fixed parent yaw rotation (`[0, -12°, 0]`).
+- A `FirstFrame` calling `onFirstFrame()` on the first `useFrame`.
+- Box max world height: cover boxes default to `width/1.4`, no-cover to `box.height ?? 144`, times `PX * BOX_SCALE` (mirror `box.tsx`); compute the max over the row for framing.
+
+- [ ] **Step 1: Read** the marketing `scene.tsx`, `box.tsx`, and `layout.ts` (Task 1).
+- [ ] **Step 2: Write** `scene.tsx` per the contracts above.
+- [ ] **Step 3: Type-check** — no error references `scene.tsx`.
+- [ ] **Step 4: Commit:** `git add apps/web/src/components/common/puzzle-plank-3d/scene.tsx`; message `feat(web): bounded single-row 3D scene for the puzzle plank`.
+
+---
+
+## Task 4: `PuzzlePlank3D` orchestrator (`index.tsx`)
+
+**Files:** Create `apps/web/src/components/common/puzzle-plank-3d/index.tsx`.
+
+Adapt the marketing `index.tsx` orchestration to a contained widget with the **CSS `PuzzlePlank` as fallback**. Read the marketing `index.tsx` first.
+
+Contracts:
+
+```tsx
+export function PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] }) { ... }
+```
+
+- Reuse the marketing patterns verbatim where possible: `supportsWebGL()`, `usePrefersReducedMotion()`, the `SceneBoundary` render-nothing error boundary, `React.lazy(() => import("./scene"))`, the `IntersectionObserver` visibility pause, `useTheme()` → `"light" | "dark"`.
+- Container `<div ref={container} style={{ position: "relative", width: "100%", height: "100%" }} aria-hidden>` — it fills the parent (the parent page owns the height, Task 5).
+- **CSS fallback layer:** render `<PuzzlePlank boxes={boxes} />` (from `@/components/common/puzzle-plank`) absolutely centered, `opacity: sceneReady ? 0 : 1` with a `.45s` transition — shown until the scene's first frame; remains (scene never mounts) when WebGL is unavailable or on boundary error. (No marketing `JigPlank`; this is the app plank.)
+- **Color resolution:** on mount / theme change, resolve each box's `c1`/`c2` via `resolveCssColor(box.c1 ?? "var(--jigsaw-primary)", el)` / `resolveCssColor(box.c2 ?? "var(--jigsaw-primary)", el)` against `container.current`, and `resolveHeadingFont(el, "--font-heading")`. Store `resolved` parallel to `boxes`. Skip until `mounted && container` like marketing.
+- **Scene layer:** when `mounted && resolved !== null`, render the lazy `PlankScene` inside `<SceneBoundary><React.Suspense fallback={null}>…` in an absolutely-positioned full-fill div with `opacity: sceneReady ? 1 : 0` transition and `pointerEvents: "none"`, passing `boxes`, `resolved`, `headingFont`, `theme`, `reducedMotion`, `visible`, `onFirstFrame={() => setSceneReady(true)}`, `eventSource={container}`.
+- Empty `boxes` → render nothing (callers already guard, but be safe).
+
+- [ ] **Step 1: Read** the marketing `index.tsx`.
+- [ ] **Step 2: Write** `index.tsx` per the contracts.
+- [ ] **Step 3: Type-check** — no error references `index.tsx`.
+- [ ] **Step 4: Commit:** `git add apps/web/src/components/common/puzzle-plank-3d/index.tsx`; message `feat(web): PuzzlePlank3D orchestrator with CSS-plank fallback`.
+
+---
+
+## Task 5: Wire into dashboard + profile shelves
+
+**Files:** Modify `apps/web/src/components/dashboard-home/shelf-section.tsx` and `apps/web/src/components/profile/shelf-section.tsx`.
+
+Swap the CSS `<PuzzlePlank>` for `<PuzzlePlank3D>` inside a **sized container** (the 3D canvas needs a defined height; this also takes over ②'s "shorter on mobile" plank intent). Keep the existing box mapping. Heights: mobile `h-[300px]`, desktop `md:h-[360px]` — a contained block matching the plank footprint.
+
+- [ ] **Step 1: Dashboard.** In `dashboard-home/shelf-section.tsx`, add import `import { PuzzlePlank3D } from "@/components/common/puzzle-plank-3d";`. Replace the plank block:
+
+```tsx
+<div className="min-w-0 overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5">
+  <PuzzlePlank
+    boxes={owned.slice(0, 5).map((copy, i) => toPlankBox(copy, i, isMobile))}
+  />
+</div>
+```
+
+with:
+
+```tsx
+<div className="min-w-0">
+  <PuzzlePlank3D
+    boxes={owned.slice(0, 5).map((copy, i) => toPlankBox(copy, i, isMobile))}
+  />
+</div>
+```
+
+and wrap the grid's plank column height: the `PuzzlePlank3D` parent must have height. Put the height on the immediate wrapper:
+
+```tsx
+<div className="h-[300px] min-w-0 md:h-[360px]">
+  <PuzzlePlank3D
+    boxes={owned.slice(0, 5).map((copy, i) => toPlankBox(copy, i, isMobile))}
+  />
+</div>
+```
+
+(Remove the now-unneeded `overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5` — the 3D canvas is self-contained. Keep `toPlankBox(..., isMobile)`: width still drives box size in `layoutRow`/`PuzzleBox`.) Leave the `PuzzlePlank` import in place ONLY if still referenced elsewhere in the file; if not, remove the now-unused import.
+
+- [ ] **Step 2: Profile.** In `profile/shelf-section.tsx`, add the same import. Replace:
+
+```tsx
+<div className="min-w-0 overflow-x-auto px-2 pt-6 pb-6">
+  <PuzzlePlank boxes={boxes} />
+</div>
+```
+
+with:
+
+```tsx
+<div className="h-[300px] min-w-0 md:h-[360px]">
+  <PuzzlePlank3D boxes={boxes} />
+</div>
+```
+
+Remove the now-unused `PuzzlePlank` import if nothing else uses it.
+
+- [ ] **Step 3: Type-check** — no error references either shelf-section. Confirm no unused-import lint error for `PuzzlePlank`.
+
+- [ ] **Step 4: Commit:** `git add` both shelf-section files; message `feat(web): render dashboard + profile shelves with the 3D plank`.
+
+---
+
+## Final verification
+
+- [ ] `cd apps/web && pnpm vitest run src/components/common/puzzle-plank-3d/layout.test.ts` → PASS.
+- [ ] `cd apps/web && pnpm type-check` → no errors referencing any new/changed file (ignore `routeTree.gen` noise).
+- [ ] Prettier: `npx prettier --write` the new + changed files; commit any delta.
+- [ ] Manual/user (browser unavailable here): dashboard + profile shelves show real puzzles as 3D boxes on a board; WebGL-off or scene error falls back to the CSS plank; reduced-motion disables parallax; no horizontal overflow; mobile shorter than desktop.
+
+## Self-review notes
+
+- **Spec coverage:** new component (Tasks 1,3,4) + palette tweak (2) + dashboard & profile wiring (5) + `layoutRow` unit test (1) all map to spec sections. Sizing handled in Task 5.
+- **Reused-not-duplicated:** `PuzzleBox`, `box-art`, `LIGHTING`, `resolveCssColor` imported from marketing `plank-3d`; only `resolveHeadingFont` is (backward-compatibly) generalized.
+- **Type consistency:** `PuzzlePlankBox` flows through `layoutRow` (Task 1), `PlankScene` props (Task 3), `PuzzlePlank3D` (Task 4), and both call sites (Task 5).

--- a/docs/superpowers/plans/2026-06-15-mobile-native-scroll-and-dashboard-declutter.md
+++ b/docs/superpowers/plans/2026-06-15-mobile-native-scroll-and-dashboard-declutter.md
@@ -1,0 +1,463 @@
+# Mobile Native Scroll + Dashboard Declutter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Below the `md` breakpoint, make the app scroll at the document level (so the browser address bar hides) with a pinned top bar and fixed bottom tab bar, and de-emphasize/condense the mobile dashboard — desktop unchanged.
+
+**Architecture:** Pure responsive Tailwind classes (no JS breakpoint branch in the shell → no hydration flash); gate every scroll/height constraint to `md:`, make the mobile top bar `sticky` and the tab bar `fixed`. The dashboard uses the existing `useIsMobile()` hook only for two numeric props CSS can't express (plank box size, goal-ring size). Two intents with **disjoint file sets** → one atomic commit each.
+
+**Tech Stack:** React, TanStack Start (SSR), Tailwind CSS, shadcn sidebar primitives, `useIsMobile()` hook.
+
+---
+
+## File Structure
+
+**Intent A — mobile native scroll** (shell + chrome):
+
+- `apps/web/src/components/dashboard-layout/shell.tsx` — gate scroll/height to `md:`, mobile content bottom padding.
+- `apps/web/src/components/dashboard-layout/mobile-top-bar.tsx` — `sticky top-0`.
+- `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx` — `fixed` to viewport bottom.
+
+**Intent B — dashboard declutter** (dashboard-home):
+
+- `apps/web/src/routes/_dashboard/dashboard.tsx` — page section gap.
+- `apps/web/src/components/dashboard-home/briefing-hero.tsx` — smaller headline + hero gap.
+- `apps/web/src/components/dashboard-home/shelf-section.tsx` — shorter/narrower plank on mobile.
+- `apps/web/src/components/dashboard-home/pulse-section.tsx` — tighter gaps + smaller goal ring on mobile.
+
+The two intents share no files, so they can be implemented and committed in parallel and integrated conflict-free.
+
+**Verification commands** (run from `apps/web`): `pnpm type-check`. The known worktree `routeTree.gen` noise (`createFileRoute("/...") not assignable to undefined`, one per route file at the `createFileRoute` call) is unrelated — only confirm no error references the _files this plan changes_.
+
+---
+
+## Task A: Mobile native document scroll
+
+One cohesive intent — the shell relaxation and the two bar changes must land together (relaxing the shell without fixing the tab bar would let the bar scroll away). One commit.
+
+**Files:**
+
+- Modify: `apps/web/src/components/dashboard-layout/shell.tsx`
+- Modify: `apps/web/src/components/dashboard-layout/mobile-top-bar.tsx`
+- Modify: `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx`
+
+- [ ] **Step 1: Relax the shell's scroll/height model to `md:` only**
+
+In `apps/web/src/components/dashboard-layout/shell.tsx`, make these four exact replacements:
+
+1. `SidebarProvider` open tag:
+
+```tsx
+<SidebarProvider className="h-svh flex-col overflow-hidden">
+```
+
+→
+
+```tsx
+<SidebarProvider className="flex-col md:h-svh md:overflow-hidden">
+```
+
+2. The sidebar/inset row:
+
+```tsx
+          <div className="flex min-h-0 flex-1">
+```
+
+→
+
+```tsx
+          <div className="flex flex-1 md:min-h-0">
+```
+
+3. `SidebarInset` className:
+
+```tsx
+            <SidebarInset className="min-h-0 overflow-hidden md:peer-data-[variant=inset]:mt-0 md:peer-data-[variant=inset]:mr-3 md:peer-data-[variant=inset]:mb-3 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
+```
+
+→
+
+```tsx
+            <SidebarInset className="md:min-h-0 md:overflow-hidden md:peer-data-[variant=inset]:mt-0 md:peer-data-[variant=inset]:mr-3 md:peer-data-[variant=inset]:mb-3 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
+```
+
+4. The inner scroll `<div>`:
+
+```tsx
+              <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
+```
+
+→
+
+```tsx
+              <div className="flex-1 overflow-x-hidden md:min-h-0 md:overflow-y-auto md:[scrollbar-gutter:stable]">
+```
+
+- [ ] **Step 2: Give mobile content room to clear the (soon-to-be) fixed tab bar**
+
+In the same file, in `ContentArea`, replace the first argument of the `cn(...)`:
+
+```tsx
+        "w-full px-4 pt-[18px] pb-8 md:p-6",
+```
+
+→
+
+```tsx
+        "w-full px-4 pt-[18px] pb-[calc(env(safe-area-inset-bottom)+76px)] md:p-6",
+```
+
+(`md:p-6` overrides the bottom padding at desktop, so desktop spacing is unchanged.)
+
+- [ ] **Step 3: Pin the mobile top bar**
+
+In `apps/web/src/components/dashboard-layout/mobile-top-bar.tsx`, the `<header>`:
+
+```tsx
+    <header className="shrink-0 border-b bg-card pt-[env(safe-area-inset-top)] md:hidden">
+```
+
+→
+
+```tsx
+    <header className="sticky top-0 z-30 shrink-0 border-b bg-card pt-[env(safe-area-inset-top)] md:hidden">
+```
+
+- [ ] **Step 4: Fix the mobile tab bar to the viewport bottom**
+
+In `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx`, the `<nav>` (change the leading `relative` to `fixed inset-x-0 bottom-0`; keep everything else):
+
+```tsx
+className =
+  "relative z-30 grid shrink-0 grid-cols-5 items-stretch overflow-visible border-t bg-card pb-[env(safe-area-inset-bottom)] md:hidden";
+```
+
+→
+
+```tsx
+className =
+  "fixed inset-x-0 bottom-0 z-30 grid shrink-0 grid-cols-5 items-stretch overflow-visible border-t bg-card pb-[env(safe-area-inset-bottom)] md:hidden";
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: no error references `shell.tsx`, `mobile-top-bar.tsx`, or `mobile-tab-bar.tsx`. (Class-only changes — there should be none. Ignore the pre-existing `routeTree.gen` route-path noise.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/dashboard-layout/shell.tsx apps/web/src/components/dashboard-layout/mobile-top-bar.tsx apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+git commit -m "feat(web): mobile uses native document scroll so the address bar hides"
+```
+
+---
+
+## Task B: Focus the mobile dashboard
+
+One intent across four dashboard-home files (all mobile-only de-emphasis). One commit.
+
+**Files:**
+
+- Modify: `apps/web/src/routes/_dashboard/dashboard.tsx`
+- Modify: `apps/web/src/components/dashboard-home/briefing-hero.tsx`
+- Modify: `apps/web/src/components/dashboard-home/shelf-section.tsx`
+- Modify: `apps/web/src/components/dashboard-home/pulse-section.tsx`
+
+- [ ] **Step 1: Tighten the page section gap on mobile**
+
+In `apps/web/src/routes/_dashboard/dashboard.tsx`:
+
+```tsx
+    <div className="flex w-full flex-col gap-8 md:gap-10">
+```
+
+→
+
+```tsx
+    <div className="flex w-full flex-col gap-6 md:gap-10">
+```
+
+- [ ] **Step 2: Shrink the hero headline + hero gap on mobile**
+
+In `apps/web/src/components/dashboard-home/briefing-hero.tsx`:
+
+2a. The `Headline` component's `<p>`:
+
+```tsx
+    <p className="font-heading max-w-[860px] text-2xl leading-[1.4] font-semibold tracking-tight text-pretty md:text-3xl">
+```
+
+→
+
+```tsx
+    <p className="font-heading max-w-[860px] text-xl leading-snug font-semibold tracking-tight text-pretty md:text-3xl md:leading-[1.4]">
+```
+
+2b. The loading-skeleton `<section>` (inside `if (loading)`):
+
+```tsx
+      <section className="flex flex-col gap-5">
+```
+
+→
+
+```tsx
+      <section className="flex flex-col gap-4 md:gap-5">
+```
+
+2c. The real `BriefingHero` `<section>` (the `return` near the end):
+
+```tsx
+    <section className="flex flex-col gap-5">
+      <Headline
+```
+
+→
+
+```tsx
+    <section className="flex flex-col gap-4 md:gap-5">
+      <Headline
+```
+
+- [ ] **Step 3: Shorter, narrower plank on mobile**
+
+In `apps/web/src/components/dashboard-home/shelf-section.tsx`:
+
+3a. Add the import near the other imports:
+
+```tsx
+import { useIsMobile } from "@/hooks/use-mobile";
+```
+
+3b. Add a mobile height array right after the existing `BOX_HEIGHTS` declaration:
+
+```tsx
+// Varied box heights so the shelf reads like a real, lived-in collection.
+const BOX_HEIGHTS = [148, 130, 156, 126, 142];
+```
+
+→
+
+```tsx
+// Varied box heights so the shelf reads like a real, lived-in collection.
+const BOX_HEIGHTS = [148, 130, 156, 126, 142];
+// Shorter set for the cramped mobile dashboard (see sub-project ②).
+const MOBILE_BOX_HEIGHTS = [118, 104, 124, 100, 114];
+```
+
+3c. Replace the whole `toPlankBox` function so it scales with `isMobile`:
+
+```tsx
+function toPlankBox(copy: OwnedCopy, index: number): PuzzlePlankBox {
+  const cover = copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
+  const [c1, c2] = BOX_GRADIENTS[index % BOX_GRADIENTS.length];
+  return {
+    title: copy.puzzle?.title ?? copy.snapshot?.title,
+    series: copy.puzzle?.brand ?? copy.snapshot?.brand,
+    pieceCount: copy.puzzle?.pieceCount ?? copy.snapshot?.pieceCount,
+    cover,
+    c1,
+    c2,
+    height: cover ? undefined : BOX_HEIGHTS[index % BOX_HEIGHTS.length],
+  };
+}
+```
+
+→
+
+```tsx
+function toPlankBox(
+  copy: OwnedCopy,
+  index: number,
+  isMobile: boolean,
+): PuzzlePlankBox {
+  const cover = copy.puzzle?.images?.[0] ?? copy.snapshot?.thumbnail;
+  const [c1, c2] = BOX_GRADIENTS[index % BOX_GRADIENTS.length];
+  const heights = isMobile ? MOBILE_BOX_HEIGHTS : BOX_HEIGHTS;
+  return {
+    title: copy.puzzle?.title ?? copy.snapshot?.title,
+    series: copy.puzzle?.brand ?? copy.snapshot?.brand,
+    pieceCount: copy.puzzle?.pieceCount ?? copy.snapshot?.pieceCount,
+    cover,
+    c1,
+    c2,
+    // Narrower boxes on mobile; PuzzlePlank derives cover-box height from width,
+    // so this shortens the whole shelf. Desktop keeps the component default (116).
+    width: isMobile ? 92 : undefined,
+    height: cover ? undefined : heights[index % heights.length],
+  };
+}
+```
+
+3d. In `ShelfSection`, add the hook call right after the translations line `const t = useTranslations("dashboard.shelf");`:
+
+```tsx
+const isMobile = useIsMobile();
+```
+
+3e. Update the plank usage (the non-empty branch) to pass `isMobile` and reduce mobile padding:
+
+```tsx
+<div className="min-w-0 overflow-x-auto px-2 pt-6 pb-5">
+  <PuzzlePlank boxes={owned.slice(0, 5).map(toPlankBox)} />
+</div>
+```
+
+→
+
+```tsx
+<div className="min-w-0 overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5">
+  <PuzzlePlank
+    boxes={owned.slice(0, 5).map((copy, i) => toPlankBox(copy, i, isMobile))}
+  />
+</div>
+```
+
+- [ ] **Step 4: Tighter pulse gaps + smaller goal ring on mobile**
+
+In `apps/web/src/components/dashboard-home/pulse-section.tsx`:
+
+4a. Add the import near the other imports:
+
+```tsx
+import { useIsMobile } from "@/hooks/use-mobile";
+```
+
+4b. Make `GoalRing` accept a `size` prop (default 148) and drive the container off it. Replace the function signature + the `const size = 148;` line + the container `<div>`:
+
+```tsx
+function GoalRing({ current, target }: { current: number; target: number }) {
+  const t = useTranslations("dashboard.pulse.goals");
+  const size = 148;
+  const stroke = 13;
+```
+
+→
+
+```tsx
+function GoalRing({
+  current,
+  target,
+  size = 148,
+}: {
+  current: number;
+  target: number;
+  size?: number;
+}) {
+  const t = useTranslations("dashboard.pulse.goals");
+  const stroke = 13;
+```
+
+and the container div:
+
+```tsx
+    <div className="relative size-[148px] shrink-0">
+```
+
+→
+
+```tsx
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+```
+
+(The `r`, `c`, `mid` geometry already derive from `size`, so they need no change.)
+
+4c. In `GoalsColumn`, add the hook after `const t = useTranslations("dashboard.pulse.goals");`:
+
+```tsx
+const isMobile = useIsMobile();
+```
+
+and pass the size to `GoalRing`:
+
+```tsx
+<Link href="/goals">
+  <GoalRing
+    current={primary.currentCompletions}
+    target={primary.targetCompletions}
+  />
+</Link>
+```
+
+→
+
+```tsx
+<Link href="/goals">
+  <GoalRing
+    current={primary.currentCompletions}
+    target={primary.targetCompletions}
+    size={isMobile ? 116 : 148}
+  />
+</Link>
+```
+
+4d. Tighten the stacked gap on mobile in **both** grids. The `PulseSkeleton` grid:
+
+```tsx
+    <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+      {Array.from({ length: 3 }).map((_, i) => (
+```
+
+→
+
+```tsx
+    <div className="grid gap-6 lg:gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+      {Array.from({ length: 3 }).map((_, i) => (
+```
+
+and the `PulseSection` grid:
+
+```tsx
+    <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+      <InMotionColumn exchanges={exchanges ?? []} />
+```
+
+→
+
+```tsx
+    <div className="grid gap-6 lg:gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]">
+      <InMotionColumn exchanges={exchanges ?? []} />
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: no error references `dashboard.tsx`, `briefing-hero.tsx`, `shelf-section.tsx`, or `pulse-section.tsx`. (Ignore the pre-existing `routeTree.gen` route-path noise.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/routes/_dashboard/dashboard.tsx apps/web/src/components/dashboard-home/briefing-hero.tsx apps/web/src/components/dashboard-home/shelf-section.tsx apps/web/src/components/dashboard-home/pulse-section.tsx
+git commit -m "feat(web): focus the mobile dashboard (smaller hero, plank, pulse)"
+```
+
+---
+
+## Final verification (controller, after integrating both intents)
+
+- [ ] **Type-check the integrated branch**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: no errors referencing any file changed by this plan.
+
+- [ ] **Format check (CI runs `format:check`)**
+
+From repo root: `npx prettier --write` the seven changed files, then commit any formatting delta.
+
+- [ ] **Manual / user verification (browser automation unavailable in this env)**
+
+On a real phone (mobile ≤767px), authenticated dashboard:
+
+- Scrolling moves the document and the browser address bar collapses; the app top bar stays pinned; the bottom tab bar stays fixed and never hides content behind it.
+- Hero headline is smaller; the plank is shorter/narrower; the pulse columns are tighter with a smaller goal ring.
+
+Desktop (≥768px): inset card + inner scroll under the glass head, and the original hero/plank/pulse sizes — all unchanged.
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** Intent A items 1–7 → Task A steps 1–4. Intent B items 1–6 → Task B steps 1–4. All spec requirements have a task.
+- **Type consistency:** `toPlankBox(copy, index, isMobile)` — every call site updated (Step 3e). `GoalRing` gains optional `size?: number` (default 148) — the one call site passes it (Step 4c); the default keeps any other use safe.
+- **Desktop safety:** every change is mobile-only (`md:`/`lg:` restores the current value, or `isMobile` ternaries default to the current value), so the desktop shell and dashboard are unchanged.

--- a/docs/superpowers/plans/2026-06-15-profile-plank-physics.md
+++ b/docs/superpowers/plans/2026-06-15-profile-plank-physics.md
@@ -1,0 +1,212 @@
+# Profile Plank Physics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+>
+> ⚠️ **This feature is purely interactive and CANNOT be browser-verified in this environment.** Build it defensively (it degrades to the static ③ scene / CSS plank) and TDD the pure helpers; the runtime behavior MUST be verified by the user.
+
+**Goal:** Make the profile shelf's 3D plank physically interactive (Rapier) — boxes rest under gravity, collide, and can be grabbed/dragged/thrown by mouse + touch — as an opt-in, isolated layer that leaves ③'s static scene (dashboard + reduced-motion + fallback) untouched.
+
+**Architecture:** New `@react-three/rapier`. A new `scene-physics.tsx` sibling to ③'s `scene.tsx`, selected by `PuzzlePlank3D` only when `interactive && !reducedMotion && WebGL`. The shared `PuzzleBox` gains a backward-compatible `anchored` prop so a `RigidBody` can own each box transform. Pure drag/throw math is unit-tested; rapier wiring is specialist work. Single worktree, atomic commit per task.
+
+**Tech Stack:** `@react-three/rapier`, `@react-three/fiber` 9, `three` 0.184, React, Vitest.
+
+**Reference files to READ first:** `apps/web/src/components/common/puzzle-plank-3d/{scene.tsx,index.tsx,layout.ts}` (③, the base) and `apps/web/src/components/marketing/plank-3d/box.tsx` (the `PuzzleBox` + scaling constants). The physics scene mirrors `scene.tsx`'s `Lights`/`Arrangement` framing/`ContactShadows`/shelf, adding rapier.
+
+**Verify:** `cd apps/web && pnpm vitest run <file>` for the pure helpers; `pnpm type-check` (ignore `routeTree.gen` noise). NO dev server / browser here.
+
+---
+
+## Task 1: Add the Rapier dependency
+
+**Files:** `apps/web/package.json` (+ lockfile).
+
+- [ ] **Step 1:** Add `"@react-three/rapier": "^2.1.0"` to `dependencies` (a 2.x release compatible with fiber 9 / three 0.184). From `apps/web`, run `pnpm install`. If a peer-dep conflict surfaces, pick the latest 2.x that resolves and note the version.
+- [ ] **Step 2:** Confirm it resolves: `pnpm why @react-three/rapier` lists a single version; `pnpm type-check` still runs.
+- [ ] **Step 3: Commit:** `chore(web): add @react-three/rapier for the interactive plank`.
+
+---
+
+## Task 2: `boxWorldSize` helper + `anchored` prop on `PuzzleBox` (TDD for the helper)
+
+**Files:** modify `apps/web/src/components/marketing/plank-3d/box.tsx`; create `box-size.test.ts` beside it; update `apps/web/src/components/common/puzzle-plank-3d/scene.tsx` to reuse the helper.
+
+`PuzzleBox` self-positions at `[slot.x, h/2, 0]`. Physics needs a parent `RigidBody` to own the transform with the visual at local origin, plus the box's world `{w,h}` to size a collider.
+
+- [ ] **Step 1: Failing test** `box-size.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { boxWorldSize, BOX_SCALE, PX } from "./box";
+
+describe("boxWorldSize", () => {
+  it("derives width and height from a no-cover box", () => {
+    const { w, h } = boxWorldSize({ width: 116, height: 144 }, 1);
+    expect(w).toBeCloseTo(116 * PX * BOX_SCALE, 6);
+    expect(h).toBeCloseTo(144 * PX * BOX_SCALE, 6);
+  });
+  it("uses width/1.4 for a cover box height", () => {
+    const { h } = boxWorldSize({ width: 140, cover: "x.jpg" }, 1);
+    expect(h).toBeCloseTo((140 / 1.4) * PX * BOX_SCALE, 6);
+  });
+  it("applies sizeScale and defaults width to 116", () => {
+    const { w } = boxWorldSize({}, 2);
+    expect(w).toBeCloseTo(116 * PX * BOX_SCALE * 2, 6);
+  });
+});
+```
+
+Run → FAIL (no `boxWorldSize`).
+
+- [ ] **Step 2: Implement in `box.tsx`.** Export a pure helper mirroring the existing inline math (the component currently computes `widthPx`, `worldScale = PX*BOX_SCALE*sizeScale`, `w`, and the default height `box.cover ? widthPx/1.4 : (box.height ?? 144)`):
+
+```ts
+import type { PlankBox } from "@/components/marketing/plank";
+
+/** World-space {w,h} of a box's front face (pre-aspect-correction), mirroring the
+ *  scaling PuzzleBox applies. Used by the bounded scene's framing and the physics
+ *  scene's colliders so they never drift from the visual size. */
+export function boxWorldSize(
+  box: Pick<PlankBox, "width" | "height" | "cover">,
+  sizeScale = 1,
+): { w: number; h: number } {
+  const widthPx = box.width ?? 116;
+  const worldScale = PX * BOX_SCALE * sizeScale;
+  const hPx = box.cover ? widthPx / 1.4 : (box.height ?? 144);
+  return { w: widthPx * worldScale, h: hPx * worldScale };
+}
+```
+
+Refactor `PuzzleBox` to use `boxWorldSize` for its initial `w`/`defaultHPx` (no behavior change). Run → PASS.
+
+- [ ] **Step 3: Add the `anchored` prop.** Add `anchored = true` to `PuzzleBox`'s props. When `true`, keep today's `<group position={[slot.x, baseY, 0]} rotation={[0, yaw, 0]}>`. When `false`, render `<group position={[0, 0, 0]} rotation={[0, 0, 0]}>` (the parent `RigidBody` owns world transform; the mesh stays centered at local origin so a centered cuboid collider matches). `slot.c1/c2`/art are unchanged. Default `true` preserves ③ + the marketing hero exactly.
+
+- [ ] **Step 4:** Update `scene.tsx`'s `boxWorldHeight` to delegate to `boxWorldSize(box).h` (DRY; no behavior change). `pnpm type-check` clean for `box.tsx`/`scene.tsx`.
+
+- [ ] **Step 5: Commit:** `feat(web): boxWorldSize helper + anchored prop on PuzzleBox`.
+
+---
+
+## Task 3: Pure drag/throw math + tests (TDD)
+
+**Files:** create `apps/web/src/components/common/puzzle-plank-3d/drag-math.ts` + `drag-math.test.ts`.
+
+Two pure helpers the drag hook will use (kept pure so they're the testable core of the otherwise-untestable interaction):
+
+- [ ] **Step 1: Failing tests** `drag-math.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { clampThrowVelocity, MAX_THROW_SPEED } from "./drag-math";
+
+describe("clampThrowVelocity", () => {
+  it("passes through a slow throw unchanged", () => {
+    expect(clampThrowVelocity([1, 0, -1])).toEqual([1, 0, -1]);
+  });
+  it("scales an over-fast throw down to MAX_THROW_SPEED, preserving direction", () => {
+    const v = clampThrowVelocity([0, 0, -100]);
+    expect(Math.hypot(...v)).toBeCloseTo(MAX_THROW_SPEED, 5);
+    expect(v[2]).toBeLessThan(0); // same direction
+    expect(v[0]).toBe(0);
+    expect(v[1]).toBe(0);
+  });
+  it("returns zero for a zero vector (no divide-by-zero)", () => {
+    expect(clampThrowVelocity([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+});
+```
+
+Run → FAIL.
+
+- [ ] **Step 2: Implement `drag-math.ts`:**
+
+```ts
+export type Vec3 = [number, number, number];
+
+/** Cap a throw so a flick can't launch a box across the scene; preserves direction. */
+export const MAX_THROW_SPEED = 6;
+
+export function clampThrowVelocity(v: Vec3): Vec3 {
+  const speed = Math.hypot(v[0], v[1], v[2]);
+  if (speed === 0 || speed <= MAX_THROW_SPEED) return v;
+  const k = MAX_THROW_SPEED / speed;
+  return [v[0] * k, v[1] * k, v[2] * k];
+}
+```
+
+Run → PASS.
+
+- [ ] **Step 3: Commit:** `feat(web): pure drag/throw helpers for the interactive plank`.
+
+(The pointer→world-on-drag-plane projection stays inline in the hook — it depends on the live three.js camera/raycaster and isn't purely unit-testable; `clampThrowVelocity` is the extracted testable core.)
+
+---
+
+## Task 4: `scene-physics.tsx` — the interactive scene (specialist)
+
+**Files:** create `apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx`.
+
+Default-export `PlankScenePhysics(props: PlankSceneProps)` (same props as ③'s scene). READ ③'s `scene.tsx` and reuse its `Lights`, the `Arrangement` camera cover-fit math, `ContactShadows`, and shelf board. Add rapier:
+
+- Wrap the world in `<Physics gravity={[0, -9.81, 0]} paused={!props.visible || props.reducedMotion}>` (never simulate offscreen). Import from `@react-three/rapier`.
+- **Bake the fixed yaw into the CAMERA**, not a rotating group — physics bodies live in world space. (Set the camera position/lookAt so the shelf reads at the same ~12° as ③, or place the camera at the yawed position; do NOT wrap bodies in a rotated group.)
+- **Fixed colliders:** shelf board as `<RigidBody type="fixed">` (cuboid matching the board), a fixed ground plane just below the shelf, and low invisible walls (left/right/back/front, derived from `rowWidth` + `maxBoxH`) to contain thrown boxes.
+- **Dynamic boxes:** for each box, a `<RigidBody type="dynamic" position={[slots[i].x, h/2, 0]} colliders={false}>` containing `<PuzzleBox … anchored={false} />` and `<CuboidCollider args={[w/2, h/2, BOX_DEPTH/2]} />` (use `boxWorldSize` for `w`,`h`; `BOX_DEPTH` from box.tsx). Tune `restitution` (~0.1), `friction` (~0.8), `linearDamping`/`angularDamping` (small) so boxes settle and stack without jitter. Give each `RigidBody` a ref for the drag hook (Task 5).
+- `FirstFrame` → `onFirstFrame` for the crossfade (as ③).
+
+- [ ] **Step 1:** Read ③'s `scene.tsx`, `box.tsx`, `layout.ts`, and the `@react-three/rapier` API (`Physics`, `RigidBody`, `CuboidCollider`, `RapierRigidBody` ref type, `setNextKinematicTranslation`, `setBodyType`/`setLinvel`).
+- [ ] **Step 2:** Write `scene-physics.tsx` per the contract; wire the drag hook from Task 5.
+- [ ] **Step 3:** `pnpm type-check` — no error referencing `scene-physics.tsx`.
+- [ ] **Step 4: Commit:** `feat(web): rapier-based interactive plank scene`.
+
+---
+
+## Task 5: Box drag hook (specialist)
+
+**Files:** create `apps/web/src/components/common/puzzle-plank-3d/use-box-drag.ts` (or inline in scene-physics if simpler).
+
+Grab-drag-throw on the dynamic bodies (pointer events unify mouse + touch):
+
+- On **pointer-down** on a box mesh: `setPointerCapture`; switch that body to `kinematicPosition` (`setBodyType`); record grab offset and a drag plane (parallel to the camera, through the grab point).
+- On **pointer-move**: raycast the pointer onto the drag plane (use the canvas's existing `transformSafeEvents` raycaster), and `setNextKinematicTranslation` to follow; push `(pos, time)` into a small ring buffer for release velocity.
+- On **pointer-up**: switch back to `dynamic`; compute velocity from the last two buffered samples, run it through `clampThrowVelocity`, `setLinvel`; release capture.
+- **Touch vs page scroll:** set the canvas `touch-action: none` only WHILE a box is grabbed (so the ② document-scroll shell still scrolls when not dragging); restore on release.
+
+- [ ] **Step 1:** Implement; use `clampThrowVelocity` (Task 3).
+- [ ] **Step 2:** `pnpm type-check` clean.
+- [ ] **Step 3: Commit:** `feat(web): grab/drag/throw interaction for the plank` (may be folded into Task 4's commit if implemented inline — then skip).
+
+---
+
+## Task 6: Orchestrator opt-in + scene selection
+
+**Files:** modify `apps/web/src/components/common/puzzle-plank-3d/index.tsx`.
+
+- [ ] **Step 1:** Add `interactive?: boolean` to `PuzzlePlank3D`. Choose the lazy scene: `interactive && !reducedMotion && supportsWebGL()` → `React.lazy(() => import("./scene-physics"))`; else the existing `./scene`. Keep both behind the same `SceneBoundary`, color resolution, `IntersectionObserver`, and CSS fallback.
+- [ ] **Step 2:** When the physics scene is active, the `<Canvas>` must accept pointer events (drag) — set the canvas/container `pointerEvents: "auto"` for the physics path; keep `"none"` for the static path. (If the canvas style lives in the scene module, pass a flag or set it there.)
+- [ ] **Step 3:** `pnpm type-check` clean.
+- [ ] **Step 4: Commit:** `feat(web): PuzzlePlank3D interactive opt-in (physics scene selection)`.
+
+---
+
+## Task 7: Profile wiring
+
+**Files:** modify `apps/web/src/components/profile/shelf-section.tsx`.
+
+- [ ] **Step 1:** Pass `interactive` to the profile's `<PuzzlePlank3D … interactive />`. The dashboard's stays without it (static). Curated boxes from ④ flow in unchanged.
+- [ ] **Step 2:** `pnpm type-check` clean; `npx prettier --write` all changed/new files.
+- [ ] **Step 3: Commit:** `feat(web): make the profile plank interactive`.
+
+---
+
+## Final verification
+
+- [ ] Pure-helper tests pass (`box-size.test.ts`, `drag-math.test.ts`).
+- [ ] `apps/web` type-check clean for all changed files; prettier clean.
+- [ ] ③'s static `scene.tsx` and the marketing hero are unchanged in behavior (the `anchored` default is `true`; dashboard plank has no `interactive`).
+- [ ] **⚠️ MANDATORY user runtime check (cannot be done here):** profile boxes rest on the shelf; mouse + touch grab/drag/throw works; boxes don't fall through the shelf or fly offscreen; the page still scrolls when not dragging a box; reduced-motion shows the static shelf; mobile perf is acceptable. Expect a tuning iteration after this.
+
+## Self-review notes
+
+- **Spec coverage:** dependency (T1) · box anchoring + size helper (T2) · pure drag/throw math (T3) · physics scene (T4) · drag hook (T5) · orchestrator opt-in (T6) · profile wiring (T7). Degradation + dashboard-untouched preserved via the `interactive` gate + default `anchored=true`.
+- **Type consistency:** `boxWorldSize(box, sizeScale)` used by scene framing + physics colliders; `clampThrowVelocity: Vec3→Vec3`; `PlankSceneProps` shared by both scenes; `interactive?: boolean` threaded index→profile only.
+- **Isolation:** all rapier usage confined to `scene-physics.tsx` + `use-box-drag.ts`; `scene.tsx` and `box.tsx`'s default path untouched, so a physics failure degrades (SceneBoundary → CSS plank) without affecting the dashboard or marketing hero.

--- a/docs/superpowers/plans/2026-06-15-profile-shelf-curation.md
+++ b/docs/superpowers/plans/2026-06-15-profile-shelf-curation.md
@@ -1,0 +1,183 @@
+# Profile Shelf Curation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Members curate which owned puzzles appear on their profile shelf and in what order; the profile 3D plank renders the curated ordered set (falling back to recent-6 when uncurated), edited via an owner-only "Arrange shelf" dialog.
+
+**Architecture:** Full DDD stack, sequential (each layer depends on the one below), single worktree, one atomic commit per layer. Domain is TDD (`.spec.ts`); backend has a Convex `.test.ts`; the worktree needs a hand-edited `_generated/api.d.ts` (codegen isn't deployed in worktrees). Web adds a curated read + an accessible (no-DnD) reorder dialog.
+
+**Tech Stack:** TypeScript DDD (domain/application/ports), Convex, the gateway operations layer, React/TanStack, Vitest.
+
+**Reference files to READ and MIRROR (do not blindly copy — follow their structure):**
+
+- Domain: `packages/domain/src/social/domain/{profile.ts,events.ts,errors.ts,ids.ts}`, `application/use-cases/{edit-profile.ts,set-profile-visibility.ts}`, `application/ports/in/edit-profile.port.ts`, `application/ports/out/profile.repository.ts`, `application/testing/in-memory-profile.repository.ts`, and the existing `domain/profile.spec.ts` / `application/use-cases/edit-profile.spec.ts`.
+- Backend: `packages/backend/convex/identity/` (the `setProfileVisibility` mutation + its profile repository/mapper + `identityQueries`), `packages/backend/convex/identity/setProfileVisibility.test.ts`, `schema.ts` (`profiles`, `ownedPuzzles`), `_generated/api.d.ts`.
+- Gateway: `packages/gateway/src/operations.ts` (the `library.ownedByOwner` + profile/identity ops).
+- Web: `apps/web/src/components/profile/shelf-section.tsx`, `member-view.tsx` (the `Member` type + whether the viewer is the owner), and an existing dialog under `apps/web/src/components/ui/` for the editor shell.
+
+**Verify** (from repo root unless noted): domain `pnpm --filter @jigswap/domain test` (or `npx vitest run` in `packages/domain`); backend `cd packages/backend && pnpm test`; types `cd apps/web && pnpm type-check` (ignore `routeTree.gen` noise). Browser automation is unavailable — the editor + plank refresh are reasoned, not browser-tested.
+
+---
+
+## Task 1: Domain — `Profile.arrangeShelf` + event + use-case (TDD)
+
+**Files (all under `packages/domain/src/social/`):** modify `domain/profile.ts`, `domain/events.ts`; create `application/ports/in/arrange-shelf.port.ts`, `application/use-cases/arrange-shelf.ts`; add cases to `domain/profile.spec.ts`; create `application/use-cases/arrange-shelf.spec.ts`.
+
+- [ ] **Step 1: Add the event.** In `domain/events.ts`, add (mirroring `ProfileVisibilityChanged`) and append to the `SocialDomainEvent` union:
+
+```ts
+// A member re-arranged their profile display shelf (the ordered, curated set of owned copies
+// shown on their profile). copyIds is the new ordered list (deduped, capped); empty clears it.
+export class ProfileShelfArranged implements DomainEvent {
+  readonly name = "ProfileShelfArranged";
+  constructor(
+    readonly profileId: ProfileId,
+    readonly memberId: MemberId,
+    readonly copyIds: readonly string[],
+    readonly occurredAt: Date,
+  ) {}
+}
+```
+
+- [ ] **Step 2: Write failing domain tests.** Add to `domain/profile.spec.ts` a describe block for `arrangeShelf` (use the existing test setup/helpers in that file to construct a Profile):
+  - sets `featuredCopyIds` in the given order and records a `ProfileShelfArranged` event;
+  - de-duplicates, preserving first-occurrence order (`["a","b","a"]` → `["a","b"]`);
+  - caps at `MAX_FEATURED` (6) — an 8-item input keeps the first 6;
+  - empty array clears the shelf (and still records the event);
+  - `updatedAt` is set to the passed `now`.
+    Run `npx vitest run profile.spec.ts` in `packages/domain` → FAIL (no `arrangeShelf`).
+
+- [ ] **Step 3: Implement in `domain/profile.ts`.** Add `featuredCopyIds: readonly string[]` to `ProfileState`; initialise to `[]` in `create`; treat missing as `[]` in `rehydrate` (`featuredCopyIds: state.featuredCopyIds ?? []`); add a getter; export `const MAX_FEATURED = 6;`. Add the method:
+
+```ts
+arrangeShelf(copyIds: readonly string[], now: Date): Result<void, SocialError> {
+  const deduped = [...new Set(copyIds)].slice(0, MAX_FEATURED);
+  this.state = { ...this.state, featuredCopyIds: deduped, updatedAt: now };
+  this.record(
+    new ProfileShelfArranged(
+      this.state.id,
+      this.state.memberId,
+      deduped,
+      now,
+    ),
+  );
+  return ok(undefined);
+}
+```
+
+(Import `ProfileShelfArranged`. `[...new Set(...)]` dedupes preserving first-occurrence order. Always succeeds — `Result` shape matches `changeVisibility` for uniform call sites.) Run the spec → PASS.
+
+- [ ] **Step 4: Add the in-port.** Create `application/ports/in/arrange-shelf.port.ts` mirroring `edit-profile.port.ts`:
+
+```ts
+import { Result } from "../../../shared-kernel";
+import { SocialError } from "../../domain";
+import { SocialApplicationError } from "../errors";
+import { MemberId } from "../../domain/ids";
+
+export interface ArrangeShelfCommand {
+  readonly memberId: MemberId;
+  readonly copyIds: readonly string[];
+}
+
+export type ArrangeShelf = (
+  cmd: ArrangeShelfCommand,
+) => Promise<Result<void, SocialError | SocialApplicationError>>;
+```
+
+(Match the exact import paths/spelling used by `edit-profile.port.ts` after reading it.)
+
+- [ ] **Step 5: Write the use-case + its failing spec.** Create `application/use-cases/arrange-shelf.ts` mirroring `edit-profile.ts` exactly (load profile via `deps.profiles.findByMember`, `profileNotFound` if absent, call `profile.arrangeShelf(cmd.copyIds, deps.clock.now())`, `save`, `publish(profile.pullEvents())`). Create `arrange-shelf.spec.ts` mirroring `edit-profile.spec.ts` using the in-memory profile repository: asserts the saved profile's `featuredCopyIds` and that a `ProfileShelfArranged` event was published; `profileNotFound` when the member has no profile. Run → PASS.
+
+- [ ] **Step 6: Commit:** `feat(domain): Profile.arrangeShelf + arrange-shelf use-case`.
+
+---
+
+## Task 2: Schema field
+
+**Files:** `packages/backend/convex/schema.ts`.
+
+- [ ] **Step 1:** In the `profiles` table add, after `visibility`:
+
+```ts
+    // Ordered, curated set of the member's owned copies featured on their profile shelf
+    // (sub-project ④). Optional so existing rows validate; absent/empty = uncurated (recent-6 fallback).
+    featuredCopyIds: v.optional(v.array(v.id("ownedPuzzles"))),
+```
+
+- [ ] **Step 2:** `cd packages/backend && pnpm type-check` (or repo type-check) — schema compiles.
+- [ ] **Step 3: Commit:** `feat(backend): add profiles.featuredCopyIds for shelf curation`.
+
+---
+
+## Task 3: Convex mutation + read + test
+
+**Files:** under `packages/backend/convex/identity/` — a new `arrangeShelf` mutation, a `featuredShelf` query (or extend the existing profile/shelf read), the profile repository/mapper update for `featuredCopyIds`, and `identity/arrangeShelf.test.ts`.
+
+Read `setProfileVisibility` (mutation + how it builds the domain use-case via the convex-backed `ProfileRepository`/mapper) and mirror it.
+
+- [ ] **Step 1:** Update the convex profile repository/mapper (the 1b mapper referenced in `profile.ts`) to read/write `featuredCopyIds` (Convex `Id<"ownedPuzzles">[]` ⇄ domain `string[]`).
+
+- [ ] **Step 2: `arrangeShelf` mutation** — args `{ copyIds: v.array(v.id("ownedPuzzles")) }`; resolve the authed user → `memberId`; load each copy from `ownedPuzzles` and **reject (throw) if any copy's `ownerId` !== the caller**; map `_id`s → domain CopyId strings; run `makeArrangeShelf({ profiles, events, clock })({ memberId, copyIds })`; surface domain errors as thrown ConvexErrors like the existing mutations.
+
+- [ ] **Step 3: `featuredShelf` query** — args `{ userId: v.id("users") }`; load the member's profile; for each `featuredCopyIds` entry in order, resolve the `ownedPuzzles` row, **skipping ids that no longer exist or are no longer owned by `userId`**; project each to the SAME owned-copy view DTO that `library.ownedByOwner` returns (reuse the existing projection helper). Return `[]` when uncurated.
+
+- [ ] **Step 4: Test** `identity/arrangeShelf.test.ts` (mirror `setProfileVisibility.test.ts`, using the convex-test harness): arranging with another user's copy is rejected; arranging with owned copies persists the deduped/capped ordered `featuredCopyIds`; `featuredShelf` returns them in order and drops a deleted copy. Run `cd packages/backend && pnpm test` → PASS.
+
+- [ ] **Step 5: Commit:** `feat(backend): arrangeShelf mutation + featuredShelf query`.
+
+---
+
+## Task 4: Generated API types (worktree codegen)
+
+**Files:** `packages/backend/convex/_generated/api.d.ts`.
+
+Codegen runs on deploy, not in this worktree. Hand-add the new function refs so downstream packages typecheck.
+
+- [ ] **Step 1:** Mirror the existing `identity.setProfileVisibility` / `identity.*` entries in `api.d.ts` to add `identity.arrangeShelf` (mutation) and `identity.featuredShelf` (query) with matching arg/return types. (See [[convex-codegen-needs-deployment]].)
+- [ ] **Step 2:** `cd packages/backend && pnpm type-check` clean for the new refs.
+- [ ] **Step 3: Commit:** `chore(backend): hand-add generated types for shelf-curation fns`.
+
+---
+
+## Task 5: Gateway operations
+
+**Files:** `packages/gateway/src/operations.ts`.
+
+- [ ] **Step 1:** Expose `arrangeShelf` (mutation) and `featuredShelf` (query) mirroring the existing `library.ownedByOwner` / identity op wrappers (same namespacing + typing pattern).
+- [ ] **Step 2:** Repo type-check clean.
+- [ ] **Step 3: Commit:** `feat(gateway): expose arrangeShelf + featuredShelf`.
+
+---
+
+## Task 6: Web — curated read + Arrange-shelf editor
+
+**Files:** modify `apps/web/src/components/profile/shelf-section.tsx`; create `apps/web/src/components/profile/arrange-shelf-dialog.tsx`.
+
+- [ ] **Step 1: Curated read + fallback.** In `profile/shelf-section.tsx`, query `featuredShelf({ userId: member._id })`. Build `boxes` from the featured copies in order when non-empty; otherwise fall back to `copies.slice(0, 6)` (current behavior). Keep the existing `useMemo`. Feed `PuzzlePlank3D` (from ③) unchanged.
+
+- [ ] **Step 2: Owner detect + entry point.** Determine whether the viewer is the owner (compare the signed-in user to `member._id` — read `member-view.tsx`/the profile route for how "is own profile" is already expressed; reuse it). When owner, render an "Arrange shelf" `Button` (in the `SectionHead` action slot) that opens `ArrangeShelfDialog`.
+
+- [ ] **Step 3: `ArrangeShelfDialog`.** Build with the existing `ui/dialog`. Props: `{ ownerId, currentFeaturedIds, onClose }`. Loads `library.ownedByOwner({ ownerId })`. State: an ordered `selected: Id<"ownedPuzzles">[]` seeded from `currentFeaturedIds`. UI:
+  - A scrollable grid of owned copies; each is a toggle button (`aria-pressed`) — clicking adds (appends) / removes from `selected`. At 6 selected, un-selected toggles are disabled with a "max 6" hint.
+  - A "Selected (n/6)" ordered list showing the chosen copies with **Move up / Move down** buttons (disabled at ends) and a Remove button. Array order = display order.
+  - Footer: Cancel + Save. Save calls the `arrangeShelf` mutation with `{ copyIds: selected }`, then `onClose()`; Convex reactivity refreshes the shelf.
+  - Accessible: real `<button>`s, `aria-pressed`, dialog focus trap from the `ui/dialog` primitive. No drag-and-drop.
+
+- [ ] **Step 4:** `cd apps/web && pnpm type-check` — no errors referencing the two files (ignore `routeTree.gen` noise). `npx prettier --write` the changed/new files.
+
+- [ ] **Step 5: Commit:** `feat(web): curated profile shelf + Arrange-shelf editor`.
+
+---
+
+## Final verification
+
+- [ ] Domain tests pass (`packages/domain`), backend tests pass (`packages/backend`), `apps/web` type-check clean for changed files.
+- [ ] Prettier clean across all changed files (CI `format:check`).
+- [ ] Manual/user: own profile shows "Arrange shelf"; selecting + ordering up to 6 persists and reorders the 3D shelf; other profiles show curated-or-recent-6; picking another user's copy is impossible (only your own copies are listed) and rejected server-side.
+
+## Self-review notes
+
+- **Spec coverage:** domain (T1) · schema (T2) · convex mutation+read+test (T3) · codegen (T4) · gateway (T5) · web read+editor (T6) — every spec layer mapped.
+- **Type consistency:** `featuredCopyIds: readonly string[]` (domain) ⇄ `Id<"ownedPuzzles">[]` (convex/web); `arrangeShelf({ copyIds })` consistent across mutation, gateway, dialog; `MAX_FEATURED = 6` shared via the domain cap (UI enforces the same 6).
+- **Risk:** the hand-edited `_generated/api.d.ts` (T4) must match T3's real signatures; a deploy regenerates it. Ownership is enforced server-side (T3 step 2), not just in the UI.

--- a/docs/superpowers/plans/2026-06-15-quick-polish-tab-icons-and-plank-fit.md
+++ b/docs/superpowers/plans/2026-06-15-quick-polish-tab-icons-and-plank-fit.md
@@ -1,0 +1,429 @@
+# Quick Polish — Mobile Tab Icons + Landing Plank Fit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the mobile bottom tab bar as icons-only, and make the over-wide landing-page `JigPlank` previews scale down to fit narrow viewports so the page no longer scrolls horizontally.
+
+**Architecture:** A new `FitToWidth` wrapper scales a fixed-size child down to fit its container (computed by a pure, unit-tested `fitScale` helper) and collapses its layout height so no gap remains. The two un-clipped marketing plank previews are wrapped in it, with a defensive `overflow-x-clip` on the marketing root. The tab-bar change drops the label `<span>` and moves the label to an `aria-label`.
+
+**Tech Stack:** React, TanStack Router, Tailwind CSS, Vitest (pure-logic unit tests, the repo convention — no DOM testing library), lucide-react icons.
+
+---
+
+## File Structure
+
+- `apps/web/src/components/marketing/fit-to-width.tsx` — **new.** Exports `fitScale` (pure) and `FitToWidth` (component). Single responsibility: scale a fixed-size child down to fit its container width.
+- `apps/web/src/components/marketing/fit-to-width.test.ts` — **new.** Unit tests for `fitScale`.
+- `apps/web/src/components/marketing/home/feature-rows.tsx` — **modify.** Wrap the "library" `JigPlank` preview in `FitToWidth`.
+- `apps/web/src/routes/_public/about.tsx` — **modify.** Wrap the mission `JigPlank` preview in `FitToWidth`.
+- `apps/web/src/routes/index.tsx` — **modify.** Add `overflow-x-clip` to the marketing root.
+- `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx` — **modify.** `TabLink`: drop the label span, add `aria-label`.
+
+---
+
+## Task 1: `fitScale` pure helper + tests
+
+**Files:**
+
+- Create: `apps/web/src/components/marketing/fit-to-width.tsx`
+- Test: `apps/web/src/components/marketing/fit-to-width.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/marketing/fit-to-width.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { fitScale } from "./fit-to-width";
+
+describe("fitScale", () => {
+  it("scales down when the child is wider than the container", () => {
+    expect(fitScale(360, 500)).toBeCloseTo(0.72, 5);
+  });
+
+  it("never scales up past 1 when the container is wider", () => {
+    expect(fitScale(800, 500)).toBe(1);
+  });
+
+  it("returns 1 when widths are equal", () => {
+    expect(fitScale(500, 500)).toBe(1);
+  });
+
+  it("guards against a zero / unmeasured container width", () => {
+    expect(fitScale(0, 500)).toBe(1);
+  });
+
+  it("guards against a zero / unmeasured natural width", () => {
+    expect(fitScale(360, 0)).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @jigswap/web exec vitest run src/components/marketing/fit-to-width.test.ts`
+Expected: FAIL — cannot resolve `./fit-to-width` (module/export does not exist yet).
+
+> If `pnpm --filter @jigswap/web` is not the right invocation in this repo, run from `apps/web`: `cd apps/web && pnpm vitest run src/components/marketing/fit-to-width.test.ts`. The package script is `"test": "vitest run"`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `apps/web/src/components/marketing/fit-to-width.tsx` with only the helper for now:
+
+```tsx
+"use client";
+
+import * as React from "react";
+
+/**
+ * Largest scale ≤ 1 that fits a child of `naturalWidth` into `containerWidth`.
+ * Only ever scales DOWN — equal/larger containers return 1 (render untouched).
+ * Returns 1 for non-positive inputs (pre-measurement / unmeasured elements).
+ */
+export function fitScale(containerWidth: number, naturalWidth: number): number {
+  if (containerWidth <= 0 || naturalWidth <= 0) return 1;
+  return Math.min(1, containerWidth / naturalWidth);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/marketing/fit-to-width.test.ts`
+Expected: PASS (5 passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/marketing/fit-to-width.tsx apps/web/src/components/marketing/fit-to-width.test.ts
+git commit -m "feat(web): add fitScale helper for scaling previews to fit width"
+```
+
+---
+
+## Task 2: `FitToWidth` component
+
+**Files:**
+
+- Modify: `apps/web/src/components/marketing/fit-to-width.tsx`
+
+No unit test: this is DOM wiring (ResizeObserver + layout measurement), which the repo does not unit-test (existing web tests are pure-logic only). Verified manually in Task 3.
+
+- [ ] **Step 1: Append the component to `fit-to-width.tsx`**
+
+Add below `fitScale` in `apps/web/src/components/marketing/fit-to-width.tsx`:
+
+```tsx
+/**
+ * Scales a fixed-size child DOWN to fit the width of this wrapper, and collapses
+ * the wrapper's rendered height to the scaled height so the shrunk child leaves
+ * no layout gap. `overflow: hidden` contains the child's un-transformed layout
+ * box (a CSS transform shrinks paint, not layout) so it can't widen the page.
+ *
+ * Used for the marketing JigPlank previews, which are intrinsically wider than a
+ * phone viewport. At widths ≥ the child's natural width, scale is 1 (untouched).
+ */
+export function FitToWidth({ children }: { children: React.ReactNode }) {
+  const outer = React.useRef<HTMLDivElement>(null);
+  const inner = React.useRef<HTMLDivElement>(null);
+  const [scale, setScale] = React.useState(1);
+  const [scaledHeight, setScaledHeight] = React.useState<number | null>(null);
+
+  React.useLayoutEffect(() => {
+    const outerEl = outer.current;
+    const innerEl = inner.current;
+    if (!outerEl || !innerEl) return;
+
+    const measure = () => {
+      // offsetWidth/Height report the UN-transformed layout box, so they give the
+      // child's natural size even while our scale transform is applied.
+      const next = fitScale(outerEl.clientWidth, innerEl.offsetWidth);
+      setScale(next);
+      setScaledHeight(innerEl.offsetHeight * next);
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(outerEl);
+    ro.observe(innerEl); // child can resize after images load (JigPlank re-measures)
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={outer}
+      style={{
+        width: "100%",
+        height: scaledHeight ?? undefined,
+        overflow: "hidden",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        ref={inner}
+        style={{
+          flex: "none",
+          transform: `scale(${scale})`,
+          transformOrigin: "top center",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: PASS (no new errors in `fit-to-width.tsx`). Pre-existing `routeTree.gen` noise, if any, is unrelated — confirm no error references `fit-to-width.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/marketing/fit-to-width.tsx
+git commit -m "feat(web): add FitToWidth wrapper that scales previews to fit"
+```
+
+---
+
+## Task 3: Wire `FitToWidth` into the marketing planks + overflow safety net
+
+**Files:**
+
+- Modify: `apps/web/src/components/marketing/home/feature-rows.tsx`
+- Modify: `apps/web/src/routes/_public/about.tsx`
+- Modify: `apps/web/src/routes/index.tsx`
+
+- [ ] **Step 1: Wrap the feature-row library plank**
+
+In `apps/web/src/components/marketing/home/feature-rows.tsx`:
+
+Add the import (alongside the existing imports):
+
+```tsx
+import { FitToWidth } from "@/components/marketing/fit-to-width";
+```
+
+Then wrap the `JigPlank` in the `library` row's `visual`. Change:
+
+```tsx
+      visual: (
+        <JigPlank
+          depth={16}
+          boxes={[
+```
+
+to:
+
+```tsx
+      visual: (
+        <FitToWidth>
+          <JigPlank
+            depth={16}
+            boxes={[
+```
+
+and the matching close — change:
+
+```tsx
+          ]}
+        />
+      ),
+    },
+```
+
+to:
+
+```tsx
+            ]}
+          />
+        </FitToWidth>
+      ),
+    },
+```
+
+(Only the `library` row's `JigPlank` is wrapped — `LendTrackVisual` and `FilterVisual` already fit on mobile.)
+
+- [ ] **Step 2: Wrap the about-page mission plank**
+
+In `apps/web/src/routes/_public/about.tsx`:
+
+Add the import:
+
+```tsx
+import { FitToWidth } from "@/components/marketing/fit-to-width";
+```
+
+Wrap the `JigPlank` that sits inside the drop-shadow div. Change:
+
+```tsx
+              <div className="[filter:drop-shadow(0_24px_36px_rgb(40_30_80_/_.16))]">
+                <JigPlank
+                  depth={16}
+                  boxes={[
+```
+
+to:
+
+```tsx
+              <div className="[filter:drop-shadow(0_24px_36px_rgb(40_30_80_/_.16))]">
+                <FitToWidth>
+                  <JigPlank
+                    depth={16}
+                    boxes={[
+```
+
+and close the `FitToWidth` right after the `JigPlank` closes (before the `</div>` that closes the drop-shadow wrapper). Locate the `JigPlank`'s closing `/>` and its surrounding `</div>`; insert `</FitToWidth>` between them so the structure is `<div drop-shadow><FitToWidth><JigPlank .../></FitToWidth></div>`.
+
+- [ ] **Step 3: Add the marketing-root overflow safety net**
+
+In `apps/web/src/routes/index.tsx`, change:
+
+```tsx
+    <div className="mk-root font-mk-sans min-h-screen">
+```
+
+to:
+
+```tsx
+    <div className="mk-root font-mk-sans min-h-screen overflow-x-clip">
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: PASS — no errors referencing `feature-rows.tsx`, `about.tsx`, or `index.tsx`.
+
+- [ ] **Step 5: Manual verification (landing page)**
+
+Run the dev server: `cd apps/web && pnpm dev`. In the browser devtools, set viewport width to 360px and open `/`:
+
+- Expected: **no horizontal scrollbar**; the feature-row "library" plank and the about-page plank visibly shrink to fit the column width.
+- Resize the viewport wider (≥ ~900px): expected the planks render at natural size (scale 1), unchanged from before.
+
+If a horizontal scrollbar remains, identify the overflowing element in devtools (Elements → toggle the scroll), and confirm whether it is another plank instance (wrap it in `FitToWidth`) or a different element (out of scope for this plan — note it for sub-project ②).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/marketing/home/feature-rows.tsx apps/web/src/routes/_public/about.tsx apps/web/src/routes/index.tsx
+git commit -m "fix(web): scale landing plank previews to fit, stop horizontal scroll"
+```
+
+---
+
+## Task 4: Mobile tab bar — icons only
+
+**Files:**
+
+- Modify: `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx` (`TabLink`)
+
+- [ ] **Step 1: Replace the `TabLink` return**
+
+In `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx`, replace the entire `return (...)` block of the `TabLink` function. Change:
+
+```tsx
+return (
+  <Link
+    href={tab.href}
+    aria-current={on ? "page" : undefined}
+    className={cn(
+      "flex min-h-14 flex-col items-center justify-center gap-[3px] pt-[7px] pb-1.5",
+      on ? "text-jigsaw-primary" : "text-muted-foreground",
+    )}
+  >
+    <span className="relative">
+      <tab.icon className="size-[21px]" />
+      {badge > 0 && (
+        <span className="bg-jigsaw-primary-accent absolute -top-1 -right-2 inline-flex h-[15px] min-w-[15px] items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold text-white">
+          {badge > 9 ? "9+" : badge}
+        </span>
+      )}
+    </span>
+    <span
+      className={cn(
+        "text-[10.5px] tracking-[0.01em]",
+        on ? "font-bold" : "font-medium",
+      )}
+    >
+      {t(`tabs.${tab.key}`)}
+    </span>
+  </Link>
+);
+```
+
+to:
+
+```tsx
+return (
+  <Link
+    href={tab.href}
+    aria-label={t(`tabs.${tab.key}`)}
+    aria-current={on ? "page" : undefined}
+    className={cn(
+      "flex min-h-14 flex-col items-center justify-center",
+      on ? "text-jigsaw-primary" : "text-muted-foreground",
+    )}
+  >
+    <span className="relative">
+      <tab.icon className="size-[21px]" />
+      {badge > 0 && (
+        <span className="bg-jigsaw-primary-accent absolute -top-1 -right-2 inline-flex h-[15px] min-w-[15px] items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold text-white">
+          {badge > 9 ? "9+" : badge}
+        </span>
+      )}
+    </span>
+  </Link>
+);
+```
+
+(The label text moves from a visible `<span>` to the `Link`'s `aria-label`; the `t` import/usage stays, so nothing becomes unused. The icon stays centered via `min-h-14 flex-col ... justify-center`.)
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: PASS — no error referencing `mobile-tab-bar.tsx`.
+
+- [ ] **Step 3: Manual verification (mobile tab bar)**
+
+With `pnpm dev` running and the viewport at 360px, open `/dashboard`:
+
+- Expected: bottom tab bar shows **icons only** — no "Home / Bibliotheek / Ruilen / Community" text. The center "+" still overlaps the bar correctly; the unread/pending badge still appears on Swaps.
+- Inspect a tab `Link` in devtools: expected `aria-label` equals the localized tab name, and the active tab still has `aria-current="page"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+git commit -m "feat(web): mobile tab bar shows icons only (label moves to aria-label)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the web test suite**
+
+Run: `cd apps/web && pnpm test`
+Expected: PASS, including the new `fit-to-width.test.ts`.
+
+- [ ] **Format check (CI runs `format:check` first)**
+
+Run prettier on the changed files before the final state, e.g. from repo root:
+`npx prettier --write apps/web/src/components/marketing/fit-to-width.tsx apps/web/src/components/marketing/fit-to-width.test.ts apps/web/src/components/marketing/home/feature-rows.tsx apps/web/src/routes/_public/about.tsx apps/web/src/routes/index.tsx apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx`
+Then commit any formatting changes.
+
+- [ ] **Type-check the package once more**
+
+Run: `cd apps/web && pnpm type-check`
+Expected: no errors referencing any file changed in this plan.
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** Item 2 → Task 4. Item 5 → Tasks 1–3 (`fitScale` + `FitToWidth` + wiring + safety net). Both spec items are covered.
+- **Why `overflow: hidden` on the `FitToWidth` outer:** a CSS `transform: scale()` shrinks only paint, not the layout box, so the un-scaled child would still widen the page; `overflow: hidden` contains it while the scaled content remains fully visible (`transform-origin: top center` anchors it).
+- **No scale-up:** `fitScale` clamps to `≤ 1`, so desktop rendering is unchanged.

--- a/docs/superpowers/specs/2026-06-15-3d-plank-real-collections-design.md
+++ b/docs/superpowers/specs/2026-06-15-3d-plank-real-collections-design.md
@@ -1,0 +1,74 @@
+# 3D plank rendering real collections (dashboard + profile)
+
+**Date:** 2026-06-15
+**Status:** Approved (design) — autonomous build per the user's "continue until everything is completed" directive; major fork (3D on dashboard + profile) pre-decided.
+**Sub-project ③ of the mobile/3D-plank punch list** (① ✓ → ② ✓ → **③ 3D plank for real collections** → ④ profile shelf curation → ⑤ rigid-body physics).
+
+## Goal
+
+Replace the 2.5D CSS `PuzzlePlank` on the dashboard "Your Shelf" and the profile shelf with a **contained, bounded WebGL 3D plank** that renders the member's _actual_ puzzle copies on a single shelf board — keeping the existing CSS `PuzzlePlank` as the graceful fallback (SSR, no-WebGL, pre-load, and on any 3D error).
+
+Scope boundary: ③ is **rendering only** — a static 3D shelf with gentle idle parallax (reduced-motion aware). No per-box manipulation and no physics (that's ⑤). No curation UI (that's ④). The component renders whatever ordered box list it's handed; ④ later changes _which_ boxes the profile passes in.
+
+## Why a new component (not adapting `JigPlank3D`)
+
+`JigPlank3D` is specialized for the marketing hero: an **endless, repeating, multi-row, full-bleed** backdrop with fog haze at both ends, fed by `--mk-*` marketing tokens, sized to the viewport. The app need is the opposite — a **finite single row of the member's real N boxes**, contained in a fixed-height block on a normal page, themed with app tokens. Forcing those two into one component would tangle both. Instead, build a focused `PuzzlePlank3D` that **reuses the genuinely shared pieces** — `PuzzleBox` (`box.tsx`), `box-art.ts`, and `palette.ts`'s `LIGHTING` + `resolveCssColor` — and has its own bounded single-row arrangement, contained camera, and CSS fallback.
+
+## Architecture
+
+New directory `apps/web/src/components/common/puzzle-plank-3d/`:
+
+- **`index.tsx` — `PuzzlePlank3D({ boxes }: { boxes: PuzzlePlankBox[] })`.** The public component, mirroring `JigPlank3D`'s orchestration but for a contained widget:
+  - WebGL-support check, `prefers-reduced-motion`, theme (`next-themes`), `React.lazy` scene, `IntersectionObserver` to pause the render loop offscreen, and a render-nothing error boundary that leaves the CSS fallback — all adapted from `JigPlank3D`.
+  - **Fallback = the existing CSS `PuzzlePlank`** (`@/components/common/puzzle-plank`), shown during SSR/first paint and crossfaded out when the scene's first frame lands; permanently shown if WebGL is unavailable or the scene errors.
+  - Resolves each box's `c1`/`c2` via `resolveCssColor` against the **app DOM scope** (the dashboard/profile pass concrete hex colors, which resolve trivially; brand `var()`s resolve too) and the app heading font.
+  - Fills its parent container (the parent owns the height; see "Sizing").
+
+- **`scene.tsx` — the bounded single-row scene** (default export, `React.lazy`-loaded). A `<Canvas>` with:
+  - One shelf board sized to the actual row width (no fog, no endless span, no repeat).
+  - The real `PuzzleBox` instances laid out left→right by a pure `layoutRow(boxes)` helper (see Components), each at its natural footprint (no size jitter — these are the member's real boxes, shown faithfully).
+  - Lighting from `palette.ts` `LIGHTING[theme]`, a `ContactShadows` under the row, and the gentle pointer `Parallax` (reduced-motion → disabled), reused/adapted from `scene.tsx`.
+  - Camera framed to fit the whole row with a small margin (cover-fit by the row's bounding width/height).
+  - `onFirstFrame` to trigger the crossfade.
+
+- **`layout.ts` — pure `layoutRow` helper + its types.** Computes each box's world `x` position and the row's total width from the box widths + a fixed gap, deterministically (no randomness). Unit-tested.
+
+- **`palette.ts` reuse:** import `LIGHTING`, `resolveCssColor` as-is. `resolveHeadingFont` currently hard-codes `--font-mk-heading`; generalize it to `resolveHeadingFont(scope, varName = "--font-mk-heading")` and call it with `--font-heading` from the app component. (Backward-compatible — the marketing caller keeps the default.)
+
+- **`box.tsx` / `box-art.ts` reuse:** `PuzzleBox` already accepts a `PlankBox` plus a resolved `BoxSlot` ({x, c1, c2}) and `headingFont`; it is theme/scope-agnostic. The app `PuzzlePlankBox` is structurally compatible with `PlankBox` (`title`/`series`/`pieceCount`/`cover`/`c1`/`c2`/`width`/`height`). The scene passes app boxes through unchanged.
+
+## Data flow
+
+No backend change. Both consumers already build the box list:
+
+- **Dashboard `shelf-section.tsx`:** swap `<PuzzlePlank boxes={…}/>` for `<PuzzlePlank3D boxes={…}/>` inside a sized container. Keep the existing `owned.slice(0, 5).map(toPlankBox)` mapping. (This supersedes ②'s mobile plank sizing on the dashboard — see "Sizing".)
+- **Profile `shelf-section.tsx`:** same swap, `copies.slice(0, 6)` mapping unchanged.
+
+## Sizing (contained canvas)
+
+The CSS plank is intrinsic-height; a `<Canvas>` needs a defined parent height. The `PuzzlePlank3D` parent container gets a responsive fixed height (a `clamp()` block) that matches the plank's visual footprint, shorter on mobile (carrying ②'s "shorter on mobile" intent into the 3D widget, which now owns it). The CSS fallback renders centered within the same box. Exact heights are pinned in the implementation plan.
+
+## Components / boundaries
+
+- **`layoutRow(boxes)` (pure)** — input: ordered boxes; output: `{ slots: {x}[], rowWidth }`. No DOM, no three.js. The one unit-tested unit.
+- **`scene.tsx`** — owns all three.js; depends on `box.tsx`, `palette.ts`, `layout.ts`. Knows nothing about the dashboard/profile.
+- **`index.tsx`** — owns WebGL/fallback/lifecycle orchestration + color resolution; depends on the CSS `PuzzlePlank` and `scene.tsx`. The only thing the pages import.
+- Consumers (`dashboard-home/shelf-section.tsx`, `profile/shelf-section.tsx`) — unchanged except the component swap + container.
+
+## Testing / verification
+
+- **Unit (TDD):** `layout.ts` `layoutRow` — deterministic x-positions and total width for given box widths + gap (mirrors the existing `box-art.test.ts` pure-logic convention).
+- **No 3D rendering tests** (consistent with the untested marketing `scene.tsx`/`index.tsx`); the error boundary + CSS fallback make 3D failures non-fatal by design.
+- **Manual / user verification** (browser automation unavailable here): on dashboard + profile, the shelf shows the member's real puzzles as 3D boxes on a board; with WebGL off or on error, the CSS plank still shows; reduced-motion disables the parallax; desktop and mobile both render contained (no full-bleed, no horizontal overflow).
+
+## Out of scope (later sub-projects)
+
+- Curation / "highlight" — which puzzles and in what order the **profile** passes (④); ③ just renders the list it's given.
+- Grab/drag and rigid-body physics (⑤).
+- Any change to the marketing hero `JigPlank3D` (it keeps its endless-backdrop behavior; ③ only generalizes `resolveHeadingFont` in the shared `palette.ts`, backward-compatibly).
+
+## Risks / decisions (documented, not blocking)
+
+- **Two WebGL contexts** can now exist on one page only on the marketing site (hero) — the app pages have one plank each, so at most one canvas per app page. Fine.
+- **Dashboard is the highest-traffic page;** the scene is `React.lazy` + offscreen-paused + DPR-clamped + CSS-fallback-first, so first paint is the cheap CSS plank and WebGL upgrades in. Acceptable.
+- **Interaction = gentle parallax only** in ③ (decided default); ⑤ layers physics on the same scene.

--- a/docs/superpowers/specs/2026-06-15-mobile-native-scroll-and-dashboard-declutter-design.md
+++ b/docs/superpowers/specs/2026-06-15-mobile-native-scroll-and-dashboard-declutter-design.md
@@ -1,0 +1,97 @@
+# Mobile native scroll + dashboard declutter
+
+**Date:** 2026-06-15
+**Status:** Approved (design)
+**Sub-project ② of the mobile/3D-plank punch list** (① quick polish ✓ → **② mobile shell + dashboard declutter** → ③ 3D plank for real collections → ④ profile shelf curation → ⑤ rigid-body physics).
+
+## Goal
+
+Two intents, disjoint file sets (so they implement independently):
+
+- **Intent A — Item 1: mobile native document scroll.** Below the `md` breakpoint, the app scrolls at the document level so the mobile browser's address bar collapses on scroll. The mobile top bar stays pinned (sticky); the bottom tab bar stays fixed. The desktop inset-card shell is unchanged.
+- **Intent B — Item 4: focus the mobile dashboard.** De-emphasize the hero, condense the crowded "pulse" middle, shorten the shelf plank, and tighten vertical rhythm — all mobile-only. Every section stays reachable; the top of the page becomes about _status + shelf_.
+
+CSS/layout only. No backend, no data, no new routes, no JS breakpoint branch in the shell (pure responsive classes → no SSR/hydration flash). Intent B uses the existing `useIsMobile()` hook for the two numeric props that can't be expressed in CSS (plank box size, goal-ring size); a brief first-paint at desktop size is acceptable.
+
+## Why CSS-responsive (not a JS-branched mobile shell)
+
+The fixed-height behavior comes solely from `h-svh overflow-hidden` on `SidebarProvider` plus the inner `overflow-y-auto`. `html` has only `overflow-x-hidden`; `body` and the root have no height/overflow lock — so relaxing those classes below `md` lets the document scroll natively. This matches the shell's existing pattern of CSS-swapping mobile vs. desktop chrome (`md:hidden` / `hidden md:block`) and avoids a hydration flash. `PageHead` is already `hidden ... md:block`, so the sticky mobile top bar is the only mobile top chrome — no collision.
+
+---
+
+## Intent A — Mobile native scroll
+
+All changes in the dashboard shell + the two mobile bars. The mechanism: gate every scroll/height constraint to `md:`, make the mobile top bar `sticky` and the tab bar `fixed`, and give mobile content bottom padding to clear the fixed bar.
+
+### `apps/web/src/components/dashboard-layout/shell.tsx`
+
+1. **`SidebarProvider`** — `className="h-svh flex-col overflow-hidden"` → `className="flex-col md:h-svh md:overflow-hidden"`. (The component's base classes already include `flex min-h-svh w-full`, so mobile keeps `min-h-svh` and grows with content; desktop regains `h-svh overflow-hidden`.)
+
+2. **The sidebar/inset row** — `<div className="flex min-h-0 flex-1">` → `<div className="flex flex-1 md:min-h-0">`. (`flex-1` is harmless on mobile; `min-h-0` — needed only for the fixed-height inner-scroll case — is gated to `md`.)
+
+3. **`SidebarInset`** — gate the scroll-clip to `md`: `className="min-h-0 overflow-hidden md:peer-data-[variant=inset]:mt-0 …"` → `className="md:min-h-0 md:overflow-hidden md:peer-data-[variant=inset]:mt-0 …"` (the existing `md:peer-data-[variant=inset]:*` inset margins/border are unchanged).
+
+4. **The inner scroll `<div>`** (currently the single scroll region) — `className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]"` → `className="flex-1 overflow-x-hidden md:min-h-0 md:overflow-y-auto md:[scrollbar-gutter:stable]"`. On mobile it becomes a normal flowing block (no inner scroll → content extends the document); desktop keeps the inner scroll under the glass head.
+
+5. **`ContentArea` bottom padding** — the now-`fixed` tab bar (~56px tall + safe area) would overlap content. Change `"w-full px-4 pt-[18px] pb-8 md:p-6"` → `"w-full px-4 pt-[18px] pb-[calc(env(safe-area-inset-bottom)+76px)] md:p-6"`. (`md:p-6` overrides the bottom padding on desktop, so desktop is unchanged.)
+
+### `apps/web/src/components/dashboard-layout/mobile-top-bar.tsx`
+
+6. **Pin the bar.** Header `className="shrink-0 border-b bg-card pt-[env(safe-area-inset-top)] md:hidden"` → prepend `sticky top-0 z-30`. The opaque `bg-card` keeps content legible scrolling underneath; the browser address bar still collapses on scroll-down (sticky is independent of the browser's own chrome).
+
+### `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx`
+
+7. **Fix the bar to the viewport bottom.** The `<nav>` is `className="relative z-30 grid shrink-0 grid-cols-5 …"`; change the leading `relative` → `fixed inset-x-0 bottom-0`. It is already `md:hidden`, so this only affects mobile. The existing `pb-[env(safe-area-inset-bottom)]`, `z-30`, and `overflow-visible` (for the raised center button) stay.
+
+### Spacing note (Item 1's "large padding")
+
+With native scroll + a fixed tab bar + the new bottom padding, short pages (e.g. the empty dashboard) sit at the top with the tab bar pinned at the bottom — no stretched filler. The oversized gap in the report was the fixed-shell behavior plus the tall hero/plank; Intent A removes the former and Intent B the latter.
+
+---
+
+## Intent B — Focus the mobile dashboard
+
+Mobile-only de-emphasis + condensing. All `md:`/`lg:` values below preserve the current desktop appearance exactly.
+
+### `apps/web/src/routes/_dashboard/dashboard.tsx`
+
+1. Page section gap: `className="flex w-full flex-col gap-8 md:gap-10"` → `gap-6 md:gap-10`.
+
+### `apps/web/src/components/dashboard-home/briefing-hero.tsx`
+
+2. **Headline** (`Headline`'s `<p>`): `"font-heading max-w-[860px] text-2xl leading-[1.4] font-semibold tracking-tight text-pretty md:text-3xl"` → make the mobile size smaller and tighter: `text-xl leading-snug … md:text-3xl md:leading-[1.4]`. Net: mobile `text-xl leading-snug`, desktop unchanged (`text-3xl`, `leading-[1.4]`).
+3. **Hero gap** (both the `BriefingHero` `<section>` and the loading-skeleton `<section>`): `"flex flex-col gap-5"` → `"flex flex-col gap-4 md:gap-5"`.
+
+### `apps/web/src/components/dashboard-home/shelf-section.tsx`
+
+4. **Shorter, narrower plank on mobile.** `PuzzlePlank` derives every box's height from its `width` (cover boxes via image aspect; no-cover boxes via the `height` fallback), so shrinking `width` + the fallback heights on mobile makes the whole plank shorter. This file is already `"use client"`.
+   - Import and call `useIsMobile()` from `@/hooks/use-mobile`.
+   - Thread `isMobile` into `toPlankBox`. On mobile set `width: 92` (desktop: leave `undefined` → the component default 116) and use a shorter fallback-height array `[118, 104, 124, 100, 114]` (desktop keeps `[148, 130, 156, 126, 142]`).
+   - Reduce the plank wrapper's vertical padding on mobile: `className="min-w-0 overflow-x-auto px-2 pt-6 pb-5"` → `"min-w-0 overflow-x-auto px-2 pt-3 pb-3 md:pt-6 md:pb-5"`.
+   - The `overflow-x-auto` swipe is kept (boxes stay legible; they're just smaller on mobile).
+   - **Note:** sub-project ③ replaces this CSS plank with the 3D scene on the dashboard, which will own final box sizing. Intent B's plank change is the minimal mobile-height trim until then; do not over-invest here.
+
+### `apps/web/src/components/dashboard-home/pulse-section.tsx`
+
+5. **Tighter stacked gap on mobile** (the three columns stack below `lg`): the `PulseSection` grid and the `PulseSkeleton` grid both use `"grid gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]"` → `"grid gap-6 lg:gap-10 lg:grid-cols-[1.15fr_0.85fr_1.1fr]"`.
+6. **Smaller goal ring on mobile.** `GoalRing` hardcodes `const size = 148`. Add a `size` prop (default `148`) and derive the SVG geometry from it (it already does: `r`, `c`, `mid` are computed from `size`; the container `size-[148px]` must become `style={{ width: size, height: size }}`). In `GoalsColumn`, call `useIsMobile()` and pass `size={isMobile ? 116 : 148}`.
+
+---
+
+## Components / boundaries
+
+- **Shell scroll model (Intent A)** — one responsibility: below `md`, document-level scroll with pinned top / fixed bottom chrome; at/above `md`, the inset-card shell with inner scroll. Expressed entirely in responsive classes across `shell.tsx` + the two mobile bars.
+- **Dashboard mobile density (Intent B)** — per-section responsive sizing; each dashboard-home component owns its own mobile treatment. `GoalRing` gains a reusable `size` prop (no longer hardcoded).
+
+## Testing / verification
+
+- No automated tests (layout-only; consistent with the untested presentational dashboard/shell components — same call made in sub-project ①). The `GoalRing` `size` prop is exercised visually.
+- **Manual verification (controller, post-integration):** Note browser automation is unavailable in this environment (no Chrome for Playwright). Verification is by layout reasoning + a user eyeball on a real phone:
+  - Mobile (≤767px), authenticated dashboard: scrolling moves the _document_ (address bar collapses); the top bar stays pinned; the tab bar stays fixed at the bottom and never overlaps content (bottom padding clears it); the hero headline is smaller, the plank shorter, the pulse columns tighter with a smaller goal ring.
+  - Desktop (≥768px): byte-for-byte unchanged — inset card, inner scroll under the glass head, original hero/plank/pulse sizes.
+
+## Out of scope (later sub-projects)
+
+- Swapping the CSS plank for the WebGL 3D scene on dashboard + profile (③) — which supersedes Intent B's plank sizing.
+- Profile shelf curation / highlight (④); rigid-body physics (⑤).
+- Any change to the desktop shell, the desktop top bar, or the sidebar offcanvas.

--- a/docs/superpowers/specs/2026-06-15-profile-plank-physics-design.md
+++ b/docs/superpowers/specs/2026-06-15-profile-plank-physics-design.md
@@ -1,0 +1,88 @@
+# Rigid-body physics on the profile plank
+
+**Date:** 2026-06-15
+**Status:** Approved (design) — autonomous build per "continue until everything is completed"; scope (full rigid-body physics) pre-decided. **⚠️ This sub-project is purely interactive and CANNOT be verified in this environment (no browser/WebGL). It is designed to degrade safely; it WILL need hands-on verification by the user.**
+**Sub-project ⑤ (final) of the punch list** (① ✓ → ② ✓ → ③ ✓ → ④ ✓ → **⑤ rigid-body physics**).
+
+## Goal
+
+Make the **profile** shelf's 3D plank physically interactive: the member's puzzle boxes rest on the shelf under gravity, collide with each other and the shelf, and can be **grabbed and dragged/thrown** with pointer or touch, tumbling and settling realistically. The **dashboard** plank stays the static ③ scene (physics is a profile-only, opt-in layer). Reduced-motion, no-WebGL, and any 3D/physics error all fall back to the static scene or the CSS plank.
+
+## Hard constraints / safety (because it can't be tested here)
+
+Physics correctness is entirely runtime behavior. To bound the risk of shipping something subtly broken:
+
+- **Opt-in + isolated:** physics is a separate scene module (`scene-physics.tsx`) selected only when the profile passes `interactive`. ③'s `scene.tsx` is untouched and remains the default everywhere (dashboard, and profile when not interactive / reduced-motion / error).
+- **Degradation chain (reuse ③'s):** no WebGL → CSS plank; `prefers-reduced-motion` → static ③ scene (no physics); the existing `SceneBoundary` catches any throw from the physics scene → CSS plank. So a physics bug never breaks the profile page — worst case it shows the CSS plank.
+- **Bounded simulation:** a ground plane + invisible side/back walls keep knocked boxes from flying offscreen or falling forever; bodies that somehow escape are not catastrophic (offscreen, paused with the frameloop).
+
+## New dependency
+
+Add `@react-three/rapier` (a version compatible with `@react-three/fiber` 9.x / `three` 0.184 — the current 2.x line) to `apps/web/package.json`; `pnpm install` updates the lockfile. Rapier's WASM is lazy-loaded with the already-lazy scene chunk, so it adds nothing to first paint (the CSS plank shows first).
+
+## Architecture
+
+Builds on `apps/web/src/components/common/puzzle-plank-3d/`.
+
+### 1. `box.tsx` (marketing, shared) — minimal anchoring prop
+
+`PuzzleBox` currently self-positions its group at `[slot.x, h/2, 0]`. Physics needs a `RigidBody` parent to own the transform with the visual centered at local origin. Add a backward-compatible prop `anchored = true`:
+
+- `anchored: true` (default) → today's behavior (group at `[slot.x, baseY, 0]`), so ③'s static scene and the marketing hero are unchanged.
+- `anchored: false` → render the group at the **local origin** (`[0, 0, 0]`, no per-box yaw) so a parent `RigidBody` positions it. The box's mesh stays centered, so a cuboid collider of half-extents `(w/2, h/2, BOX_DEPTH/2)` matches it.
+
+`PuzzleBox` already computes `w`, `h`, `BOX_DEPTH`; expose the resolved `{ w, h }` so the physics scene can size colliders without recomputing. Either (a) lift the height calc into a tiny shared helper `boxWorldSize(box, sizeScale)` in `box.tsx` (returns `{ w, h }`, reused by `scene.tsx`'s `boxWorldHeight` too — DRY), or (b) the physics scene recomputes via the same formula. Prefer (a).
+
+### 2. `scene-physics.tsx` (new) — the interactive scene
+
+A sibling of `scene.tsx` (same `PlankSceneProps` plus nothing new), default-exported and `React.lazy`-loaded by the orchestrator when interactive. Differences from `scene.tsx`:
+
+- Wrap the world in rapier `<Physics>` (gravity `[0, -9.81, 0]`, `paused` driven by `visible`/reduced-motion so it never simulates offscreen), reusing the same `Lights`, camera cover-fit (`Arrangement` framing math), `ContactShadows`, and shelf board.
+- **Shelf + ground + walls = fixed colliders:** the shelf board is a `<RigidBody type="fixed">` cuboid; add a fixed ground plane just below the shelf and low invisible walls (left/right/back/front) sized from `rowWidth`/`maxBoxH` to contain thrown boxes.
+- **Each box = a dynamic `<RigidBody>`** at its `layoutRow` slot `[slots[i].x, h/2, 0]` (initial resting transform), containing `<PuzzleBox … anchored={false} />` and a `<CuboidCollider args={[w/2, h/2, BOX_DEPTH/2]} />`. Modest restitution, sensible friction/density so boxes settle and stack without jitter.
+- **No `Parallax`** (pointer drives dragging, not camera tilt). Keep the fixed yaw on the camera framing, not on a rotating group (physics bodies must live in world space, not inside a tilting group — bake the yaw into camera position instead).
+- `FirstFrame` → crossfade as before.
+
+### 3. Drag interaction (`use-box-drag.ts` or inline)
+
+Pointer/touch grab-drag-throw on the dynamic bodies, canvas pointer events enabled (the physics scene's `<Canvas>` uses `pointerEvents: "auto"` — ③'s static canvas keeps `"none"`):
+
+- On pointer-down on a box: capture it, switch the body to `kinematicPosition` (so it follows the cursor exactly, ignoring gravity while held), and record the grab offset.
+- On pointer-move: project the pointer onto a drag plane (parallel to the camera, through the grab point) and set the kinematic body's next position there. Track recent positions for a release velocity.
+- On pointer-up: switch the body back to `dynamic` and apply the computed linear velocity (a gentle throw); clamp to a max so a flick can't launch a box across the screen.
+- Touch: the same pointer events (pointer events unify mouse/touch); ensure the container's `touch-action` allows the drag without the page scrolling (the canvas is inside the document-scroll mobile shell from ②, so set `touch-action: none` on the canvas only while a box is grabbed, restoring it on release, so vertical page scroll still works when not dragging).
+
+### 4. Orchestrator (`index.tsx`) — opt-in + selection
+
+- Add an `interactive?: boolean` prop to `PuzzlePlank3D`. When `interactive && !reducedMotion && WebGL`, lazy-load `scene-physics`; otherwise lazy-load the static `scene` (today's behavior). Both go through the same `SceneBoundary` + CSS fallback + color resolution + `IntersectionObserver` visibility.
+- The physics canvas needs pointer events; gate the canvas `pointerEvents` on whether the physics scene is active.
+
+### 5. Profile wiring (`profile/shelf-section.tsx`)
+
+Pass `interactive` to the profile's `PuzzlePlank3D` (the dashboard does not). The curated boxes from ④ flow in unchanged.
+
+## Components / boundaries
+
+- **`scene-physics.tsx`** — owns all rapier usage; isolated so ③'s `scene.tsx` and the marketing hero are untouched. Knows nothing about profiles.
+- **`box.tsx` `anchored` prop + `boxWorldSize` helper** — the only change to the shared renderer; default preserves every existing caller.
+- **drag hook** — owns pointer→world projection + kinematic/dynamic toggling; the one piece with the most runtime risk, kept small and isolated.
+- **`index.tsx`** — owns scene SELECTION (static vs physics) + the existing lifecycle/fallback.
+
+## Testing / verification
+
+- **Unit (TDD where pure):** the release-velocity clamp and the drag-plane / pointer→world projection math can be extracted to pure helpers and unit-tested (e.g. `clampThrowVelocity`, `pointerToDragPlane`). The collider half-extents come from the unit-tested `boxWorldSize`. That is the only automatable coverage.
+- **No simulation tests** — physics behavior is not unit-testable here and the env has no browser. The `SceneBoundary` + CSS fallback make a physics failure non-fatal.
+- **⚠️ Mandatory user verification:** on the profile page, boxes rest on the shelf; grabbing/dragging with mouse AND touch works; thrown boxes tumble and settle without falling through the shelf or flying offscreen; page still scrolls when not dragging a box; reduced-motion shows the static shelf; perf is acceptable on a real phone. This is the gate before ⑤ is considered done — I cannot confirm any of it here.
+
+## Out of scope
+
+- Physics on the dashboard plank (static ③ only).
+- Persisting knocked-around positions (boxes re-init to their resting layout on each mount).
+- Any change to the marketing hero scene or ③'s static `scene.tsx`.
+
+## Risks (high — flagged)
+
+- **Untestable here:** every behavioral aspect (collider alignment, drag feel, throw clamp, settle stability, mobile perf, touch-vs-scroll) is runtime-only. Expect an iteration pass after the user tries it.
+- **Mobile perf:** physics stepping + WebGL on a phone; mitigated by offscreen pause (frameloop/`paused`), DPR clamp, few bodies (≤6), and simple cuboid colliders.
+- **Touch vs page scroll:** the ② mobile shell scrolls the document; the canvas must only swallow touch while a box is grabbed, or the shelf will trap page scroll. Designed above (`touch-action` toggled on grab).
+- **Dependency/version:** `@react-three/rapier` must match fiber 9 / three 0.184; if the install surfaces a peer conflict, pin a compatible version.

--- a/docs/superpowers/specs/2026-06-15-profile-shelf-curation-design.md
+++ b/docs/superpowers/specs/2026-06-15-profile-shelf-curation-design.md
@@ -1,0 +1,80 @@
+# Profile shelf curation ("highlight")
+
+**Date:** 2026-06-15
+**Status:** Approved (design) — autonomous build per "continue until everything is completed"; the WHAT was pre-decided (curate which puzzles show + order, separate from the catalogue, small backend field).
+**Sub-project ④ of the punch list** (① ✓ → ② ✓ → ③ ✓ → **④ profile shelf curation** → ⑤ rigid-body physics).
+
+## Goal
+
+Let a member curate **which** of their owned puzzles appear on their profile shelf and **in what order** — a hand-arranged display shelf, distinct from the full catalogue (My Puzzles). The profile shelf (now the 3D plank from ③) renders the curated, ordered set; with nothing curated it falls back to the current behavior (most-recent 6). Owners get an "Arrange shelf" editor on their own profile.
+
+This is one cohesive feature spanning the DDD stack: domain → schema → Convex → gateway → codegen → web. It is **sequential** (each layer depends on the one below), so it builds in a single isolated worktree with atomic commits per layer — not parallel intents.
+
+## Decisions (documented)
+
+- **Storage:** an ordered `featuredCopyIds` array on the `profiles` aggregate/table (opaque CopyId strings, capped at 6, de-duplicated). Order in the array = display order. Chosen over a per-copy boolean flag because it captures order natively and keeps the curated set on the profile aggregate that owns the shelf.
+- **Edit surface:** an owner-only "Arrange shelf" affordance on the member's **own** profile shelf, opening a dialog: the owner's owned copies as a selectable grid (toggle to include, max 6) with **up/down reorder controls** on the selected items. No drag-and-drop dependency — accessible, robust, and verifiable without a browser (important: browser automation is unavailable in this environment). Save calls the `arrangeShelf` mutation.
+- **Ownership validation** (curated copies must belong to the member) lives in the **Convex mutation** (cross-aggregate concern), not the Profile aggregate. The aggregate stores opaque ordered ids, deduping + capping only.
+- **Fallback:** empty `featuredCopyIds` → the profile shelf shows the most-recent 6 owned copies (today's behavior), so existing profiles are unchanged until the owner curates.
+
+## Architecture (by layer)
+
+### 1. Domain — `packages/domain/src/social/`
+
+- `domain/profile.ts`: add `featuredCopyIds: readonly string[]` to `ProfileState` (default `[]` in `create`). Add `arrangeShelf(copyIds: readonly string[], now: Date): Result<void, SocialError>` that de-duplicates (preserving first occurrence order), caps to `MAX_FEATURED = 6`, sets state + `updatedAt`, and records a new `ProfileShelfArranged` event. `rehydrate` accepts the new field (treat missing as `[]`).
+- `domain/events.ts`: add `ProfileShelfArranged(profileId, memberId, copyIds: readonly string[], at: Date)`.
+- `application/use-cases/arrange-shelf.ts`: a use-case mirroring `edit-profile.ts` — loads the member's Profile via the repo, calls `arrangeShelf`, saves, publishes events. Input `{ memberId, copyIds, now }`.
+- Tests: `domain/profile.spec.ts` (dedupe, cap-at-6, order preserved, event emitted, empty clears) and `application/use-cases/arrange-shelf.spec.ts` (loads/saves/publishes) — following the existing `.spec.ts` convention and the in-memory profile repository.
+
+### 2. Schema — `packages/backend/convex/schema.ts`
+
+`profiles`: add `featuredCopyIds: v.optional(v.array(v.id("ownedPuzzles")))`. Optional so existing rows validate; absent = uncurated.
+
+### 3. Convex — `packages/backend/convex/identity/`
+
+- A mutation `arrangeShelf({ copyIds })` (auth: current user → their `memberId`): loads each `ownedPuzzles` row, **rejects any copy not owned by the caller**, maps Convex `_id`s to domain CopyId strings, runs the domain use-case via the existing profile repository/mapper, and persists `featuredCopyIds` on the profile row. Mirror the structure of the existing `setProfileVisibility`/`editProfile` mutations.
+- A read that resolves the **ordered featured copies** to the same owned-copy view DTO the shelf already consumes: add `featuredShelf({ userId })` returning the curated copies in order, or extend the existing profile read. Resolves each featured `_id` against `ownedPuzzles`, drops any that no longer exist / are no longer owned (defensive), and returns `[]` when uncurated (the web layer applies the recent-6 fallback).
+- Tests: `identity/arrangeShelf.test.ts` (ownership rejection, dedupe/cap via domain, persisted order) following the `*.test.ts` convention at the convex root.
+- **Codegen:** new functions need `_generated/api.d.ts`. Per project convention, in a worktree the deployment-driven codegen isn't run — **hand-edit `packages/backend/convex/_generated/api.d.ts`** to add the new function signatures so the gateway + web typecheck. (See the [[convex-codegen-needs-deployment]] memory.)
+
+### 4. Gateway — `packages/gateway/src/operations.ts`
+
+Expose `arrangeShelf` (mutation) and `featuredShelf` (query) alongside the existing `library.ownedByOwner` / profile ops, matching the existing operation-wrapping pattern.
+
+### 5. Web — profile shelf + editor
+
+- `apps/web/src/components/profile/shelf-section.tsx`:
+  - Read the curated set via the new gateway query; map to `PuzzlePlankBox[]` in curated order. When empty, fall back to `copies.slice(0, 6)` (today's recent-6) so uncurated profiles look identical.
+  - Feed the (already 3D from ③) `PuzzlePlank3D`.
+  - When the viewer **is the owner**, render an "Arrange shelf" button opening the editor dialog.
+- New `apps/web/src/components/profile/arrange-shelf-dialog.tsx`:
+  - Lists the owner's owned copies (from `library.ownedByOwner`), each toggleable into the featured set (cap 6, disable further selection at the cap with a hint).
+  - Selected items show their position with **Move up / Move down** controls (and remove). Selection/array order = display order.
+  - Save → `arrangeShelf({ copyIds })`; optimistic close; Convex reactivity refreshes the shelf.
+  - Accessible (buttons, `aria-pressed`, focus management) — no DnD library.
+
+## Components / boundaries
+
+- **`Profile.arrangeShelf` (domain)** — pure: dedupe + cap + order + event. No knowledge of copies' validity (the mutation guards ownership).
+- **`arrangeShelf` mutation (convex)** — owns auth + ownership validation + persistence.
+- **`featuredShelf` query (convex/gateway)** — resolves ids → ordered view DTOs; defensive against stale ids.
+- **`ArrangeShelfDialog` (web)** — owns the editor UX; depends only on `ownedByOwner` + the `arrangeShelf` mutation.
+- **profile `shelf-section`** — chooses curated-vs-fallback and renders the plank + (owner-only) editor entry point.
+
+## Testing / verification
+
+- **Domain (TDD, `.spec.ts`):** `profile.spec.ts` arrangeShelf cases; `arrange-shelf.spec.ts` use-case wiring. These run in CI and are fully testable here.
+- **Backend (`.test.ts`):** `arrangeShelf.test.ts` ownership-rejection + persistence.
+- **Web:** no component tests (convention); the editor's accessible button-based reorder is reasoned, not browser-tested (automation unavailable).
+- **Manual/user:** own profile shows "Arrange shelf"; picking + ordering persists and reorders the 3D shelf; other members' profiles show their curated shelf (or recent-6 fallback); the editor caps at 6.
+
+## Out of scope
+
+- The 3D rendering itself (③, done) — ④ only changes _which ordered boxes_ the profile passes to `PuzzlePlank3D`.
+- Curating the **dashboard** shelf (the dashboard keeps showing recent owned copies; curation is a profile/identity feature).
+- Physics (⑤).
+
+## Risks
+
+- **Codegen in worktree:** the hand-edited `_generated/api.d.ts` must match the real function signatures; a real deploy regenerates it. Flag clearly in the plan.
+- **Stale featured ids:** copies can be deleted/transferred after curation; the `featuredShelf` read drops ids that no longer resolve to an owned copy, so the shelf never shows a broken box.

--- a/docs/superpowers/specs/2026-06-15-quick-polish-tab-icons-and-plank-fit-design.md
+++ b/docs/superpowers/specs/2026-06-15-quick-polish-tab-icons-and-plank-fit-design.md
@@ -1,0 +1,69 @@
+# Quick polish — mobile tab icons + landing plank fit
+
+**Date:** 2026-06-15
+**Status:** Approved (design)
+**Sub-project ① of the mobile/3D-plank punch list** (decomposition: ① quick polish → ② mobile shell + dashboard declutter → ③ 3D plank for real collections → ④ profile shelf curation → ⑤ rigid-body physics).
+
+## Goal
+
+Two small, independent fixes:
+
+1. **Item 2** — Mobile bottom tab bar shows icon **+ text label**; it should show **icon only**.
+2. **Item 5** — The landing page scrolls horizontally on narrow viewports because the CSS `JigPlank` preview is wider than the viewport. The plank should **scale down to fit** the page width.
+
+Both are visual/layout only. No backend, no data, no new routes.
+
+## Item 2 — Mobile tab bar: icons only
+
+**File:** `apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx` (`TabLink`)
+
+- Remove the text-label `<span>` that renders `t(`tabs.${tab.key}`)`.
+- The visible label was the link's only accessible name, so **add `aria-label={t(`tabs.${tab.key}`)}` to the `Link`** to preserve the screen-reader name. The existing `aria-current="page"` on the active tab is unchanged.
+- Keep: icon size (`size-[21px]`), the unread badge, the active vs. muted color treatment, the `min-h-14` touch target and vertical centering. The bar reads as icons-only but stays the same height-class so the raised center "+" still overlaps correctly.
+- The `t` lookups for labels stay (now used for `aria-label`), so no translation keys are removed.
+
+**Out of scope:** the center "+" button, the desktop sidebar, the mobile top bar.
+
+## Item 5 — Landing plank scales to fit
+
+### Root cause
+
+`JigPlank` (`components/marketing/plank.tsx`) is `width: fit-content` and intrinsically ~500px wide. In the hero it's clipped by `overflow-hidden`, but it is also rendered as an inline preview — un-clipped, in a `w-full` flex cell — in:
+
+- `components/marketing/home/feature-rows.tsx` — the "library" feature row visual.
+- `routes/_public/about.tsx` — the mission section visual.
+
+On a ~360px phone the ~500px plank overflows its cell and widens the document → horizontal scroll.
+
+### Fix — reusable `FitToWidth` wrapper (chosen approach A)
+
+New component: `apps/web/src/components/marketing/fit-to-width.tsx`
+
+- Renders `children` inside a measured wrapper.
+- Uses `ResizeObserver` on the outer container and reads the child's natural (unscaled) size.
+- Computes `scale = Math.min(1, containerWidth / naturalWidth)` and applies `transform: scale(scale)` with `transform-origin: top center` (or center).
+- Collapses the wrapper's rendered height to `naturalHeight * scale` so the scaled-down plank doesn't leave a layout gap and surrounding content flows correctly.
+- Only ever scales **down** (`min(1, …)`) — at desktop widths the plank renders at natural size, unchanged.
+- SSR-safe: before measurement, render at scale 1 (natural size) so first paint is correct on wide screens; the observer corrects narrow screens on mount.
+
+Wrap the two inline `JigPlank` previews (`feature-rows.tsx` library row, `about.tsx` mission visual) with `FitToWidth`. The hero's plank is already clipped and is left untouched.
+
+### Defensive safety net
+
+Add `overflow-x-clip` to the marketing landing root in `routes/index.tsx` (`<div className="mk-root font-mk-sans min-h-screen">`). This is a cheap backstop against any other stray horizontal overflow; the `FitToWidth` wrapper is the real fix for the plank.
+
+## Components / boundaries
+
+- `FitToWidth` — single purpose: scale a fixed-size child down to fit its container width and collapse the layout height accordingly. Inputs: `children`. No knowledge of planks specifically; reusable for any over-wide preview.
+
+## Testing / verification
+
+- No automated tests for this layout-only change (consistent with the existing marketing components, which are untested presentational pieces).
+- Manual verification: load the landing page at ~360px width — no horizontal scrollbar, the feature-row and about planks visibly shrink to fit. Load the dashboard on mobile — bottom tab bar shows icons with no text labels; VoiceOver/TalkBack still announces each tab name (aria-label). At desktop width the planks render at natural size, unchanged.
+
+## Out of scope (later sub-projects)
+
+- Mobile shell native scroll / address-bar hiding, dashboard declutter (②).
+- Swapping the CSS plank for the WebGL 3D scene (③).
+- Profile shelf curation / highlight (④).
+- Rigid-body physics (⑤).

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -209,8 +209,10 @@ import type * as social_adapters_idGenerators from "../social/adapters/idGenerat
 import type * as social_adapters_inProcessEventPublisher from "../social/adapters/inProcessEventPublisher.js";
 import type * as social_adapters_mappers from "../social/adapters/mappers.js";
 import type * as social_adapters_systemClock from "../social/adapters/systemClock.js";
+import type * as social_arrangeShelf from "../social/arrangeShelf.js";
 import type * as social_editProfile from "../social/editProfile.js";
 import type * as social_errors from "../social/errors.js";
+import type * as social_featuredShelf from "../social/featuredShelf.js";
 import type * as social_followMember from "../social/followMember.js";
 import type * as social_getActivityFeed from "../social/getActivityFeed.js";
 import type * as social_getProfile from "../social/getProfile.js";
@@ -451,8 +453,10 @@ declare const fullApi: ApiFromModules<{
   "social/adapters/inProcessEventPublisher": typeof social_adapters_inProcessEventPublisher;
   "social/adapters/mappers": typeof social_adapters_mappers;
   "social/adapters/systemClock": typeof social_adapters_systemClock;
+  "social/arrangeShelf": typeof social_arrangeShelf;
   "social/editProfile": typeof social_editProfile;
   "social/errors": typeof social_errors;
+  "social/featuredShelf": typeof social_featuredShelf;
   "social/followMember": typeof social_followMember;
   "social/getActivityFeed": typeof social_getActivityFeed;
   "social/getProfile": typeof social_getProfile;

--- a/packages/backend/convex/arrangeShelf.test.ts
+++ b/packages/backend/convex/arrangeShelf.test.ts
@@ -1,0 +1,222 @@
+import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seedUsers = (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    const alice = await ctx.db.insert("users", {
+      clerkId: "clerk_alice",
+      email: "alice@example.com",
+      name: "Alice",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const bob = await ctx.db.insert("users", {
+      clerkId: "clerk_bob",
+      email: "bob@example.com",
+      name: "Bob",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { alice, bob };
+  });
+
+const asAlice = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+
+const asBob = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_bob" });
+
+describe("arrangeShelf", () => {
+  test("arranging with another user's copy is rejected", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seedUsers(t);
+
+    // Bob owns a puzzle
+    const puzzleId = await t.run((ctx) =>
+      ctx.db.insert("puzzles", {
+        title: "Test Puzzle",
+        pieceCount: 500,
+        status: "approved",
+        submittedBy: bob,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const bobsCopyId = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: bob,
+        condition: "good",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    // Alice tries to arrange a shelf with Bob's copy
+    await expect(
+      asAlice(t).mutation(api.social.arrangeShelf.arrangeShelf, {
+        copyIds: [bobsCopyId],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("arranging with owned copies persists the deduped/capped ordered featuredCopyIds", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seedUsers(t);
+
+    const puzzleId = await t.run((ctx) =>
+      ctx.db.insert("puzzles", {
+        title: "Test Puzzle",
+        pieceCount: 1000,
+        status: "approved",
+        submittedBy: alice,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const copy1 = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "good",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const copy2 = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "like_new",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    // First set up Alice's profile
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice",
+    });
+
+    // Arrange shelf with [copy2, copy1, copy2] — duplicates should be deduped
+    await asAlice(t).mutation(api.social.arrangeShelf.arrangeShelf, {
+      copyIds: [copy2, copy1, copy2],
+    });
+
+    const profile = await asAlice(t).query(
+      api.social.getProfile.getProfile,
+      {},
+    );
+    expect(profile).not.toBeNull();
+
+    // Verify featuredShelf returns them in order and deduped
+    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
+      userId: alice,
+    });
+    expect(shelf).toHaveLength(2);
+    expect(shelf[0]._id).toBe(copy2);
+    expect(shelf[1]._id).toBe(copy1);
+  });
+
+  test("featuredShelf returns items in order and drops a deleted copy", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seedUsers(t);
+
+    const puzzleId = await t.run((ctx) =>
+      ctx.db.insert("puzzles", {
+        title: "Another Puzzle",
+        pieceCount: 500,
+        status: "approved",
+        submittedBy: alice,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const copy1 = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "good",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const copy2 = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "like_new",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice",
+    });
+
+    await asAlice(t).mutation(api.social.arrangeShelf.arrangeShelf, {
+      copyIds: [copy1, copy2],
+    });
+
+    // Delete copy1
+    await t.run((ctx) => ctx.db.delete(copy1));
+
+    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
+      userId: alice,
+    });
+    // copy1 was deleted, only copy2 should remain
+    expect(shelf).toHaveLength(1);
+    expect(shelf[0]._id).toBe(copy2);
+  });
+
+  test("featuredShelf returns [] when the profile has no curation", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seedUsers(t);
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice",
+    });
+
+    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
+      userId: alice,
+    });
+    expect(shelf).toEqual([]);
+  });
+
+  test("arrangeShelf records a ProfileShelfArranged domain event", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seedUsers(t);
+
+    await asAlice(t).mutation(api.social.arrangeShelf.arrangeShelf, {
+      copyIds: [],
+    });
+    const events = await t.run((ctx) => ctx.db.query("domainEvents").collect());
+    expect(events.map((e) => e.name)).toContain("ProfileShelfArranged");
+  });
+
+  test("requires authentication", async () => {
+    const t = convexTest(schema, modules);
+    await seedUsers(t);
+
+    await expect(
+      t.mutation(api.social.arrangeShelf.arrangeShelf, { copyIds: [] }),
+    ).rejects.toThrow(ConvexError);
+  });
+});

--- a/packages/backend/convex/getCopyInstanceView.test.ts
+++ b/packages/backend/convex/getCopyInstanceView.test.ts
@@ -395,7 +395,7 @@ describe("getCopyInstanceView rich detail", () => {
     expect(view?.snapshot.difficulty).toBeUndefined();
   });
 
-  test("stats: timesCompleted, fastestFinishDays, timesLentOut, yourAvgRating", async () => {
+  test("stats: timesCompleted, fastestFinishMinutes, timesLentOut, yourAvgRating", async () => {
     const t = convexTest(schema, modules);
     const { now, viewer, solver, copy } = await seedCopy(t);
     await setVisibility(t, solver, "public");
@@ -471,7 +471,8 @@ describe("getCopyInstanceView rich detail", () => {
       { copyId: copy },
     );
     expect(view?.stats.timesCompleted).toBe(3);
-    expect(view?.stats.fastestFinishDays).toBe(2);
+    // 2-day fastest solve, now reported in raw minutes (2 * 24 * 60).
+    expect(view?.stats.fastestFinishMinutes).toBe(2 * 24 * 60);
     expect(view?.stats.timesLentOut).toBe(2);
     // Viewer's own ratings: 4 and 5 -> avg 4.5.
     expect(view?.stats.yourAvgRating).toBe(4.5);
@@ -485,7 +486,7 @@ describe("getCopyInstanceView rich detail", () => {
       { copyId: copy },
     );
     expect(view?.stats.timesCompleted).toBe(0);
-    expect(view?.stats.fastestFinishDays).toBeNull();
+    expect(view?.stats.fastestFinishMinutes).toBeNull();
     expect(view?.stats.timesLentOut).toBe(0);
     expect(view?.stats.yourAvgRating).toBeNull();
   });
@@ -734,12 +735,12 @@ describe("getCopyInstanceView rich detail", () => {
     const solverEntry = view?.completions[0];
     const viewerEntry = view?.completions[1];
     expect(solverEntry?.isYou).toBe(false);
-    expect(solverEntry?.finishDays).toBe(7);
+    expect(solverEntry?.finishMinutes).toBe(7 * 24 * 60);
     expect(solverEntry?.rating).toBeNull();
     expect(solverEntry?.note).toBeNull();
 
     expect(viewerEntry?.isYou).toBe(true);
-    expect(viewerEntry?.finishDays).toBe(3);
+    expect(viewerEntry?.finishMinutes).toBe(3 * 24 * 60);
     expect(viewerEntry?.rating).toBe(5);
     expect(viewerEntry?.note).toBe("Loved it");
   });

--- a/packages/backend/convex/getPuzzleDefinitionView.test.ts
+++ b/packages/backend/convex/getPuzzleDefinitionView.test.ts
@@ -286,6 +286,38 @@ describe("getPuzzleDefinitionView", () => {
     expect(view?.stats.availableToSwap).toBe(3);
   });
 
+  test("totalCompletions counts a solve recorded against a COPY (ownedPuzzleId, no puzzleId)", async () => {
+    const t = convexTest(schema, modules);
+    const { now, viewer, puzzleId } = await seed(t);
+
+    // The viewer's own copy of this puzzle.
+    const copyId = await mkCopy(t, {
+      aggregateId: "c-viewer",
+      puzzleId,
+      ownerId: viewer,
+      createdAt: now,
+    });
+
+    await t.run(async (ctx) => {
+      // "Mark my copy complete" stores the solve against ownedPuzzleId only (no
+      // puzzleId) — the catalogue total must still count it.
+      await ctx.db.insert("completions", {
+        userId: viewer,
+        ownedPuzzleId: copyId,
+        startDate: now,
+        endDate: now + 3 * DAY,
+        photos: [],
+        isCompleted: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const view = await get(t, puzzleId);
+    expect(view?.stats.totalCompletions).toBe(1);
+    expect(view?.stats.avgCompletionDays).toBe(3);
+  });
+
   test("avgCompletionDays is null when no completed completions", async () => {
     const t = convexTest(schema, modules);
     const { puzzleId } = await seed(t);

--- a/packages/backend/convex/library/getCopyInstanceView.ts
+++ b/packages/backend/convex/library/getCopyInstanceView.ts
@@ -14,20 +14,19 @@ import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
 import { projectMemberIdentity } from "../social/privacy";
 
-const MS_PER_DAY = 86_400_000;
-
-// Whole-day solve duration: prefer (endDate - startDate) rounded to whole days; else fall back to
-// completionTimeMinutes / 1440 rounded; else null when neither is recorded.
-const finishDaysOf = (c: {
+// Solve duration in whole MINUTES: prefer (endDate - startDate); else completionTimeMinutes; else
+// null. Returned raw (not rounded to days) so the UI can humanize it (e.g. "2 hours", "1 day",
+// "4 days", "1 week") instead of collapsing a sub-day solve to "0 days".
+const finishMinutesOf = (c: {
   startDate: number;
   endDate?: number;
   completionTimeMinutes?: number;
 }): number | null => {
   if (c.endDate != null) {
-    return Math.round((c.endDate - c.startDate) / MS_PER_DAY);
+    return Math.round((c.endDate - c.startDate) / 60000);
   }
   if (c.completionTimeMinutes != null) {
-    return Math.round(c.completionTimeMinutes / 1440);
+    return Math.round(c.completionTimeMinutes);
   }
   return null;
 };
@@ -173,7 +172,7 @@ export const getCopyInstanceView = query({
           solver: await project(c.userId),
           isYou: c.userId === viewerId,
           occurredAt: c.endDate ?? c.startDate,
-          finishDays: finishDaysOf(c),
+          finishMinutes: finishMinutesOf(c),
           rating: c.rating ?? null,
           note: c.review ?? null,
         })),
@@ -205,11 +204,11 @@ export const getCopyInstanceView = query({
     );
 
     // --- Per-copy stats. -----------------------------------------------------------------------
-    const finishDaysList = completedCompletions
-      .map(finishDaysOf)
+    const finishMinutesList = completedCompletions
+      .map(finishMinutesOf)
       .filter((d): d is number => d != null);
-    const fastestFinishDays =
-      finishDaysList.length > 0 ? Math.min(...finishDaysList) : null;
+    const fastestFinishMinutes =
+      finishMinutesList.length > 0 ? Math.min(...finishMinutesList) : null;
 
     const viewerRatings = completions
       .filter((c) => c.userId === viewerId && c.rating != null)
@@ -223,7 +222,7 @@ export const getCopyInstanceView = query({
 
     const stats = {
       timesCompleted: completedCompletions.length,
-      fastestFinishDays,
+      fastestFinishMinutes,
       timesLentOut: loans.length,
       yourAvgRating,
     };

--- a/packages/backend/convex/library/getPuzzleDefinitionView.ts
+++ b/packages/backend/convex/library/getPuzzleDefinitionView.ts
@@ -140,10 +140,31 @@ export const getPuzzleDefinitionView = query({
     );
 
     // --- completions of the definition (totalCompletions, avgCompletionDays) --------------------
-    const completions = await ctx.db
+    // A solve can be recorded against the puzzle DEFINITION (puzzleId) OR against a specific COPY
+    // of it (ownedPuzzleId, with no puzzleId — that's how "mark my copy complete" stores it). Count
+    // both so completing your own copy still shows in the catalogue total; dedupe by _id in case a
+    // row carries both FKs.
+    const byDefinition = await ctx.db
       .query("completions")
       .withIndex("by_puzzle", (q) => q.eq("puzzleId", args.puzzleId))
       .collect();
+    const byCopy = (
+      await Promise.all(
+        owned.map((copy) =>
+          ctx.db
+            .query("completions")
+            .withIndex("by_owned_puzzle", (q) =>
+              q.eq("ownedPuzzleId", copy._id),
+            )
+            .collect(),
+        ),
+      )
+    ).flat();
+    const dedupedCompletions = new Map<string, (typeof byDefinition)[number]>();
+    for (const c of [...byDefinition, ...byCopy]) {
+      dedupedCompletions.set(c._id as unknown as string, c);
+    }
+    const completions = [...dedupedCompletions.values()];
     const completed = completions.filter((c) => c.isCompleted);
     const finishDaysList = completed
       .map(finishDaysOf)

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -629,6 +629,9 @@ export default defineSchema({
     bio: v.optional(v.string()),
     // Who can see this profile. Optional so existing rows stay valid; absent means "public".
     visibility: v.optional(v.union(v.literal("public"), v.literal("private"))),
+    // Ordered, curated set of the member's owned copies featured on their profile shelf
+    // (sub-project ④). Optional so existing rows validate; absent/empty = uncurated (recent-6 fallback).
+    featuredCopyIds: v.optional(v.array(v.id("ownedPuzzles"))),
     updatedAt: v.number(),
   })
     .index("by_member", ["memberId"])

--- a/packages/backend/convex/social/adapters/mappers.ts
+++ b/packages/backend/convex/social/adapters/mappers.ts
@@ -41,6 +41,8 @@ export const profileToDomain = (row: Doc<"profiles">): Profile => {
     bio: row.bio,
     // Legacy rows written before visibility existed are treated as public.
     visibility: row.visibility ?? "public",
+    // Legacy rows written before shelf curation existed are treated as uncurated (empty list).
+    featuredCopyIds: (row.featuredCopyIds ?? []) as string[],
     updatedAt: new Date(row.updatedAt),
   };
   return Profile.rehydrate(state);
@@ -56,6 +58,10 @@ export const profileToRow = (profile: Profile): ProfileRow => {
     displayName: state.displayName.value,
     bio: state.bio,
     visibility: state.visibility,
+    featuredCopyIds:
+      state.featuredCopyIds.length > 0
+        ? (state.featuredCopyIds as unknown as Id<"ownedPuzzles">[])
+        : undefined,
     updatedAt: state.updatedAt.getTime(),
   };
 };

--- a/packages/backend/convex/social/arrangeShelf.ts
+++ b/packages/backend/convex/social/arrangeShelf.ts
@@ -1,0 +1,76 @@
+import { makeArrangeShelf, Profile } from "@jigswap/domain";
+import { ConvexError, v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
+import { mutation } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
+import { convexProfileRepository } from "./adapters/convexProfileRepository";
+import { profileIdGenerator } from "./adapters/idGenerators";
+import { inProcessEventPublisher } from "./adapters/inProcessEventPublisher";
+import { systemClock } from "./adapters/systemClock";
+import { toConvexError } from "./errors";
+
+// Composition root for arranging a profile's shelf: authenticate -> verify ownership of all
+// supplied copies -> wire adapters -> call the use case. The member is derived from auth.
+// WHY the create branch (mirrors setProfileVisibility): first-time curators who haven't edited
+// their profile yet still need a profile row to store featuredCopyIds on.
+export const arrangeShelf = mutation({
+  args: {
+    copyIds: v.array(v.id("ownedPuzzles")),
+  },
+  handler: async (ctx, args) => {
+    const memberId = await requireMember(ctx);
+
+    // Ownership check: every supplied copy must be owned by the calling member. Reject if any
+    // copy is owned by a different user or no longer exists (server-side enforcement).
+    for (const copyId of args.copyIds) {
+      const copy = await ctx.db.get(copyId);
+      if (!copy) {
+        throw new ConvexError({
+          code: "CopyNotFound",
+          message: `Copy ${copyId} not found`,
+        });
+      }
+      if (copy.ownerId !== (memberId as unknown as Id<"users">)) {
+        throw new ConvexError({
+          code: "NotCopyOwner",
+          message: `Copy ${copyId} is not owned by the calling member`,
+        });
+      }
+    }
+
+    const profiles = convexProfileRepository(ctx);
+    const events = inProcessEventPublisher(ctx);
+    const clock = systemClock;
+
+    // Create-on-first-use: mirror setProfileVisibility so curating a shelf before any profile
+    // edit still works.
+    const existing = await profiles.findByMember(memberId);
+    if (!existing) {
+      const account = await ctx.db.get(memberId as unknown as Id<"users">);
+      const displayName = account?.name?.trim() || "Member";
+      const created = Profile.create(profileIdGenerator.next(), memberId, {
+        displayName,
+        now: clock.now(),
+      });
+      if (created.isErr) throw toConvexError(created.error);
+      created.value.arrangeShelf(
+        args.copyIds as unknown as string[],
+        clock.now(),
+      );
+      await profiles.save(created.value);
+      await events.publish(created.value.pullEvents());
+      return;
+    }
+
+    const arrangeShelfUseCase = makeArrangeShelf({
+      profiles,
+      events,
+      clock,
+    });
+    const result = await arrangeShelfUseCase({
+      memberId,
+      copyIds: args.copyIds as unknown as string[],
+    });
+    if (result.isErr) throw toConvexError(result.error);
+  },
+});

--- a/packages/backend/convex/social/arrangeShelf.ts
+++ b/packages/backend/convex/social/arrangeShelf.ts
@@ -1,4 +1,4 @@
-import { makeArrangeShelf, Profile } from "@jigswap/domain";
+import { makeArrangeShelf, MAX_FEATURED, Profile } from "@jigswap/domain";
 import { ConvexError, v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
@@ -19,6 +19,15 @@ export const arrangeShelf = mutation({
   },
   handler: async (ctx, args) => {
     const memberId = await requireMember(ctx);
+
+    // Transport-layer guard: the domain caps to MAX_FEATURED anyway, but reject an oversized
+    // payload up front so a malformed client can't force a long ownership-check read loop.
+    if (args.copyIds.length > MAX_FEATURED) {
+      throw new ConvexError({
+        code: "TooManyCopyIds",
+        message: `At most ${MAX_FEATURED} copies can be featured`,
+      });
+    }
 
     // Ownership check: every supplied copy must be owned by the calling member. Reject if any
     // copy is owned by a different user or no longer exists (server-side enforcement).

--- a/packages/backend/convex/social/featuredShelf.ts
+++ b/packages/backend/convex/social/featuredShelf.ts
@@ -1,0 +1,51 @@
+import type { OwnedCopyView } from "@jigswap/contracts";
+import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
+import { query } from "../_generated/server";
+import { toOwnedCopyView } from "../library/mappers";
+
+// Social read: the curated, ordered set of owned copies a member has featured on their profile
+// shelf. Returns them in the stored order and skips any entry that no longer exists or is no longer
+// owned by `userId` (defensive; ownership could have changed since curation). Returns [] when
+// the member has no profile or has not curated their shelf (caller falls back to recent-6).
+export const featuredShelf = query({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args): Promise<OwnedCopyView[]> => {
+    const profile = await ctx.db
+      .query("profiles")
+      .withIndex("by_member", (q) =>
+        q.eq("memberId", args.userId as Id<"users">),
+      )
+      .unique();
+
+    if (!profile || !profile.featuredCopyIds?.length) {
+      return [];
+    }
+
+    const results: OwnedCopyView[] = [];
+
+    for (const copyId of profile.featuredCopyIds) {
+      const copy = await ctx.db.get(copyId);
+      // Skip entries that no longer exist or are no longer owned by the profile member.
+      if (!copy || copy.ownerId !== args.userId) continue;
+
+      const puzzle = await ctx.db.get(copy.puzzleId);
+
+      // Resolve cover: approved copy photo first, then puzzle box art.
+      let coverUrl: string | null = null;
+      if (copy.coverImageId) {
+        const img = await ctx.db.get(copy.coverImageId);
+        if (img && (img.moderationStatus ?? "approved") === "approved") {
+          coverUrl = await ctx.storage.getUrl(img.fileId);
+        }
+      }
+      if (!coverUrl && puzzle?.image) {
+        coverUrl = await ctx.storage.getUrl(puzzle.image);
+      }
+
+      results.push(toOwnedCopyView(copy, puzzle, { coverUrl }));
+    }
+
+    return results;
+  },
+});

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -59,30 +59,19 @@ export const createOrUpdateUser = mutation({
 // were cut over to thin driving adapters under convex/identity/* and convex/insights/getGlobalStats
 // (returning typed view DTOs from @jigswap/contracts). Only writes + internal helpers remain here.
 
-// Update user profile
+// Update the Convex-only profile fields (bio / location / preferredLanguage).
+// Username is intentionally NOT writable here: Clerk is its source of truth
+// (uniqueness + validation), mirrored into this `users` row by the user.updated
+// webhook (see updateOrCreateUser).
 export const updateUserProfile = mutation({
   args: {
     userId: v.id("users"),
     bio: v.optional(v.string()),
     location: v.optional(v.string()),
     preferredLanguage: v.optional(v.string()),
-    username: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { userId, ...updates } = args;
-
-    // Check if username is already taken (if provided)
-    if (updates.username) {
-      const existingUser = await ctx.db
-        .query("users")
-        .withIndex("by_username", (q) => q.eq("username", updates.username))
-        .unique();
-
-      if (existingUser && existingUser._id !== userId) {
-        throw new Error("Username already taken");
-      }
-    }
-
     await ctx.db.patch(userId, {
       ...updates,
       updatedAt: Date.now(),

--- a/packages/contracts/src/library/views.ts
+++ b/packages/contracts/src/library/views.ts
@@ -291,10 +291,10 @@ export interface CopyCompletionEntry {
   /** Epoch millis the completion is sorted/dated on (its `endDate`, else `startDate`). */
   occurredAt: number;
   /**
-   * How long the solve took, in whole days: `endDate - startDate` rounded to whole days when both
-   * are present, else `completionTimeMinutes / 1440` rounded, else null.
+   * How long the solve took, in whole MINUTES: `endDate - startDate` when both are present, else
+   * `completionTimeMinutes`, else null. Raw minutes so the UI can humanize (hours/days/weeks).
    */
-  finishDays: number | null;
+  finishMinutes: number | null;
   /** The 1-5 star rating, or null when unrated. */
   rating: number | null;
   /** The free-text review, or null when absent. */
@@ -330,8 +330,8 @@ export interface CopyTransferEntry {
 export interface CopyInstanceStats {
   /** Number of completed completions of this copy. */
   timesCompleted: number;
-  /** The smallest `finishDays` across completed completions, or null when none. */
-  fastestFinishDays: number | null;
+  /** The smallest `finishMinutes` across completed completions, or null when none. */
+  fastestFinishMinutes: number | null;
   /** Number of loans recorded for this copy. */
   timesLentOut: number;
   /**

--- a/packages/domain/src/social/application/ports/in/arrange-shelf.port.ts
+++ b/packages/domain/src/social/application/ports/in/arrange-shelf.port.ts
@@ -1,0 +1,18 @@
+import { Result } from "../../../../shared-kernel";
+import { SocialError } from "../../../domain";
+import { MemberId } from "../../../domain/ids";
+import { SocialApplicationError } from "../../errors";
+
+// The command to arrange a member's profile shelf: the ordered set of owned copy ids to feature.
+// `memberId` is resolved from auth by the transport adapter; `copyIds` is the client-supplied
+// ordered list (deduped and capped to MAX_FEATURED by the domain).
+export interface ArrangeShelfCommand {
+  readonly memberId: MemberId;
+  readonly copyIds: readonly string[];
+}
+
+// Inbound port: the arrange-shelf use case. Fails with ProfileNotFound when the member has no
+// profile yet.
+export type ArrangeShelf = (
+  cmd: ArrangeShelfCommand,
+) => Promise<Result<void, SocialError | SocialApplicationError>>;

--- a/packages/domain/src/social/application/ports/in/index.ts
+++ b/packages/domain/src/social/application/ports/in/index.ts
@@ -1,3 +1,4 @@
+export * from "./arrange-shelf.port";
 export * from "./edit-profile.port";
 export * from "./follow-member.port";
 export * from "./post-comment.port";

--- a/packages/domain/src/social/application/use-cases/arrange-shelf.spec.ts
+++ b/packages/domain/src/social/application/use-cases/arrange-shelf.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { toMemberId, toProfileId } from "../../../shared-kernel";
+import { Profile } from "../../domain";
+import {
+  FixedClock,
+  InMemoryProfileRepository,
+  RecordingEventPublisher,
+} from "../testing";
+import { makeArrangeShelf } from "./arrange-shelf";
+
+const alice = toMemberId("alice");
+const bob = toMemberId("bob");
+const profileId = toProfileId("profile-1");
+const NOW = new Date("2026-06-08T10:00:00Z");
+
+describe("makeArrangeShelf", () => {
+  let profiles: InMemoryProfileRepository;
+  let events: RecordingEventPublisher;
+  let arrangeShelf: ReturnType<typeof makeArrangeShelf>;
+
+  const seedProfile = async (): Promise<void> => {
+    const created = Profile.create(profileId, alice, {
+      displayName: "Alice",
+      bio: "Original",
+      now: NOW,
+    });
+    if (!created.isOk) throw new Error("setup");
+    created.value.pullEvents(); // not part of this use case's published events
+    await profiles.save(created.value);
+  };
+
+  beforeEach(() => {
+    profiles = new InMemoryProfileRepository();
+    events = new RecordingEventPublisher();
+    arrangeShelf = makeArrangeShelf({
+      profiles,
+      events,
+      clock: new FixedClock(NOW),
+    });
+  });
+
+  it("saves the ordered featuredCopyIds and publishes ProfileShelfArranged", async () => {
+    await seedProfile();
+
+    const result = await arrangeShelf({
+      memberId: alice,
+      copyIds: ["copy-1", "copy-2", "copy-3"],
+    });
+
+    expect(result.isOk).toBe(true);
+    const stored = await profiles.findByMember(alice);
+    expect(stored?.featuredCopyIds).toEqual(["copy-1", "copy-2", "copy-3"]);
+
+    expect(events.names()).toEqual(["ProfileShelfArranged"]);
+    const published = events.published[0] as unknown as {
+      copyIds: readonly string[];
+      occurredAt: Date;
+    };
+    expect(published.copyIds).toEqual(["copy-1", "copy-2", "copy-3"]);
+    expect(published.occurredAt).toEqual(NOW);
+  });
+
+  it("clears the shelf when given an empty array", async () => {
+    await seedProfile();
+
+    const result = await arrangeShelf({
+      memberId: alice,
+      copyIds: [],
+    });
+
+    expect(result.isOk).toBe(true);
+    const stored = await profiles.findByMember(alice);
+    expect(stored?.featuredCopyIds).toEqual([]);
+    expect(events.names()).toEqual(["ProfileShelfArranged"]);
+  });
+
+  it("rejects arranging a shelf for a member without a profile (ProfileNotFound)", async () => {
+    const result = await arrangeShelf({
+      memberId: bob,
+      copyIds: ["copy-1"],
+    });
+
+    expect(result.isErr).toBe(true);
+    if (result.isErr) expect(result.error.code).toBe("ProfileNotFound");
+    expect(events.published).toHaveLength(0);
+  });
+});

--- a/packages/domain/src/social/application/use-cases/arrange-shelf.ts
+++ b/packages/domain/src/social/application/use-cases/arrange-shelf.ts
@@ -1,0 +1,42 @@
+import {
+  Clock,
+  DomainEventPublisher,
+  err,
+  ok,
+  Result,
+} from "../../../shared-kernel";
+import { SocialError } from "../../domain";
+import { SocialApplicationError } from "../errors";
+import {
+  ArrangeShelf,
+  ArrangeShelfCommand,
+} from "../ports/in/arrange-shelf.port";
+import { ProfileRepository } from "../ports/out/profile.repository";
+
+export interface ArrangeShelfDeps {
+  readonly profiles: ProfileRepository;
+  readonly events: DomainEventPublisher;
+  readonly clock: Clock;
+}
+
+// Transaction script: load the member's profile (ProfileNotFound if absent), delegate the
+// shelf-arrangement to Profile.arrangeShelf, save, then publish ProfileShelfArranged. Creating
+// a profile is a separate flow; this use case only curates an existing one.
+export const makeArrangeShelf =
+  (deps: ArrangeShelfDeps): ArrangeShelf =>
+  async (
+    cmd: ArrangeShelfCommand,
+  ): Promise<Result<void, SocialError | SocialApplicationError>> => {
+    const profile = await deps.profiles.findByMember(cmd.memberId);
+    if (!profile) {
+      return err(SocialApplicationError.profileNotFound(cmd.memberId));
+    }
+
+    // arrangeShelf always succeeds — no domain validation can fail beyond type safety.
+    profile.arrangeShelf(cmd.copyIds, deps.clock.now());
+
+    await deps.profiles.save(profile);
+    await deps.events.publish(profile.pullEvents());
+
+    return ok(undefined);
+  };

--- a/packages/domain/src/social/application/use-cases/index.ts
+++ b/packages/domain/src/social/application/use-cases/index.ts
@@ -1,3 +1,4 @@
+export * from "./arrange-shelf";
 export * from "./edit-profile";
 export * from "./follow-member";
 export * from "./post-comment";

--- a/packages/domain/src/social/domain/events.ts
+++ b/packages/domain/src/social/domain/events.ts
@@ -85,10 +85,23 @@ export class PhotoCommentPosted implements DomainEvent {
   ) {}
 }
 
+// A member re-arranged their profile display shelf (the ordered, curated set of owned copies
+// shown on their profile). copyIds is the new ordered list (deduped, capped); empty clears it.
+export class ProfileShelfArranged implements DomainEvent {
+  readonly name = "ProfileShelfArranged";
+  constructor(
+    readonly profileId: ProfileId,
+    readonly memberId: MemberId,
+    readonly copyIds: readonly string[],
+    readonly occurredAt: Date,
+  ) {}
+}
+
 export type SocialDomainEvent =
   | MemberFollowed
   | MemberUnfollowed
   | ProfileUpdated
   | ProfileVisibilityChanged
   | CommentPosted
-  | PhotoCommentPosted;
+  | PhotoCommentPosted
+  | ProfileShelfArranged;

--- a/packages/domain/src/social/domain/profile.spec.ts
+++ b/packages/domain/src/social/domain/profile.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { toMemberId, toProfileId } from "../../shared-kernel";
+import type { ProfileShelfArranged } from "./events";
 import { MemberId, ProfileId } from "./ids";
 import { EditProps, Profile } from "./profile";
 
@@ -158,5 +159,66 @@ describe("Profile.changeVisibility", () => {
     profile.changeVisibility("private", LATER);
     expect(profile.displayName.value).toBe("Alice");
     expect(profile.bio).toBe("Loves 1000-piece landscapes");
+  });
+});
+
+describe("Profile.arrangeShelf", () => {
+  const LATER = new Date("2026-06-09T12:00:00Z");
+
+  const open = (): Profile => {
+    const result = Profile.create(profileId, member, editProps());
+    if (!result.isOk) throw new Error("setup");
+    result.value.pullEvents(); // discard the creation event
+    return result.value;
+  };
+
+  it("sets featuredCopyIds in the given order and records a ProfileShelfArranged event", () => {
+    const profile = open();
+    const result = profile.arrangeShelf(["a", "b", "c"], LATER);
+
+    expect(result.isOk).toBe(true);
+    expect(profile.featuredCopyIds).toEqual(["a", "b", "c"]);
+
+    const events = profile.pullEvents();
+    expect(events.map((e) => e.name)).toEqual(["ProfileShelfArranged"]);
+    const event = events[0] as unknown as ProfileShelfArranged;
+    expect(event.profileId).toBe(profileId);
+    expect(event.memberId).toBe(member);
+    expect(event.copyIds).toEqual(["a", "b", "c"]);
+    expect(event.occurredAt).toEqual(LATER);
+  });
+
+  it("de-duplicates, preserving first-occurrence order", () => {
+    const profile = open();
+    profile.arrangeShelf(["a", "b", "a"], LATER);
+    expect(profile.featuredCopyIds).toEqual(["a", "b"]);
+  });
+
+  it("caps at MAX_FEATURED (6) — an 8-item input keeps the first 6", () => {
+    const profile = open();
+    profile.arrangeShelf(["a", "b", "c", "d", "e", "f", "g", "h"], LATER);
+    expect(profile.featuredCopyIds).toEqual(["a", "b", "c", "d", "e", "f"]);
+    expect(profile.featuredCopyIds).toHaveLength(6);
+  });
+
+  it("empty array clears the shelf and still records the event", () => {
+    const profile = open();
+    profile.arrangeShelf(["a", "b"], NOW);
+    profile.pullEvents(); // discard first event
+
+    const result = profile.arrangeShelf([], LATER);
+    expect(result.isOk).toBe(true);
+    expect(profile.featuredCopyIds).toEqual([]);
+
+    const events = profile.pullEvents();
+    expect(events.map((e) => e.name)).toEqual(["ProfileShelfArranged"]);
+    const event = events[0] as unknown as ProfileShelfArranged;
+    expect(event.copyIds).toEqual([]);
+  });
+
+  it("sets updatedAt to the passed now", () => {
+    const profile = open();
+    profile.arrangeShelf(["a"], LATER);
+    expect(profile.toState().updatedAt).toEqual(LATER);
   });
 });

--- a/packages/domain/src/social/domain/profile.ts
+++ b/packages/domain/src/social/domain/profile.ts
@@ -1,8 +1,15 @@
 import { DomainEvent, err, ok, Result } from "../../shared-kernel";
 import { DisplayName } from "./display-name";
 import { SocialError } from "./errors";
-import { ProfileUpdated, ProfileVisibilityChanged } from "./events";
+import {
+  ProfileShelfArranged,
+  ProfileUpdated,
+  ProfileVisibilityChanged,
+} from "./events";
 import { MemberId, ProfileId } from "./ids";
+
+// Maximum number of copies that can be featured on the profile shelf.
+export const MAX_FEATURED = 6;
 
 // Who can see a member's profile. "public" (the default) reveals the member's identity to anyone;
 // "private" hides it from members they are not connected with. Read by other features to decide
@@ -25,6 +32,9 @@ export interface ProfileState {
   readonly displayName: DisplayName;
   readonly bio?: string;
   readonly visibility: ProfileVisibility;
+  // Ordered, curated set of owned copies featured on the profile shelf (sub-project ④).
+  // Empty means uncurated (the plank falls back to recent-6).
+  readonly featuredCopyIds: readonly string[];
   readonly updatedAt: Date;
 }
 
@@ -56,6 +66,10 @@ export class Profile {
     return this.state.visibility;
   }
 
+  get featuredCopyIds(): readonly string[] {
+    return this.state.featuredCopyIds;
+  }
+
   // Open a brand-new profile for a member. Validates the display name; an invalid one fails the
   // whole creation. Records ProfileUpdated so the initial public state propagates like any edit.
   static create(
@@ -72,6 +86,7 @@ export class Profile {
       displayName: displayName.value,
       bio: props.bio,
       visibility: "public",
+      featuredCopyIds: [],
       updatedAt: props.now,
     });
     profile.record(
@@ -128,6 +143,26 @@ export class Profile {
     return ok(undefined);
   }
 
+  // Set the curated, ordered list of owned copies featured on the profile shelf. Dedupes preserving
+  // first-occurrence order; caps at MAX_FEATURED. Empty array clears the shelf. Always succeeds —
+  // the Result shape matches changeVisibility for a uniform call site. Emits ProfileShelfArranged.
+  arrangeShelf(
+    copyIds: readonly string[],
+    now: Date,
+  ): Result<void, SocialError> {
+    const deduped = [...new Set(copyIds)].slice(0, MAX_FEATURED);
+    this.state = { ...this.state, featuredCopyIds: deduped, updatedAt: now };
+    this.record(
+      new ProfileShelfArranged(
+        this.state.id,
+        this.state.memberId,
+        deduped,
+        now,
+      ),
+    );
+    return ok(undefined);
+  }
+
   // Drain recorded events for the publisher; clears the buffer so a save can't double-emit.
   pullEvents(): readonly DomainEvent[] {
     const drained = this.events;
@@ -137,7 +172,10 @@ export class Profile {
 
   // Map to/from persistence without the aggregate knowing about any storage technology.
   static rehydrate(state: ProfileState): Profile {
-    return new Profile(state);
+    return new Profile({
+      ...state,
+      featuredCopyIds: state.featuredCopyIds ?? [],
+    });
   }
 
   toState(): ProfileState {

--- a/packages/gateway/src/operations.ts
+++ b/packages/gateway/src/operations.ts
@@ -201,6 +201,12 @@ export const gateway = {
   social: {
     editProfile: api.social.editProfile.editProfile,
     setProfileVisibility: api.social.setProfileVisibility.setProfileVisibility,
+    // Profile shelf curation: arrange the ordered set of owned copies shown on the profile plank.
+    // Only the owner can call this (server enforces ownership of every copy). featuredShelf is
+    // the read side — returns the curated copies in order, or [] when uncurated (fallback to
+    // recent-6 is the caller's responsibility).
+    arrangeShelf: api.social.arrangeShelf.arrangeShelf,
+    featuredShelf: api.social.featuredShelf.featuredShelf,
     follow: api.social.followMember.followMember,
     unfollow: api.social.unfollowMember.unfollowMember,
     profile: api.social.getProfile.getProfile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0)
+      '@react-three/rapier':
+        specifier: ^2.1.0
+        version: 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0))(react@19.2.7)(three@0.184.0)
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
@@ -1019,6 +1022,9 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@dimforge/rapier3d-compat@0.19.2':
+    resolution: {integrity: sha512-AZHL1jqUF55QJkJyU1yKeh4ImX2J93bVLIezT1+o0FZqTix6O06MOaqpKoJ4MmbDCsoZmwO+qc471/SDMDm2AA==}
 
   '@edge-runtime/primitives@6.0.0':
     resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
@@ -3099,6 +3105,13 @@ packages:
         optional: true
       react-native:
         optional: true
+
+  '@react-three/rapier@2.2.0':
+    resolution: {integrity: sha512-mVsqbKXlGZoN+XrqdhzFZUQmy8pibEOVzl4k7LC+LHe84bQnYBSagy1Hvbda6bL1PJDdTFyiDiBk5buKFinNIQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.4
+      react: ^19
+      three: '>=0.159.0'
 
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
@@ -10487,6 +10500,8 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
+  '@dimforge/rapier3d-compat@0.19.2': {}
+
   '@edge-runtime/primitives@6.0.0': {}
 
   '@edge-runtime/vm@5.0.0':
@@ -12863,6 +12878,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - immer
+
+  '@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0))(react@19.2.7)(three@0.184.0)':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.19.2
+      '@react-three/fiber': 9.6.1(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0)
+      react: 19.2.7
+      suspend-react: 0.1.3(react@19.2.7)
+      three: 0.184.0
+      three-stdlib: 2.36.1(three@0.184.0)
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
Addresses the mobile/3D-plank punch list, decomposed into five independently-reviewed sub-projects (each with a committed spec + plan under `docs/superpowers/`). Built on top of the merged photo-lightbox work; this PR's diff is only the new work.

## What's in here

**① Quick polish**
- Mobile bottom tab bar is icons-only (label moved to `aria-label`).
- Landing-page planks scale to fit (`FitToWidth`) — fixes horizontal scroll on phones.

**② Mobile native scroll + dashboard declutter**
- Below `md`, the app scrolls at the **document level** so the browser address bar collapses; sticky mobile top bar, fixed bottom tab bar. Desktop inset-card shell unchanged.
- Mobile dashboard de-emphasised: smaller hero, tighter rhythm, shorter plank, condensed pulse.

**③ 3D plank for real collections**
- Dashboard + profile shelves render the member's real puzzles as a contained WebGL 3D plank (`PuzzlePlank3D`), reusing the marketing box renderer. CSS plank remains the SSR/no-WebGL/error fallback.

**④ Profile shelf curation ("highlight")**
- Members pick + order up to 6 owned puzzles to feature on their profile (full DDD: domain `Profile.arrangeShelf` + event, `profiles.featuredCopyIds`, Convex `arrangeShelf`/`featuredShelf` with **server-side ownership enforcement**, gateway, accessible no-DnD editor). Uncurated profiles fall back to recent-6.

**⑤ Rigid-body physics on the profile plank**
- Opt-in Rapier layer: boxes rest under gravity, collide, and can be grabbed/dragged/thrown (mouse + touch). Isolated so reduced-motion / no-WebGL / any physics error degrades to the static shelf → CSS plank. Dashboard plank stays static.

## Verification

- ✅ Type-check clean; web pure-logic tests (15) green; **domain 1004** + **backend 323** tests green (incl. new `arrangeShelf` ownership cases).
- ✅ Each sub-project got an independent review; fixes folded in (about-page scaling, tab-bar clearance, memoised box arrays, copy-id cap, and a blocking `intersectPlane` guard + `pointercancel` scroll-lock fix in the drag hook).
- ⚠️ **Not verifiable in CI / needs a real device:** the 3D shelves rendering (③) and the physics *feel* (⑤ — settle/jitter, drag-throw, touch-vs-scroll, mobile perf). Damping/restitution/throw-cap are starting estimates; **expect a tuning pass**. Fallbacks guarantee these can't break the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
