### PR TITLE
docs + security/quality fixes from multi-agent analysis

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1790,6 +1790,7 @@
     "description": "How this copy has changed hands over time.",
     "originalOwner": "Original owner",
     "currentOwner": "Current owner",
+    "anonymous": "Anonymous user",
     "transferredVia": "Transferred via exchange {exchangeId}",
     "noTransfers": "This copy has never been transferred.",
     "loading": "Loading custody timeline..."

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1816,6 +1816,7 @@
     "statusRecalled": "Recalled",
     "borrowedBy": "Borrowed by {name}",
     "unknownMember": "Unknown member",
+    "anonymousMember": "Anonymous user",
     "borrowedCount": "{count, plural, one {# borrowed puzzle} other {# borrowed puzzles}}",
     "pieceCount": "{count, plural, one {# piece} other {# pieces}}"
   },

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1790,6 +1790,7 @@
     "description": "Hoe dit exemplaar in de loop van de tijd van eigenaar is gewisseld.",
     "originalOwner": "Oorspronkelijke eigenaar",
     "currentOwner": "Huidige eigenaar",
+    "anonymous": "Anonieme gebruiker",
     "transferredVia": "Overgedragen via ruil {exchangeId}",
     "noTransfers": "Dit exemplaar is nooit overgedragen.",
     "loading": "Eigendomsketen laden..."

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1816,6 +1816,7 @@
     "statusRecalled": "Teruggevraagd",
     "borrowedBy": "Geleend door {name}",
     "unknownMember": "Onbekend lid",
+    "anonymousMember": "Anonieme gebruiker",
     "borrowedCount": "{count, plural, one {# geleende puzzel} other {# geleende puzzels}}",
     "pieceCount": "{count, plural, one {# stuk} other {# stukken}}"
   },

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1790,6 +1790,7 @@
     "description": "How this copy has changed hands over time.",
     "originalOwner": "Original owner",
     "currentOwner": "Current owner",
+    "anonymous": "Anonymous user",
     "transferredVia": "Transferred via exchange {exchangeId}",
     "noTransfers": "This copy has never been transferred.",
     "loading": "Loading custody timeline..."

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1816,6 +1816,7 @@
     "statusRecalled": "Recalled",
     "borrowedBy": "Borrowed by {name}",
     "unknownMember": "Unknown member",
+    "anonymousMember": "Anonymous user",
     "borrowedCount": "{count, plural, one {# borrowed puzzle} other {# borrowed puzzles}}",
     "pieceCount": "{count, plural, one {# piece} other {# pieces}}"
   },

--- a/apps/web/src/components/dashboard-home/briefing-hero.tsx
+++ b/apps/web/src/components/dashboard-home/briefing-hero.tsx
@@ -4,7 +4,7 @@ import { Link } from "@/compat/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { gateway, Id } from "@/gateway";
+import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
 import { useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
@@ -196,7 +196,7 @@ export function BriefingHero() {
 
   const exchanges = useQuery(
     gateway.exchange.forUser,
-    member?._id ? { userId: member._id as Id<"users"> } : "skip",
+    member?._id ? {} : "skip",
   );
   const goals = useQuery(gateway.solving.myGoals, member?._id ? {} : "skip");
 

--- a/apps/web/src/components/dashboard-home/pulse-section.tsx
+++ b/apps/web/src/components/dashboard-home/pulse-section.tsx
@@ -399,7 +399,7 @@ export function PulseSection() {
 
   const exchanges = useQuery(
     gateway.exchange.forUser,
-    member?._id ? { userId: member._id as Id<"users"> } : "skip",
+    member?._id ? {} : "skip",
   );
   const goals = useQuery(gateway.solving.myGoals, member?._id ? {} : "skip");
   const feed = useQuery(

--- a/apps/web/src/components/dashboard-home/shelf-section.tsx
+++ b/apps/web/src/components/dashboard-home/shelf-section.tsx
@@ -107,7 +107,7 @@ export function ShelfSection() {
   );
   const exchanges = useQuery(
     gateway.exchange.forUser,
-    member?._id ? { userId: member._id as Id<"users"> } : "skip",
+    member?._id ? {} : "skip",
   );
 
   // Memoized so the 3D plank's color-resolution effect doesn't re-run on every

--- a/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
@@ -10,7 +10,7 @@
 import { Link } from "@/compat/link";
 import { usePathname } from "@/compat/navigation";
 import { useCurrentMember } from "@/components/dashboard-home/use-current-member";
-import { gateway, Id } from "@/gateway";
+import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
 import { useQuery } from "convex/react";
 import {
@@ -62,7 +62,7 @@ export function MobileTabBar() {
   const { member } = useCurrentMember();
   const exchanges = useQuery(
     gateway.exchange.forUser,
-    member?._id ? { userId: member._id as Id<"users"> } : "skip",
+    member?._id ? {} : "skip",
   );
   const pending = (exchanges ?? []).filter(
     (exchange) =>

--- a/apps/web/src/components/details/puzzle-detail/custody-timeline.tsx
+++ b/apps/web/src/components/details/puzzle-detail/custody-timeline.tsx
@@ -3,12 +3,19 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { gateway, Id } from "@/gateway";
 import { useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
 import { ArrowRight, History, User } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 interface CustodyTimelineProps {
   copyId: Id<"ownedPuzzles">;
 }
+
+// The web tier derives Convex view types from the gateway (not @jigswap/contracts directly).
+type CustodyTimelineView = NonNullable<
+  FunctionReturnType<typeof gateway.custody.timeline>
+>;
+type ProjectedMember = CustodyTimelineView["currentOwner"];
 
 // Chain-of-Custody panel on the owned-copy detail: renders the Copy's provenance (original owner ->
 // each settled transfer -> current owner) from the custody read-model via the gateway.
@@ -34,7 +41,10 @@ export function CustodyTimeline({ copyId }: CustodyTimelineProps) {
 
   if (timeline === null) return null;
 
-  const ownerName = (name: string | undefined | null): string => name ?? "—";
+  // Render a privacy-projected member's name: a revealed member shows their name; an anonymised one
+  // shows the "Anonymous user" label — never a real name.
+  const ownerName = (member: ProjectedMember): string =>
+    member.anonymous ? t("anonymous") : member.member.name;
 
   return (
     <Card>
@@ -52,7 +62,7 @@ export function CustodyTimeline({ copyId }: CustodyTimelineProps) {
           <div>
             <p className="text-sm font-medium">{t("originalOwner")}</p>
             <p className="text-sm text-muted-foreground">
-              {ownerName(timeline.originalOwner?.name)}
+              {ownerName(timeline.originalOwner)}
             </p>
           </div>
         </div>
@@ -67,7 +77,7 @@ export function CustodyTimeline({ copyId }: CustodyTimelineProps) {
                 <ArrowRight className="h-4 w-4 mt-0.5 text-muted-foreground" />
                 <div>
                   <p className="text-sm font-medium">
-                    {ownerName(transfer.newOwner?.name)}
+                    {ownerName(transfer.newOwner)}
                   </p>
                   <p className="text-xs text-muted-foreground">
                     {t("transferredVia", { exchangeId: transfer.exchangeId })}
@@ -87,7 +97,7 @@ export function CustodyTimeline({ copyId }: CustodyTimelineProps) {
           <div>
             <p className="text-sm font-medium">{t("currentOwner")}</p>
             <p className="text-sm text-muted-foreground">
-              {ownerName(timeline.currentOwner?.name)}
+              {ownerName(timeline.currentOwner)}
             </p>
           </div>
         </div>

--- a/apps/web/src/components/details/puzzle-detail/loan-history.tsx
+++ b/apps/web/src/components/details/puzzle-detail/loan-history.tsx
@@ -70,7 +70,9 @@ export function LoanHistory({ copyId }: LoanHistoryProps) {
                   <div className="flex items-center gap-2">
                     <p className="text-sm font-medium">
                       {t("borrowedBy", {
-                        name: loan.borrower?.name ?? t("unknownMember"),
+                        name: loan.borrower.anonymous
+                          ? t("anonymousMember")
+                          : loan.borrower.member.name,
                       })}
                     </p>
                     <Badge

--- a/apps/web/src/components/profile/edit-profile-form.tsx
+++ b/apps/web/src/components/profile/edit-profile-form.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { gateway, Id } from "@/gateway";
+import { gateway } from "@/gateway";
 import { useMutation, useQuery } from "convex/react";
 import { Save } from "lucide-react";
 import { useState } from "react";
@@ -77,7 +77,6 @@ export function EditProfileForm({
       }
       // Location/bio live only in Convex.
       await updateProfile({
-        userId: member._id as Id<"users">,
         location: location.trim() || undefined,
         bio: bio.trim() || undefined,
       });

--- a/apps/web/src/components/profile/stats-section.tsx
+++ b/apps/web/src/components/profile/stats-section.tsx
@@ -35,6 +35,11 @@ export function ProfileStatsSection({ member }: { member: Member }) {
       </div>
     );
   }
+  // A private, non-mutual member's stats are hidden server-side (null). Degrade
+  // gracefully — render no stats rather than crashing on a missing card.
+  if (stats === null) {
+    return null;
+  }
 
   const items = [
     { value: stats.puzzlesOwned, label: t("puzzlesOwned") },

--- a/apps/web/src/components/social/member-tile.tsx
+++ b/apps/web/src/components/social/member-tile.tsx
@@ -71,7 +71,7 @@ export function MemberTile({
         <div className="text-muted-foreground mt-2 flex items-center gap-3 text-xs">
           {stats === undefined ? (
             <Skeleton className="h-3 w-32" />
-          ) : (
+          ) : stats === null ? null : (
             <>
               <span>
                 <strong className="text-foreground">

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -127,7 +127,7 @@ function RootComponent() {
     <ClerkProvider localization={intl.locale === "nl" ? nlNL : enUS}>
       <ConvexProviderWithClerk client={context.convexClient} useAuth={useAuth}>
         <AuthCacheSync />
-        <RootDocument>
+        <RootDocument locale={intl.locale}>
           <Providers locale={intl.locale} messages={intl.messages}>
             <ErrorBoundary>
               <Outlet />
@@ -155,9 +155,18 @@ function AuthCacheSync() {
   return null;
 }
 
-function RootDocument({ children }: { children: React.ReactNode }) {
+// `locale` is threaded from the resolved intl context so <html lang> matches the
+// active language (nl/en) for screen readers, browser translation, hyphenation and
+// SEO. The errorComponent path has no resolved intl context, so it falls back to "en".
+function RootDocument({
+  children,
+  locale = "en",
+}: {
+  children: React.ReactNode;
+  locale?: string;
+}) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,340 @@
+# JigSwap Developer Guide
+
+A guide for contributors working on JigSwap — a personal puzzle library and exchange platform. It covers the architecture, local setup, how data flows end to end, project conventions, and concrete "how to" recipes for the most common changes.
+
+> **Read this alongside the specs.** The canonical design intent lives in [`spec/`](../spec). In particular:
+>
+> - [`spec/architecture/README.md`](../spec/architecture/README.md) — the four decisions that shape the architecture.
+> - [`spec/architecture/01-bounded-contexts.md`](../spec/architecture/01-bounded-contexts.md) — bounded contexts, ubiquitous language, the context map.
+> - [`spec/architecture/02-hexagonal-architecture.md`](../spec/architecture/02-hexagonal-architecture.md) — ports/adapters layout, dependency injection, domain events.
+> - [`spec/architecture/03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md) — the TanStack Start BFF and the gateway seam.
+> - [`spec/architecture/04-migration-roadmap.md`](../spec/architecture/04-migration-roadmap.md) — the strangler-fig migration from Next.js/entity-driven to TanStack Start/DDD.
+> - [`spec/features/`](../spec/features) — per-feature intent.
+> - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow, commit style, PR process.
+
+> **Heads-up on stale docs.** `README.md` and `CONTRIBUTING.md` still describe the **pre-migration** Next.js setup (App Router, `next-intl`, port 3000, `pnpm convex:dev` from `packages/backend`). The architecture proposal has since been adopted: the web app is now **TanStack Start** (Vite, `use-intl`, file-based routing) and the backend is organised by **bounded context** with a **hexagonal/DDD** domain layer. When the README and the code disagree, trust the code. This guide reflects the current code.
+
+---
+
+## 1. Architecture overview
+
+JigSwap is a **pnpm + Nx monorepo** with a strict layering: a framework-agnostic **DDD domain layer**, a **contracts** package that owns the wire shapes, a **gateway** seam that is the single import point for the Convex API, a **Convex backend** that wires domain logic to persistence via ports/adapters, and a **TanStack Start** web app that consumes everything reactively.
+
+### 1.1 Monorepo layout (pnpm workspaces + Nx)
+
+```
+jigswap/
+├── apps/
+│   └── web/                 # @jigswap/web — TanStack Start (SSR React) app
+├── packages/
+│   ├── domain/              # @jigswap/domain — pure DDD/hexagonal domain layer
+│   ├── contracts/           # @jigswap/contracts — view DTOs + Zod input schemas
+│   ├── gateway/             # @jigswap/gateway — the single Convex-API import seam
+│   └── backend/             # @jigswap/backend — Convex functions, schema, adapters
+├── spec/                    # architecture + feature specifications
+├── package.json             # root scripts (Nx run-many targets)
+├── nx.json / project.json   # Nx config + per-project targets
+└── pnpm-workspace.yaml      # workspace globs + dependency pins/overrides
+```
+
+- **pnpm** (pinned via `packageManager` in the root `package.json`) is the package manager. Workspace packages link to each other with `workspace:^` and `linkWorkspacePackages: true`.
+- **Nx** orchestrates tasks. Root scripts are `nx run-many` wrappers (`dev`, `build`, `lint`, `type-check`, `test`). Use `pnpm graph` to view the dependency graph and `pnpm affected` to target only changed projects.
+- **Dependency pins** live in `pnpm-workspace.yaml` `overrides` (notably `zod`, `eslint-plugin-react-hooks`) — read the comments there before bumping them; several pins exist to keep type-checking and lint green.
+
+### 1.2 The dependency direction (hexagonal / DDD)
+
+The whole point of the layering is that **dependencies point inward toward the domain**, and the domain depends on nothing external:
+
+```
+            apps/web  (TanStack Start UI — no domain logic, no Convex import)
+                │  imports @/gateway
+                ▼
+        packages/gateway  (the ONLY importer of convex/_generated/api)
+                │
+                ▼
+       packages/backend/convex  (Convex functions = driving adapters)
+                │  composes use cases, injects port implementations (driven adapters)
+                ▼
+         packages/domain  (pure aggregates, use cases, ports — no I/O)
+                ▲
+                │  defines wire shapes used by backend handler return types
+        packages/contracts  (view DTOs + Zod input schemas, Convex-free)
+```
+
+Key invariants enforced at the module/TypeScript level (and by `pnpm arch:check`, a `dependency-cruiser` run over `packages/domain/src`):
+
+- `packages/domain` imports **nothing** from Convex, Clerk, or any I/O framework. All external concerns are interfaces (`ports`).
+- Bounded contexts in `packages/domain` **never import each other** — cross-context data flows through an **anti-corruption layer (ACL)** port.
+- The web app **never** imports `@jigswap/backend` or `@jigswap/contracts` directly — only `@/gateway`.
+- Only `packages/gateway/src/operations.ts` imports `@jigswap/backend/convex/_generated/api`.
+
+### 1.3 The domain layer (`packages/domain`)
+
+Twelve **bounded contexts** plus a `shared-kernel`:
+
+`catalog`, `conversation`, `exchange`, `identity`, `insights`, `library`, `notifications`, `reputation`, `sharing`, `social`, `solving`, and `shared-kernel`.
+
+Each context (except `insights`, see below) follows the same internal structure:
+
+```
+packages/domain/src/<context>/
+├── domain/                  # aggregates, value objects, events, errors, ids
+└── application/
+    ├── use-cases/           # makeXxx(deps) factory functions + *.spec.ts tests
+    ├── ports/in/            # inbound command/port interfaces
+    ├── ports/out/           # outbound repository/service interfaces (the ACL seams)
+    └── testing/             # in-memory adapters: FixedClock, repos, RecordingEventPublisher
+```
+
+**The aggregate pattern.** Every aggregate has exactly four public surface points:
+
+1. A `static` named constructor (`submit` / `register` / `propose` / `acquire` / `open` / `create`) returning `Result<Aggregate, DomainError>`.
+2. `static rehydrate(state)` for loading from persistence.
+3. `toState()` for saving back.
+4. `pullEvents(): readonly DomainEvent[]` to drain recorded events.
+
+Use cases always do `save(aggregate)` **then** `events.publish(aggregate.pullEvents())`.
+
+**The shared-kernel** (`packages/domain/src/shared-kernel`) provides five building blocks used everywhere: branded `Id<TBrand>` (+ central `branded-ids.ts` constructors like `toCopyId`, `toMemberId`); `Result<T,E>` (`ok`/`err`/`isOk`/`isErr`) instead of exceptions; `DomainEvent` + `DomainEventPublisher`; a `Clock` interface (deterministic tests); and `DomainError`.
+
+**The `insights` outlier.** `insights` has **no aggregates and no application layer** — it is purely a set of total, deterministic projection functions (`computePersonalStats`, `computeCollectionBreakdown`, `computeCompletionTrends`, `recommendPuzzles`, `computeTradeActivity`) over plain DTO inputs. Do not add use-case or port files there.
+
+**Cross-context ACLs.** Library holds a `CatalogSnapshot` value object (denormalised Catalog data) and gets it through the `CatalogSnapshotProvider` outbound port — the only seam where Library touches Catalog. Exchange reads copy availability through `CopyPort` (a read-only `CopyView`), never importing Library's aggregate. Notifications translates upstream events into its own `NOTIFICATION_TYPES` literals so it never imports another context's event class.
+
+### 1.4 Contracts (`packages/contracts`)
+
+A zero-runtime-dependency (except Zod) package owning **every view DTO and input schema that crosses the frontend/backend seam**, organised by bounded context. Most DTOs are plain TypeScript interfaces; a handful (`paginationInput`, `ExchangeStatsView`, `MemberStatsView`, `GlobalStatsView`) are Zod schemas exporting inferred types. New shapes should be **plain interfaces** unless runtime validation is needed.
+
+- Convex-free by design: IDs are plain `string` (`DocId = string`) even though Convex uses branded `Id<T>` at runtime; assignability works both ways.
+- **No build step**: `main`/`types` point at `./src/index.ts`, so `tsc` processes it inside each consumer.
+- The web app **never imports `@jigswap/contracts`**. Contract types reach the frontend by structural inference: backend handlers annotate their return type as the contract interface, and the web app derives local types with `FunctionReturnType<typeof gateway.foo.bar>`.
+
+### 1.5 Gateway / BFF boundary (`packages/gateway` + `apps/web/src/gateway`)
+
+`packages/gateway/src/operations.ts` is a one-file facade exporting a single `gateway` object that maps every Convex function reference into bounded-context namespaces (`gateway.catalog.*`, `gateway.library.*`, `gateway.exchange.*`, …). It is the **only** file allowed to import `@jigswap/backend/convex/_generated/api`. `packages/gateway/src/types.ts` re-exports Convex `Doc` and `Id` so nothing else touches `_generated/dataModel`.
+
+`apps/web/src/gateway/index.ts` is a thin shim re-exporting `@jigswap/gateway` under the `@/gateway` alias (a migration convenience). All web code imports from `@/gateway`.
+
+> Per [`spec/architecture/03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md) §3.3, the BFF pattern also allows `createServerFn().validator(<zod schema from contracts>)` for SSR server functions — shape validation only, no business rules. Most reads/writes currently go through reactive Convex calls directly.
+
+### 1.6 Convex backend (`packages/backend/convex`)
+
+A hexagonal-architecture monolith on the Convex platform. Each bounded context exposes its public API as thin query/mutation/action files (**driving adapters**) that compose domain use cases from `packages/domain` and inject port implementations from `<context>/adapters/` (**driven adapters**, factory functions closing over the Convex `ctx`).
+
+- **Schema** (`convex/schema.ts`) is the single source of persistence truth (25 tables). Aggregate-managed tables carry an optional `aggregateId` column + a `by_aggregate_id` index.
+- **Auth** is Clerk. `convex/auth.config.ts` trusts the Clerk frontend API; every auth-gated function calls `requireMember(ctx)` (`identity/requireMember.ts`), which resolves the Clerk JWT subject → `users` row → typed `MemberId`. The **only** unauthenticated inbound surface is the Clerk webhook at `POST /clerk-users-webhook` (`http.ts`) plus a couple of explicitly public reads (`insights/getGlobalStats`, `contact/submitContactMessage`).
+- **Domain events** are the connective tissue. `events/makeEventPublisher.ts` runs a context's critical _same-transaction_ sync handlers, then `recordAndSchedule` appends each event to the durable `domainEvents` table and schedules `events/dispatch.ts` via `ctx.scheduler.runAfter(0)`. `dispatch` fans each event to async subscribers (Notifications, Custody, Library ownership/loan reactions) and is idempotent (stamps `processedAt`).
+- **Dual-tier coexistence.** A legacy table-driven layer (`users.ts`, `exchanges.ts`, `adminCategories.ts`) coexists with the DDD layer in the same tables. Rule: if `aggregateId` is set, the domain path owns the row; otherwise the legacy path does. Never assume `aggregateId` is present.
+- **Node actions** (files with `'use node';`) run in Convex's Node runtime for `web-push` (VAPID), `jimp` image re-encoding, and the Hugging Face moderation call. They cannot touch `ctx.db`; they use `ctx.runQuery`/`ctx.runMutation`.
+
+### 1.7 Web app (`apps/web`)
+
+TanStack Start (SSR React on Vite), migrated from Next.js. File-based routing under `apps/web/src/routes/`. Three layout groups: the root `__root.tsx` (bootstraps Clerk auth, Convex, i18n); a pathless `_dashboard` layout (auth-gated app shell); and a pathless `_public` layout (marketing). `/admin` is a role-gated path layout.
+
+- **Data**: exclusively Convex reactive client (`useQuery`/`useMutation`/`useAction` from `convex/react`) via `@/gateway`. SSR auth is bootstrapped in the root `beforeLoad` (`fetchClerkAuth` injects a Convex JWT into the SSR HTTP client); `ConvexProviderWithClerk` refreshes tokens on the client.
+- **Shell**: `components/dashboard-layout/shell.tsx` is a console-style inset layout. Navigation IA + per-route metadata live in a single file, `components/dashboard-layout/route-meta.ts` (`ROUTE_META` + `NAV_GROUPS`). Leaf routes publish title/breadcrumbs/actions via `usePageHeader`/`usePageHeaderActions` rather than rendering their own `<h1>`.
+- **i18n**: `use-intl` with `en`/`nl` JSON catalogs. Locale is detected server-side from the `jigswap-intl` cookie (`apps/web/src/lib/i18n.ts`).
+- **Compat shims** (`apps/web/src/compat/clerk.tsx`, `link.tsx`, `navigation.ts`) preserve Next.js API surfaces during the migration. New code should use TanStack Router APIs directly.
+
+---
+
+## 2. Local setup & key scripts
+
+### Prerequisites
+
+- Node.js (see `.nvmrc`; run `nvm use`).
+- pnpm — use the version pinned in the root `package.json` `packageManager` field (`corepack enable` will honour it).
+- A Clerk account and a Convex account/deployment.
+
+### Setup
+
+```bash
+git clone https://github.com/SanderVerkuil/jigswap.git
+cd jigswap
+pnpm install
+```
+
+Create `apps/web/.env.local`. Required keys (note the framework migration kept the `NEXT_PUBLIC_` prefixes that Convex/Clerk read; verify against `apps/web/.env.example` if present):
+
+```env
+# Convex
+CONVEX_DEPLOYMENT=dev:your-deployment
+NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
+
+# Clerk
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_CLERK_FRONTEND_API_URL=https://your-clerk-frontend.clerk.accounts.dev
+```
+
+The Convex deployment must have a JWT template named `convex` (the SSR bootstrap requests this template), and the Clerk webhook (`/clerk-users-webhook`) must be configured to keep `users` rows in sync.
+
+### Running
+
+Run the backend and the web app in two terminals:
+
+```bash
+# Terminal 1 — Convex backend (watches packages/backend/convex, regenerates _generated/)
+pnpm --filter @jigswap/backend convex:dev
+
+# Terminal 2 — web app (Vite dev server)
+pnpm dev
+```
+
+The dev server runs on **`http://localhost:3001`** (Vite). The old README still says 3000 — that was the Next.js era.
+
+### Key scripts (root)
+
+| Script                              | What it does                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| `pnpm dev`                          | Start the web app (`nx dev web`, Vite).                                  |
+| `pnpm build` / `pnpm build:web`     | Build all projects / just the web app.                                   |
+| `pnpm lint` / `pnpm lint:fix`       | ESLint across projects (`run-many`).                                     |
+| `pnpm type-check`                   | `tsc --noEmit` across projects.                                          |
+| `pnpm test`                         | Vitest across projects.                                                  |
+| `pnpm format` / `pnpm format:check` | Prettier write / check (CI runs `format:check` first).                   |
+| `pnpm arch:check`                   | `dependency-cruiser` over `packages/domain/src` — enforces the layering. |
+| `pnpm mutation:domain`              | Stryker mutation testing of the domain layer.                            |
+| `pnpm graph` / `pnpm affected`      | Nx dependency graph / affected-only tasks.                               |
+
+Backend-specific: `pnpm --filter @jigswap/backend convex:dev` (dev + codegen) and `convex:deploy` (prod).
+
+---
+
+## 3. Request / data flow, end to end
+
+**SSR auth bootstrap.** Browser → TanStack Start server → `__root.tsx` `beforeLoad` calls `fetchClerkAuth` (server fn) → Clerk `auth()` returns `{ userId, token }` (a `convex` JWT template token) → the token is injected into the Convex SSR HTTP client → SSR queries run authenticated → context is dehydrated to the client → `clientAuthCache` is seeded on hydration so subsequent client navigations skip the server fetch.
+
+**Reactive read.** A route calls `useQuery(gateway.<context>.<fn>, args)` → `ConvexProviderWithClerk` keeps a live WebSocket open → Convex re-runs the query whenever underlying tables change → React re-renders. No manual invalidation for data on the same client. Pass `"skip"` as the args to defer a query until preconditions are met.
+
+**Read through the backend.** The Convex handler resolves rows + storage URLs, calls a pure `mappers.ts` row→DTO function (typed against the `@jigswap/contracts` interface, enforced by `tsc`), and returns the DTO. For copy timelines, every surfaced member id is passed through `social/privacy.ts → projectMemberIdentity` (the privacy chokepoint), which reveals identity only for self / public-profile / mutual-follower and otherwise emits an opaque salted `anonRef`. Hidden identities never cross the wire.
+
+**Type propagation.** Backend handler declares `Promise<SomeView | null>` → `gateway` exposes the reference → the web app derives its local type via `FunctionReturnType<typeof gateway.<context>.<fn>>`. Contract types flow to the frontend purely by inference; the web app never imports `@jigswap/contracts`.
+
+**Write (mutation).** A component calls `useMutation(gateway.<context>.<fn>)` and invokes it with args → the Convex mutation runs `requireMember(ctx)`, composes the domain use case (e.g. `makeProposeExchange`) with injected adapters, persists, then publishes domain events. Sync handlers run in the same transaction (e.g. Exchange marks a copy unavailable on settlement); async subscribers run via the scheduled `dispatch` mutation (e.g. Notifications writes a notification; Custody records a chain-of-custody entry; Library transfers ownership / opens a loan). Affected reactive `useQuery` subscriptions re-deliver automatically.
+
+**Worked example — exchange settlement.** Second `confirmCompletion` → `makeConfirmCompletion` detects dual confirmation → emits `OwnershipTransferred` (swap/sale) or `PossessionTransferred` (lend) → sync handler marks the copy unavailable in the same transaction → `recordAndSchedule` persists events + schedules `dispatch` → dispatch runs: (1) `custody/subscriber` records the pre-transfer owner, (2) `library/transferOnSettlement` flips `ownerId`, (3) `library/openLoanOnSettlement` opens a `loans` row for lends, (4) `notifications/subscriber` notifies both parties → Reputation now allows a `PartnerReview`.
+
+---
+
+## 4. Conventions
+
+### Testing
+
+- **Domain unit tests**: `*.spec.ts` colocated in `packages/domain` (typically `application/use-cases/*.spec.ts`). Use the in-memory `testing/` harness for each context — `FixedClock`, `SequentialIdGenerator`, `InMemory*Repository`, `RecordingEventPublisher` — **no mocking framework**. This is the canonical pattern.
+- **Backend integration tests**: `*.test.ts` at the `packages/backend/convex/` root.
+- **Web tests**: `*.test.ts` (e.g. `humanize-duration.test.ts`, `puzzle-import/draft-to-form-defaults.test.ts`).
+- Run with `pnpm test` (Vitest). Mutation-test the domain with `pnpm mutation:domain`.
+- `apps/web/src/routeTree.gen.ts` is generated and produces expected `tsc` noise — ignore it.
+
+### Prettier / lint
+
+- **Prettier must be run before committing** — CI runs `format:check` first and fails fast (before type-check). Format changed files: `pnpm format` (or scope it). `prettier-plugin-organize-imports` is active.
+- Lint with `pnpm lint` / fix with `pnpm lint:fix`. Keep `nx lint @jigswap/web` at 0 errors; some `pnpm-workspace.yaml` pins exist specifically to keep lint green — don't bump them casually.
+- `pnpm arch:check` must pass: it enforces the domain-layer dependency rules (no cross-context imports, no I/O imports).
+
+### Commit & PR style
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>` — `feat`, `fix`, `docs`, `style`, `refactor`, `chore`). Branch off `main` with a descriptive name (`feat/...`, `fix/...`), run `pnpm lint:fix` + Prettier, open a PR against `main` and fill out the template. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+### Codegen (Convex)
+
+After adding/renaming a Convex function or table, run `pnpm --filter @jigswap/backend convex:dev` to regenerate `convex/_generated/` (`api.js`, `api.d.ts`, `dataModel.d.ts`, `server.d.ts`). **In a worktree without a live deployment, hand-edit `packages/backend/convex/_generated/api.d.ts`** to declare the new function — the gateway cannot reference a function the generated API type doesn't know about. Never hand-edit `_generated/` in the main repo (it's regenerated). Never hand-edit `dataModel.d.ts` (derived from `schema.ts`).
+
+---
+
+## 5. How-to recipes
+
+### 5.1 Add a feature end to end (read path)
+
+Adding a new read that surfaces in the UI touches four packages, in dependency order:
+
+1. **Contract** — add the view interface in `packages/contracts/src/<context>/views.ts` (plain interface unless runtime validation is needed). Ensure it's re-exported from the context `index.ts`.
+2. **Backend mapper** — add a pure row→DTO function in `packages/backend/convex/<context>/mappers.ts`, typed against the contract.
+3. **Backend query** — create `packages/backend/convex/<context>/myQuery.ts` exporting a `query`/`mutation` from `../_generated/server`; auth-gate with `await requireMember(ctx)`; annotate the handler return type as `Promise<MyView | null>` so `tsc` enforces the mapper. Resolve all rows/URLs in the handler, then call the mapper (mappers stay pure/async-free).
+4. **Codegen** — run `convex:dev` (or hand-edit `_generated/api.d.ts` in a worktree).
+5. **Gateway** — add `myOp: api.<context>.myQuery.myQuery` to the right namespace in `packages/gateway/src/operations.ts`.
+6. **Web** — call `useQuery(gateway.<context>.myOp, args)` and derive types via `FunctionReturnType<typeof gateway.<context>.myOp>`. Pass `"skip"` until preconditions hold.
+
+For a write, skip the DTO unless the mutation returns a view; in the backend mutation, compose the relevant domain use case with injected adapters and publish events (see §5.4). Web side: `useMutation(gateway.<context>.myMutation)`.
+
+### 5.2 Add a bounded context
+
+Domain side (`packages/domain/src/<context>/`):
+
+1. Create `domain/{aggregate.ts, ids.ts, events.ts, errors.ts, index.ts}` and `application/{use-cases/, ports/{in/,out/}, testing/, index.ts}`.
+2. Implement aggregates with the static-factory + `rehydrate` + `toState` + `pullEvents` pattern, returning `Result<...>`.
+3. Declare branded IDs in `domain/ids.ts` **and** add constructors to `shared-kernel/branded-ids.ts`.
+4. Write outbound port interfaces for any repository/external service; for cross-context data add an ACL port (never import another context's aggregate).
+5. Implement in-memory adapters in `testing/` for all outbound ports; write `*.spec.ts` use-case tests.
+6. Re-export from the context `index.ts`.
+
+Contracts side: add `packages/contracts/src/<context>/{views.ts,index.ts}` and `export * from "./<context>"` in `packages/contracts/src/index.ts`.
+
+Backend side: create `packages/backend/convex/<context>/` with `adapters/` (repositories, an `inProcessEventPublisher` if it needs sync reactions, a system clock, id generators), one file per use case, an `errors.ts` mapping domain errors to `ConvexError`, and a `subscriber.ts` if it reacts to foreign events (register it in `events/dispatch.ts`). Add any new tables to `schema.ts` with `by_aggregate_id` indexes, then run codegen.
+
+Gateway side: add a new top-level namespace key to the `gateway` object in `packages/gateway/src/operations.ts`.
+
+### 5.3 Add a contract + gateway operation
+
+1. **Contract**: `packages/contracts/src/<context>/views.ts` — interface (or Zod schema + inferred type if validated). Re-export via the context `index.ts`. No build step; consumers pick it up by type reference.
+2. **Backend**: mapper in `mappers.ts` + a query/mutation with the contract as its annotated return type.
+3. **Codegen** then **gateway**: `myOp: api.<context>.<file>.<fn>` under the correct namespace in `operations.ts`.
+4. **Web**: consume via `useQuery`/`useMutation(gateway.<context>.myOp, …)` and `FunctionReturnType`.
+
+> Some legacy operations still point at old modules (e.g. `gateway.library.generateUploadUrl` → `api.puzzles.generateUploadUrl`); these are noted in the gateway source and should migrate to domain modules over time.
+
+### 5.4 Add a Convex function / table (with codegen)
+
+**New function**: create the `.ts` file under `packages/backend/convex/<context>/`, export a named `query`/`mutation`/`action`/`internalQuery`/… from `../_generated/server`. Auth-gate member operations with `await requireMember(ctx)` (never trust a client-supplied user id). For mutations that change domain state, build the publisher via `makeEventPublisher(ctx, "<context>", syncHandlers?)` (or the context's `inProcessEventPublisher`); use `noopEventPublisher` when events are only needed to satisfy a use case's signature without async dispatch. Driven adapters are factory functions called once per invocation (composition root). Then run codegen / hand-edit `_generated/api.d.ts` in a worktree.
+
+**New table / index**: add a `defineTable(...)` (or `.index()` / `.searchIndex()`) in `convex/schema.ts`. For aggregate-managed tables use `aggregateId: v.optional(v.string())` + `.index("by_aggregate_id", ["aggregateId"])`. Run `convex:dev` to push the schema and regenerate `dataModel.d.ts`.
+
+**New domain-event subscriber**: export `handleDomainEvent(ctx, event)` from `<context>/subscriber.ts` and register it in `events/dispatch.ts` before the `processedAt` stamp. Subscribers run inside the dispatch transaction; throwing rolls back all side effects and the scheduler retries cleanly.
+
+**New Node action** (third-party APIs, image work, push): add `'use node';` at the top, export an `internalAction`/`action`, use `ctx.runQuery`/`ctx.runMutation` for DB access, and schedule it from a mutation with `ctx.scheduler.runAfter(0, internal.<path>.<name>, args)`.
+
+### 5.5 Add a web route / component
+
+**Authenticated dashboard page**:
+
+1. Create `apps/web/src/routes/_dashboard/<path>.tsx` exporting `Route = createFileRoute('/_dashboard/<path>')(...)`.
+2. Add an entry to `ROUTE_META` in `components/dashboard-layout/route-meta.ts` with `pageKey` (+ optional `group`).
+3. Add `shell.pages.<pageKey>.title` (and `.subtitle` if needed) to `apps/web/locales/source.json`.
+4. To appear in the sidebar, add a `ShellNavItem` to the relevant `NAV_GROUPS` array in `route-meta.ts`.
+
+The shell renders the page head, breadcrumbs, and nav highlight automatically. Do **not** render your own `<h1>`/title; publish dynamic header content with `usePageHeaderActions(() => <node>, deps)` or `usePageHeader(() => ({ title, crumbs, actions }), deps)` (both clear on unmount).
+
+**Marketing page**: create `apps/web/src/routes/_public/<name>.tsx` via `createFileRoute('/_public/<name>')`; the `_public.tsx` layout supplies the marketing header/footer. Build from primitives in `components/marketing/`.
+
+**Auth in components**: `useUser()` (from `@/compat/clerk`) for the Clerk user; `useQuery(gateway.identity.currentUser, {})` for the Convex `MemberView`. Many mutations expect the domain ULID `aggregateId` (not the Convex `_id`) — guard with `if (!row.aggregateId) return;` since legacy rows may lack it.
+
+### 5.6 Add a new language
+
+i18n uses `use-intl` (not `next-intl`). Catalogs live in `apps/web/locales/` (`source.json` is the dev/source-of-truth that feeds Crowdin; `en.json` / `nl.json` are the production catalogs). The active locale is detected server-side from the `jigswap-intl` cookie (falling back to `Accept-Language`, then `en`) in `apps/web/src/lib/i18n.ts`; the timezone is fixed to `Europe/Amsterdam`.
+
+To add a string: add the key to `apps/web/locales/source.json` under the right namespace, and use it via `useTranslations('namespace')`. In dev, `source.json` is always used regardless of locale.
+
+To add a new language (e.g. `de`):
+
+1. Add the locale code to the supported-locale list in `apps/web/src/lib/i18n.ts` (the detection/matcher logic and catalog loader).
+2. Add the production catalog `apps/web/locales/de.json` (Crowdin manages translations from `source.json`).
+3. Update the language switcher UI so users can pick it (writes the `jigswap-intl` cookie via the `setLocale` server fn, which clears the intl cache and invalidates the router so the new catalog loads).
+4. Confirm Clerk localization: `ClerkProvider` is locale-reactive, so add/verify the matching Clerk localization import if you want Clerk UI translated too.
+
+---
+
+## 6. Quick reference — where things live
+
+| You want to…                        | Go to                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Change a domain rule / invariant    | `packages/domain/src/<context>/domain/` (+ `*.spec.ts`)                |
+| Add a use case                      | `packages/domain/src/<context>/application/use-cases/`                 |
+| Add/adjust a wire shape             | `packages/contracts/src/<context>/views.ts`                            |
+| Add a Convex query/mutation/action  | `packages/backend/convex/<context>/`                                   |
+| Change the DB schema                | `packages/backend/convex/schema.ts` (then codegen)                     |
+| Expose a backend fn to the UI       | `packages/gateway/src/operations.ts`                                   |
+| Add a page                          | `apps/web/src/routes/` (+ `components/dashboard-layout/route-meta.ts`) |
+| Add navigation / page-head metadata | `apps/web/src/components/dashboard-layout/route-meta.ts`               |
+| Add a translation string            | `apps/web/locales/source.json`                                         |
+| Understand intent                   | `spec/architecture/` and `spec/features/`                              |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,340 +1,538 @@
 # JigSwap Developer Guide
 
-A guide for contributors working on JigSwap — a personal puzzle library and exchange platform. It covers the architecture, local setup, how data flows end to end, project conventions, and concrete "how to" recipes for the most common changes.
+A guide for contributors and developers working on **JigSwap** — a personal puzzle library
+and exchange platform. This document covers the architecture, local setup, the end-to-end
+request/data flow, project conventions, and concrete "how to" recipes for the most common
+extension tasks.
 
-> **Read this alongside the specs.** The canonical design intent lives in [`spec/`](../spec). In particular:
->
-> - [`spec/architecture/README.md`](../spec/architecture/README.md) — the four decisions that shape the architecture.
-> - [`spec/architecture/01-bounded-contexts.md`](../spec/architecture/01-bounded-contexts.md) — bounded contexts, ubiquitous language, the context map.
-> - [`spec/architecture/02-hexagonal-architecture.md`](../spec/architecture/02-hexagonal-architecture.md) — ports/adapters layout, dependency injection, domain events.
-> - [`spec/architecture/03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md) — the TanStack Start BFF and the gateway seam.
-> - [`spec/architecture/04-migration-roadmap.md`](../spec/architecture/04-migration-roadmap.md) — the strangler-fig migration from Next.js/entity-driven to TanStack Start/DDD.
-> - [`spec/features/`](../spec/features) — per-feature intent.
-> - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow, commit style, PR process.
+> **Read the specs.** This guide is a map; the source of truth for intent is `spec/`.
+> Start with [`spec/architecture/README.md`](../spec/architecture/README.md) and read the
+> four numbered documents in order. Product intent lives in [`spec/features/`](../spec/features).
+> For contribution mechanics (PR workflow, commit style, code of conduct) see
+> [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
-> **Heads-up on stale docs.** `README.md` and `CONTRIBUTING.md` still describe the **pre-migration** Next.js setup (App Router, `next-intl`, port 3000, `pnpm convex:dev` from `packages/backend`). The architecture proposal has since been adopted: the web app is now **TanStack Start** (Vite, `use-intl`, file-based routing) and the backend is organised by **bounded context** with a **hexagonal/DDD** domain layer. When the README and the code disagree, trust the code. This guide reflects the current code.
+> **A note on the README.** The root `README.md` predates the current architecture and
+> describes a Next.js + Turbopack web app served on port 3000. **That is stale.** The web app
+> has been migrated to **TanStack Start** (Vite + Nitro). Verify framework details against the
+> code, not the README. This guide reflects the current state.
 
 ---
 
 ## 1. Architecture overview
 
-JigSwap is a **pnpm + Nx monorepo** with a strict layering: a framework-agnostic **DDD domain layer**, a **contracts** package that owns the wire shapes, a **gateway** seam that is the single import point for the Convex API, a **Convex backend** that wires domain logic to persistence via ports/adapters, and a **TanStack Start** web app that consumes everything reactively.
+JigSwap is a **pnpm + Nx monorepo** organized around a strict **hexagonal (ports-and-adapters),
+Domain-Driven Design** core. The architecture is the product of a deliberate refactor away from
+an entity-driven, Convex-coupled shape; see
+[`spec/architecture/01-bounded-contexts.md`](../spec/architecture/01-bounded-contexts.md) and
+[`02-hexagonal-architecture.md`](../spec/architecture/02-hexagonal-architecture.md).
 
-### 1.1 Monorepo layout (pnpm workspaces + Nx)
+### 1.1 Monorepo layout
 
 ```
 jigswap/
 ├── apps/
-│   └── web/                 # @jigswap/web — TanStack Start (SSR React) app
+│   └── web/                    # TanStack Start web app (Vite + Nitro)
 ├── packages/
-│   ├── domain/              # @jigswap/domain — pure DDD/hexagonal domain layer
-│   ├── contracts/           # @jigswap/contracts — view DTOs + Zod input schemas
-│   ├── gateway/             # @jigswap/gateway — the single Convex-API import seam
-│   └── backend/             # @jigswap/backend — Convex functions, schema, adapters
-├── spec/                    # architecture + feature specifications
-├── package.json             # root scripts (Nx run-many targets)
-├── nx.json / project.json   # Nx config + per-project targets
-└── pnpm-workspace.yaml      # workspace globs + dependency pins/overrides
+│   ├── domain/                 # @jigswap/domain — pure DDD core, zero I/O
+│   ├── contracts/              # @jigswap/contracts — shared view DTOs + Zod schemas
+│   ├── gateway/                # @jigswap/gateway — the single seam onto the Convex API
+│   └── backend/
+│       └── convex/             # @jigswap/backend — Convex functions, grouped by context
+├── spec/                       # Architecture + feature specifications
+├── nx.json                     # Nx workspace config
+├── pnpm-workspace.yaml         # pnpm workspace (apps/*, packages/*)
+└── package.json                # Root scripts
 ```
 
-- **pnpm** (pinned via `packageManager` in the root `package.json`) is the package manager. Workspace packages link to each other with `workspace:^` and `linkWorkspacePackages: true`.
-- **Nx** orchestrates tasks. Root scripts are `nx run-many` wrappers (`dev`, `build`, `lint`, `type-check`, `test`). Use `pnpm graph` to view the dependency graph and `pnpm affected` to target only changed projects.
-- **Dependency pins** live in `pnpm-workspace.yaml` `overrides` (notably `zod`, `eslint-plugin-react-hooks`) — read the comments there before bumping them; several pins exist to keep type-checking and lint green.
+**Nx** orchestrates per-project targets (`dev`, `build`, `lint`, `type-check`, `test`) and
+caches results. **pnpm** is the package manager (workspace protocol `workspace:^` links the
+internal packages). Run `pnpm graph` to view the dependency graph.
 
-### 1.2 The dependency direction (hexagonal / DDD)
+### 1.2 The four tiers and the dependency rule
 
-The whole point of the layering is that **dependencies point inward toward the domain**, and the domain depends on nothing external:
-
-```
-            apps/web  (TanStack Start UI — no domain logic, no Convex import)
-                │  imports @/gateway
-                ▼
-        packages/gateway  (the ONLY importer of convex/_generated/api)
-                │
-                ▼
-       packages/backend/convex  (Convex functions = driving adapters)
-                │  composes use cases, injects port implementations (driven adapters)
-                ▼
-         packages/domain  (pure aggregates, use cases, ports — no I/O)
-                ▲
-                │  defines wire shapes used by backend handler return types
-        packages/contracts  (view DTOs + Zod input schemas, Convex-free)
-```
-
-Key invariants enforced at the module/TypeScript level (and by `pnpm arch:check`, a `dependency-cruiser` run over `packages/domain/src`):
-
-- `packages/domain` imports **nothing** from Convex, Clerk, or any I/O framework. All external concerns are interfaces (`ports`).
-- Bounded contexts in `packages/domain` **never import each other** — cross-context data flows through an **anti-corruption layer (ACL)** port.
-- The web app **never** imports `@jigswap/backend` or `@jigswap/contracts` directly — only `@/gateway`.
-- Only `packages/gateway/src/operations.ts` imports `@jigswap/backend/convex/_generated/api`.
-
-### 1.3 The domain layer (`packages/domain`)
-
-Twelve **bounded contexts** plus a `shared-kernel`:
-
-`catalog`, `conversation`, `exchange`, `identity`, `insights`, `library`, `notifications`, `reputation`, `sharing`, `social`, `solving`, and `shared-kernel`.
-
-Each context (except `insights`, see below) follows the same internal structure:
+Data and types flow through four tiers. **Dependencies point inward** — the domain knows
+nothing about anything outside it.
 
 ```
-packages/domain/src/<context>/
-├── domain/                  # aggregates, value objects, events, errors, ids
-└── application/
-    ├── use-cases/           # makeXxx(deps) factory functions + *.spec.ts tests
-    ├── ports/in/            # inbound command/port interfaces
-    ├── ports/out/           # outbound repository/service interfaces (the ACL seams)
-    └── testing/             # in-memory adapters: FixedClock, repos, RecordingEventPublisher
+  apps/web  ──depends on──▶  @jigswap/gateway  ──passes through──▶  @jigswap/backend (Convex)
+   (UI)                       (transport seam)                       (composition roots / adapters)
+                                                                              │
+                                                                  imports & invokes
+                                                                              ▼
+                                                                     @jigswap/domain
+                                                                  (pure aggregates + use cases)
+
+  @jigswap/contracts  ◀── declared as return types by ── Convex handlers
+       (shared view DTOs; structurally checked by tsc against handler return types)
 ```
 
-**The aggregate pattern.** Every aggregate has exactly four public surface points:
+- **`@jigswap/domain`** — pure TypeScript. **Zero** imports of `convex`, `convex/values`,
+  `@clerk/*`, React, or TanStack. Holds aggregates, value objects, domain events, use-case
+  interactors, and port _interfaces_. This is where invariants live.
+- **`@jigswap/backend` (Convex)** — the legitimate **transactional core**. Convex functions are
+  thin **adapters** (composition roots): they authenticate, wire driven adapters from `ctx`, call
+  a domain use case, and map the `Result` to a `ConvexError`. `ctx.db` never leaks past a
+  repository adapter. Convex is hosted as the core (not the BFF) because Convex mutations are ACID
+  transactions and Convex reactivity depends on reads happening inside Convex query functions.
+- **`@jigswap/contracts`** — the shared type boundary between all tiers. Plain TS view DTOs plus a
+  few Zod schemas, organized by bounded context. Zero runtime deps except `zod`; no Convex imports.
+  IDs flow as plain `string` (`DocId`).
+- **`@jigswap/gateway`** — a three-file package (`index.ts`, `types.ts`, `operations.ts`) that is
+  the **single place** in the monorepo allowed to import `@jigswap/backend/.../_generated/api`. The
+  `gateway` const maps every UI-callable operation, grouped by context namespace, to its Convex
+  `api.*.*` reference, passing it through unchanged so Convex reactivity and arg typing are
+  preserved.
+- **`apps/web`** — TanStack Start. Orchestrates, authenticates, and renders. **No domain logic.**
+  Calls `useQuery`/`useMutation`/`useAction` (from `convex/react`) against `gateway.*` references.
+  It depends on `@jigswap/gateway` (and transitively `@jigswap/backend`) but **not** on
+  `@jigswap/contracts` directly — it derives view types via
+  `FunctionReturnType<typeof gateway.some.operation>`.
 
-1. A `static` named constructor (`submit` / `register` / `propose` / `acquire` / `open` / `create`) returning `Result<Aggregate, DomainError>`.
-2. `static rehydrate(state)` for loading from persistence.
-3. `toState()` for saving back.
-4. `pullEvents(): readonly DomainEvent[]` to drain recorded events.
+> **Why the indirection?** This is Phase 1 of the BFF roadmap
+> ([`03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md)). The gateway
+> centralizes the import so a future `ApplicationGateway` interface/adapter split can swap
+> transports without touching UI call sites.
 
-Use cases always do `save(aggregate)` **then** `events.publish(aggregate.pullEvents())`.
+### 1.3 Bounded contexts
 
-**The shared-kernel** (`packages/domain/src/shared-kernel`) provides five building blocks used everywhere: branded `Id<TBrand>` (+ central `branded-ids.ts` constructors like `toCopyId`, `toMemberId`); `Result<T,E>` (`ok`/`err`/`isOk`/`isErr`) instead of exceptions; `DomainEvent` + `DomainEventPublisher`; a `Clock` interface (deterministic tests); and `DomainError`.
+The domain (`packages/domain/src/`) is split into **twelve bounded contexts plus a
+shared-kernel**, each in its own folder with the same internal structure:
 
-**The `insights` outlier.** `insights` has **no aggregates and no application layer** — it is purely a set of total, deterministic projection functions (`computePersonalStats`, `computeCollectionBreakdown`, `computeCompletionTrends`, `recommendPuzzles`, `computeTradeActivity`) over plain DTO inputs. Do not add use-case or port files there.
+```
+packages/domain/src/{context}/
+├── domain/          # aggregates, value objects, domain events, ids, errors  (NO imports from application/)
+├── application/
+│   ├── use-cases/   # makeXxx(deps) => async (cmd) => Result  factory functions
+│   ├── ports/in/    # inbound ports (use-case command interfaces)
+│   ├── ports/out/   # outbound ports (repository / publisher / clock / policy interfaces)
+│   └── testing/     # in-memory test doubles (repos, recording publishers, fixed clocks)
+└── index.ts         # re-exports domain + application
+```
 
-**Cross-context ACLs.** Library holds a `CatalogSnapshot` value object (denormalised Catalog data) and gets it through the `CatalogSnapshotProvider` outbound port — the only seam where Library touches Catalog. Exchange reads copy availability through `CopyPort` (a read-only `CopyView`), never importing Library's aggregate. Notifications translates upstream events into its own `NOTIFICATION_TYPES` literals so it never imports another context's event class.
+**Core transactional contexts** (own aggregates with state machines, emit/consume events):
+`catalog`, `library`, `exchange`, `conversation`, `identity`.
 
-### 1.4 Contracts (`packages/contracts`)
+**Supporting contexts** (derived aggregates reacting to events, or pure projections):
+`reputation`, `social`, `sharing`, `solving`, `notifications`, `insights`. The `insights`
+context has **no aggregates and no ports** — it is pure projection functions over plain DTOs.
 
-A zero-runtime-dependency (except Zod) package owning **every view DTO and input schema that crosses the frontend/backend seam**, organised by bounded context. Most DTOs are plain TypeScript interfaces; a handful (`paginationInput`, `ExchangeStatsView`, `MemberStatsView`, `GlobalStatsView`) are Zod schemas exporting inferred types. New shapes should be **plain interfaces** unless runtime validation is needed.
+The **`shared-kernel`** provides the primitives every context depends on:
 
-- Convex-free by design: IDs are plain `string` (`DocId = string`) even though Convex uses branded `Id<T>` at runtime; assignability works both ways.
-- **No build step**: `main`/`types` point at `./src/index.ts`, so `tsc` processes it inside each consumer.
-- The web app **never imports `@jigswap/contracts`**. Contract types reach the frontend by structural inference: backend handlers annotate their return type as the contract interface, and the web app derives local types with `FunctionReturnType<typeof gateway.foo.bar>`.
+- `result.ts` — the discriminated-union `Result<T,E>` with `ok`/`err` constructors and
+  `isOk`/`isErr` guards. Every fallible operation returns this; errors propagate as values, never
+  thrown.
+- `identifier.ts` + `branded-ids.ts` — branded `Id<TBrand>` (a `string` at runtime, distinct at
+  the type level) and centralized typed constructors (`toMemberId`, `toCopyId`, …). Always use the
+  constructors, never bare casts.
+- `domain-event.ts`, `domain-event-publisher.ts`, `clock.ts`, `domain-error.ts`.
 
-### 1.5 Gateway / BFF boundary (`packages/gateway` + `apps/web/src/gateway`)
+**Cross-context rule:** no context imports another's domain types. Cross-context data crosses
+through explicit **outbound ports** (anti-corruption layers), e.g. Library reads Catalog through
+`CatalogSnapshotProvider` (returning a denormalized `CatalogSnapshot` VO), and Exchange reads
+Library through `CopyPort` (returning a plain `CopyView`).
 
-`packages/gateway/src/operations.ts` is a one-file facade exporting a single `gateway` object that maps every Convex function reference into bounded-context namespaces (`gateway.catalog.*`, `gateway.library.*`, `gateway.exchange.*`, …). It is the **only** file allowed to import `@jigswap/backend/convex/_generated/api`. `packages/gateway/src/types.ts` re-exports Convex `Doc` and `Id` so nothing else touches `_generated/dataModel`.
+### 1.4 Aggregate lifecycle (uniform contract)
 
-`apps/web/src/gateway/index.ts` is a thin shim re-exporting `@jigswap/gateway` under the `@/gateway` alias (a migration convenience). All web code imports from `@/gateway`.
+Every aggregate implements the same four-part contract — **preserve this when adding methods**:
 
-> Per [`spec/architecture/03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md) §3.3, the BFF pattern also allows `createServerFn().validator(<zod schema from contracts>)` for SSR server functions — shape validation only, no business rules. Most reads/writes currently go through reactive Convex calls directly.
+1. A **static factory** (`submit`/`register`/`propose`/`acquire`/`open`) that validates from its
+   own data only and records the first domain event. Returns `Result<Aggregate, Error>`.
+2. **Mutating methods** that guard invariants and record further events. Return `Result<void, Error>`.
+3. **`pullEvents(): readonly DomainEvent[]`** — drains and clears the event buffer so the use case
+   can publish after save without double-emitting.
+4. **`static rehydrate(state)` + `toState()`** — map to/from a plain persistable interface with no
+   storage knowledge.
 
-### 1.6 Convex backend (`packages/backend/convex`)
+Cross-aggregate facts (uniqueness, availability, party identity) are **application-layer concerns**
+enforced via outbound ports, never inside an aggregate.
 
-A hexagonal-architecture monolith on the Convex platform. Each bounded context exposes its public API as thin query/mutation/action files (**driving adapters**) that compose domain use cases from `packages/domain` and inject port implementations from `<context>/adapters/` (**driven adapters**, factory functions closing over the Convex `ctx`).
+### 1.5 The Convex backend
 
-- **Schema** (`convex/schema.ts`) is the single source of persistence truth (25 tables). Aggregate-managed tables carry an optional `aggregateId` column + a `by_aggregate_id` index.
-- **Auth** is Clerk. `convex/auth.config.ts` trusts the Clerk frontend API; every auth-gated function calls `requireMember(ctx)` (`identity/requireMember.ts`), which resolves the Clerk JWT subject → `users` row → typed `MemberId`. The **only** unauthenticated inbound surface is the Clerk webhook at `POST /clerk-users-webhook` (`http.ts`) plus a couple of explicitly public reads (`insights/getGlobalStats`, `contact/submitContactMessage`).
-- **Domain events** are the connective tissue. `events/makeEventPublisher.ts` runs a context's critical _same-transaction_ sync handlers, then `recordAndSchedule` appends each event to the durable `domainEvents` table and schedules `events/dispatch.ts` via `ctx.scheduler.runAfter(0)`. `dispatch` fans each event to async subscribers (Notifications, Custody, Library ownership/loan reactions) and is idempotent (stamps `processedAt`).
-- **Dual-tier coexistence.** A legacy table-driven layer (`users.ts`, `exchanges.ts`, `adminCategories.ts`) coexists with the DDD layer in the same tables. Rule: if `aggregateId` is set, the domain path owns the row; otherwise the legacy path does. Never assume `aggregateId` is present.
-- **Node actions** (files with `'use node';`) run in Convex's Node runtime for `web-push` (VAPID), `jimp` image re-encoding, and the Hugging Face moderation call. They cannot touch `ctx.db`; they use `ctx.runQuery`/`ctx.runMutation`.
+`packages/backend/convex/` mirrors the domain contexts. The `schema.ts` declares ~27 tables. Key
+patterns:
 
-### 1.7 Web app (`apps/web`)
+- **Auth** is always server-side: `identity/requireMember.ts` reads `ctx.auth.getUserIdentity()`
+  and resolves the `clerkId` to a `users` row. The Convex `_id` **is** the `MemberId`. **Never
+  accept a `userId` from client args.**
+- **Composition root pattern:** authenticate → build adapters from `ctx` → call
+  `make<UseCase>({…adapters})` → invoke → `if (result.isErr) throw toConvexError(...)`.
+- **Dual identity:** every DDD-aggregate table carries an `aggregateId` (UUID, domain identity)
+  beside the Convex `_id` (transport identity). Repositories key reads on the `by_aggregate_id`
+  index; child tables store the Convex `_id` as FK. Legacy rows predating the migration lack
+  `aggregateId` and fall back to the raw `_id`.
+- **Domain events** are durably decoupled. `events/makeEventPublisher.ts` (1) runs critical
+  synchronous reactions in the same transaction (e.g. marking a transferred copy unavailable,
+  recomputing goal progress), then (2) appends each event to the `domainEvents` table and schedules
+  `events/dispatch.ts` via `ctx.scheduler.runAfter(0)`. The dispatcher fans events to async
+  subscribers (Notifications, Custody, Library transfer, Library loan) and stamps `processedAt`
+  only after all succeed — at-least-once delivery with Convex's automatic retry on rollback.
 
-TanStack Start (SSR React on Vite), migrated from Next.js. File-based routing under `apps/web/src/routes/`. Three layout groups: the root `__root.tsx` (bootstraps Clerk auth, Convex, i18n); a pathless `_dashboard` layout (auth-gated app shell); and a pathless `_public` layout (marketing). `/admin` is a role-gated path layout.
+### 1.6 The TanStack Start web app
 
-- **Data**: exclusively Convex reactive client (`useQuery`/`useMutation`/`useAction` from `convex/react`) via `@/gateway`. SSR auth is bootstrapped in the root `beforeLoad` (`fetchClerkAuth` injects a Convex JWT into the SSR HTTP client); `ConvexProviderWithClerk` refreshes tokens on the client.
-- **Shell**: `components/dashboard-layout/shell.tsx` is a console-style inset layout. Navigation IA + per-route metadata live in a single file, `components/dashboard-layout/route-meta.ts` (`ROUTE_META` + `NAV_GROUPS`). Leaf routes publish title/breadcrumbs/actions via `usePageHeader`/`usePageHeaderActions` rather than rendering their own `<h1>`.
-- **i18n**: `use-intl` with `en`/`nl` JSON catalogs. Locale is detected server-side from the `jigswap-intl` cookie (`apps/web/src/lib/i18n.ts`).
-- **Compat shims** (`apps/web/src/compat/clerk.tsx`, `link.tsx`, `navigation.ts`) preserve Next.js API surfaces during the migration. New code should use TanStack Router APIs directly.
+`apps/web/src/` is a fully SSR React app on TanStack Start (Vite + Nitro), file-based routing via
+TanStack Router. See [`03-bff-tanstack-start.md`](../spec/architecture/03-bff-tanstack-start.md).
+
+- **Routing:** files under `apps/web/src/routes/`. Pathless layouts use underscore-prefixed
+  directories: `_dashboard` (authenticated console shell), `_public` (marketing chrome). The route
+  tree is auto-generated as `routeTree.gen.ts` — **never edit it manually** (the dev server
+  regenerates it; it is also a known source of `tsc` noise).
+- **Auth:** `__root.tsx` runs `fetchClerkAuth` (a `createServerFn`) on every SSR request and seeds
+  a module-level `clientAuthCache` for client navigation. `_dashboard/route.tsx` calls
+  `requireAuth` in `beforeLoad` (reads `userId` off context — no server call). `/admin` uses
+  `requireAdmin`, which **does** make a server call to read Clerk `sessionClaims.metadata.role`.
+- **Data fetching:** all Convex interaction is `useQuery`/`useMutation`/`useAction` from
+  `convex/react` against `gateway.*` (imported via the `@/gateway` shim at
+  `apps/web/src/gateway/index.ts`). There is **no intermediate HTTP BFF layer on the critical path
+  for UI data.** SSR uses the Convex HTTP client pre-authed with the Clerk JWT.
+- **i18n:** `use-intl` (not next-intl, despite the README). Messages live in
+  `apps/web/locales/source.json` (dev) and `locales/{en,nl}.json` (prod). Locale detection is
+  cookie → `Accept-Language` → default `en`. See `apps/web/src/lib/i18n.ts`.
+- **Migration compat shims** (`apps/web/src/compat/`): `clerk.tsx` adds `SignedIn`/`SignedOut`;
+  `link.tsx` maps `href` → TanStack `to`; `navigation.ts` maps `next/navigation` hooks. **Do not
+  use Next.js APIs directly** (`next/image`, `next/font`, `next/headers`, `next/navigation`) — go
+  through the shims.
+- **Theme:** Tailwind 4 (CSS-based config, no `tailwind.config.js`); custom tokens in
+  `globals.css`. Dark mode via `next-themes` `class` strategy.
 
 ---
 
 ## 2. Local setup & key scripts
 
-### Prerequisites
+### 2.1 Prerequisites
 
-- Node.js (see `.nvmrc`; run `nvm use`).
-- pnpm — use the version pinned in the root `package.json` `packageManager` field (`corepack enable` will honour it).
-- A Clerk account and a Convex account/deployment.
+- **Node.js** — version is pinned by `.nvmrc` (run `nvm use`).
+- **pnpm** — see `packageManager` in the root `package.json` (Corepack will use the pinned version).
+- **Git**.
 
-### Setup
+### 2.2 First-time setup
 
 ```bash
 git clone https://github.com/SanderVerkuil/jigswap.git
 cd jigswap
 pnpm install
+cp apps/web/.env.example apps/web/.env.local   # then fill in values
 ```
 
-Create `apps/web/.env.local`. Required keys (note the framework migration kept the `NEXT_PUBLIC_` prefixes that Convex/Clerk read; verify against `apps/web/.env.example` if present):
+Required env vars in `apps/web/.env.local`:
 
 ```env
-# Convex
-CONVEX_DEPLOYMENT=dev:your-deployment
 NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
-
-# Clerk
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...
 NEXT_PUBLIC_CLERK_FRONTEND_API_URL=https://your-clerk-frontend.clerk.accounts.dev
+# Optional: Crowdin
+CROWDIN_PROJECT_ID=...
+CROWDIN_API_TOKEN=...
+NEXT_PUBLIC_CROWDIN_DISTRIBUTION_HASH=...
 ```
 
-The Convex deployment must have a JWT template named `convex` (the SSR bootstrap requests this template), and the Clerk webhook (`/clerk-users-webhook`) must be configured to keep `users` rows in sync.
+`auth.config.ts` on the backend registers Clerk as the Convex auth provider via
+`NEXT_PUBLIC_CLERK_FRONTEND_API_URL`.
 
-### Running
+### 2.3 Running
 
-Run the backend and the web app in two terminals:
+Two processes, two terminals:
 
 ```bash
-# Terminal 1 — Convex backend (watches packages/backend/convex, regenerates _generated/)
-pnpm --filter @jigswap/backend convex:dev
+# Terminal 1 — Convex backend (watches packages/backend/convex/, regenerates _generated/)
+cd packages/backend && pnpm convex:dev
 
 # Terminal 2 — web app (Vite dev server)
-pnpm dev
+pnpm dev          # = nx dev web  (runs `vite dev` for apps/web)
 ```
 
-The dev server runs on **`http://localhost:3001`** (Vite). The old README still says 3000 — that was the Next.js era.
+> The dev server runs on **`http://localhost:3001`** in this environment (not 3000 as the README
+> states). Browser-based verification with Playwright is not available here (no Chrome), but the
+> dev server itself runs fine.
 
-### Key scripts (root)
+### 2.4 Key scripts
 
-| Script                              | What it does                                                             |
-| ----------------------------------- | ------------------------------------------------------------------------ |
-| `pnpm dev`                          | Start the web app (`nx dev web`, Vite).                                  |
-| `pnpm build` / `pnpm build:web`     | Build all projects / just the web app.                                   |
-| `pnpm lint` / `pnpm lint:fix`       | ESLint across projects (`run-many`).                                     |
-| `pnpm type-check`                   | `tsc --noEmit` across projects.                                          |
-| `pnpm test`                         | Vitest across projects.                                                  |
-| `pnpm format` / `pnpm format:check` | Prettier write / check (CI runs `format:check` first).                   |
-| `pnpm arch:check`                   | `dependency-cruiser` over `packages/domain/src` — enforces the layering. |
-| `pnpm mutation:domain`              | Stryker mutation testing of the domain layer.                            |
-| `pnpm graph` / `pnpm affected`      | Nx dependency graph / affected-only tasks.                               |
+Root (`package.json`), all via Nx:
 
-Backend-specific: `pnpm --filter @jigswap/backend convex:dev` (dev + codegen) and `convex:deploy` (prod).
+| Script                              | Purpose                                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| `pnpm dev`                          | `nx dev web` — start the web app                                                       |
+| `pnpm build`                        | build all projects                                                                     |
+| `pnpm lint` / `pnpm lint:fix`       | ESLint across all projects                                                             |
+| `pnpm type-check`                   | `tsc --noEmit` across all projects                                                     |
+| `pnpm test`                         | run all project tests (Vitest)                                                         |
+| `pnpm format` / `pnpm format:check` | Prettier write / check (CI runs `format:check`)                                        |
+| `pnpm graph`                        | open the Nx dependency graph                                                           |
+| `pnpm affected`                     | run targets only on affected projects                                                  |
+| `pnpm arch:check`                   | dependency-cruiser — enforces the hexagonal dependency rule over `packages/domain/src` |
+| `pnpm mutation:domain`              | Stryker mutation testing for the domain package                                        |
+
+Backend (`packages/backend`): `pnpm convex:dev`, `pnpm convex:deploy`, `pnpm type-check`.
+
+Web (`apps/web`): `pnpm dev` (`vite dev`), `pnpm build`, `pnpm start`, `pnpm type-check`,
+`pnpm test`.
 
 ---
 
 ## 3. Request / data flow, end to end
 
-**SSR auth bootstrap.** Browser → TanStack Start server → `__root.tsx` `beforeLoad` calls `fetchClerkAuth` (server fn) → Clerk `auth()` returns `{ userId, token }` (a `convex` JWT template token) → the token is injected into the Convex SSR HTTP client → SSR queries run authenticated → context is dehydrated to the client → `clientAuthCache` is seeded on hydration so subsequent client navigations skip the server fetch.
+### 3.1 SSR auth + i18n bootstrap
 
-**Reactive read.** A route calls `useQuery(gateway.<context>.<fn>, args)` → `ConvexProviderWithClerk` keeps a live WebSocket open → Convex re-runs the query whenever underlying tables change → React re-renders. No manual invalidation for data on the same client. Pass `"skip"` as the args to defer a query until preconditions are met.
+Browser request → Nitro server → `__root.tsx` `beforeLoad` (SSR) runs `fetchClerkAuth`
+(`createServerFn`, reads the Clerk session via `clerkMiddleware` registered in `start.ts`) and
+`getIntlCached` (reads the `jigswap-intl` cookie / `Accept-Language`, loads JSON messages) → the
+root context `{ userId, token, intl }` is dehydrated into the HTML → `ConvexProviderWithClerk` and
+`IntlProvider` hydrate from the dehydrated context on the client.
 
-**Read through the backend.** The Convex handler resolves rows + storage URLs, calls a pure `mappers.ts` row→DTO function (typed against the `@jigswap/contracts` interface, enforced by `tsc`), and returns the DTO. For copy timelines, every surfaced member id is passed through `social/privacy.ts → projectMemberIdentity` (the privacy chokepoint), which reveals identity only for self / public-profile / mutual-follower and otherwise emits an opaque salted `anonRef`. Hidden identities never cross the wire.
+On client-side navigation, `beforeLoad` checks the module-level `clientAuthCache` and returns
+immediately on a hit (no server round-trip). `requireAuth` reads `userId` off context;
+`requireAdmin` is the only per-navigation server call in the app.
 
-**Type propagation.** Backend handler declares `Promise<SomeView | null>` → `gateway` exposes the reference → the web app derives its local type via `FunctionReturnType<typeof gateway.<context>.<fn>>`. Contract types flow to the frontend purely by inference; the web app never imports `@jigswap/contracts`.
+### 3.2 A reactive query (the common path)
 
-**Write (mutation).** A component calls `useMutation(gateway.<context>.<fn>)` and invokes it with args → the Convex mutation runs `requireMember(ctx)`, composes the domain use case (e.g. `makeProposeExchange`) with injected adapters, persists, then publishes domain events. Sync handlers run in the same transaction (e.g. Exchange marks a copy unavailable on settlement); async subscribers run via the scheduled `dispatch` mutation (e.g. Notifications writes a notification; Custody records a chain-of-custody entry; Library transfers ownership / opens a loan). Affected reactive `useQuery` subscriptions re-deliver automatically.
+```
+Component: useQuery(gateway.library.getCopyInstanceView, { copyId })
+  └─▶ gateway.library.getCopyInstanceView === api.library.getCopyInstanceView.getCopyInstanceView
+        └─▶ Convex runtime invokes the handler in packages/backend/convex/library/getCopyInstanceView.ts
+              ├─ requireMember(ctx)                          (auth gate)
+              ├─ fetch ownedPuzzles / custody / completions / loans rows
+              ├─ projectMemberIdentity(...) per participant  (privacy chokepoint, salted by copyId)
+              └─ assemble CopyInstanceView  (typed in packages/contracts/src/library/views.ts)
+        ◀── result delivered reactively over the Convex WebSocket
+  ◀── UI derives its local type via FunctionReturnType<typeof gateway.library.getCopyInstanceView>
+```
 
-**Worked example — exchange settlement.** Second `confirmCompletion` → `makeConfirmCompletion` detects dual confirmation → emits `OwnershipTransferred` (swap/sale) or `PossessionTransferred` (lend) → sync handler marks the copy unavailable in the same transaction → `recordAndSchedule` persists events + schedules `dispatch` → dispatch runs: (1) `custody/subscriber` records the pre-transfer owner, (2) `library/transferOnSettlement` flips `ownerId`, (3) `library/openLoanOnSettlement` opens a `loans` row for lends, (4) `notifications/subscriber` notifies both parties → Reputation now allows a `PartnerReview`.
+`useQuery` is `undefined` while loading and `null` when the record does not exist — **guard both
+explicitly** (`undefined` → skeleton, `null` → empty/not-found, data → render).
+
+### 3.3 A mutation (with domain events)
+
+Example — exchange proposal through settlement:
+
+```
+useMutation(gateway.exchange.propose)(...)
+  → Convex mutation exchange/propose.ts: requireMember → CopyPort availability check
+    → makeProposeExchange creates the Exchange aggregate → repository.save() inserts the row
+    → inProcessEventPublisher publishes ExchangeProposed → recordAndSchedule appends a
+      domainEvents row + schedules dispatch
+  → dispatch (async internalMutation): notifications/subscriber translates ExchangeProposed →
+    trade_request notification for the recipient → inAppChannel persists to the notifications table
+  → any dependent useQuery subscriptions refresh automatically (no manual refetch)
+
+… recipient accepts, both confirm …
+  → confirmCompletion detects dual confirmation → emits ExchangeCompleted + OwnershipTransferred
+    → SYNC handler marks the copy unavailable in the same transaction
+    → dispatch order: custody subscriber inserts the provenance row (capturing the PRE-transfer
+      owner) BEFORE library/transferOnSettlement reassigns the owner; then notifications fire
+```
+
+For a `lend` kind, settlement emits `PossessionTransferred`; `library/openLoanOnSettlement.ts`
+opens a `Loan` and moves `heldBy` to the borrower (ownership never moves).
+
+### 3.4 Image upload (Convex Storage)
+
+`generateUploadUrl` mutation → one-time signed URL → `POST` the `File` blob to that URL via
+`fetch` → read `storageId` from the response → pass `storageId` to the domain mutation
+(`createOwned`, `addCopyPhoto`, …). The next read resolves the storage URL.
+
+### 3.5 i18n language switch
+
+`LanguageSwitcher` → `setLocale` POST server fn sets the `jigswap-intl` cookie → `clearIntlCache()`
+→ `router.invalidate()` re-runs `__root` `beforeLoad` → `getIntlCached` loads the new messages →
+`IntlProvider` re-renders → Clerk re-localizes.
 
 ---
 
 ## 4. Conventions
 
-### Testing
+### 4.1 Hexagonal discipline (enforced)
 
-- **Domain unit tests**: `*.spec.ts` colocated in `packages/domain` (typically `application/use-cases/*.spec.ts`). Use the in-memory `testing/` harness for each context — `FixedClock`, `SequentialIdGenerator`, `InMemory*Repository`, `RecordingEventPublisher` — **no mocking framework**. This is the canonical pattern.
-- **Backend integration tests**: `*.test.ts` at the `packages/backend/convex/` root.
-- **Web tests**: `*.test.ts` (e.g. `humanize-duration.test.ts`, `puzzle-import/draft-to-form-defaults.test.ts`).
-- Run with `pnpm test` (Vitest). Mutation-test the domain with `pnpm mutation:domain`.
-- `apps/web/src/routeTree.gen.ts` is generated and produces expected `tsc` noise — ignore it.
+- `domain/` imports nothing from `application/` or any adapter. `application/` imports `domain/`
+  and defines ports — **no** Convex/Clerk/DB imports. A violation is a defect; `pnpm arch:check`
+  (dependency-cruiser) guards it.
+- All fallible operations return `Result<T,E>`; never throw across the use-case boundary.
+- Use branded ID constructors from `branded-ids.ts`, never bare `as` casts.
+- Owner-only field stripping in mappers is **opt-out**: `toOwnedCopyView` etc. omit
+  `notes`/`acquisitionPrice`/etc. unless `opts.includeOwnerOnly === true`. Pass that flag only
+  after establishing `viewer === owner`. This is a security invariant.
+- The privacy chokepoint (`social/privacy.ts` `projectMemberIdentity`) is the only place that
+  decides reveal-vs-anonymize, and it runs server-side.
 
-### Prettier / lint
+### 4.2 Testing
 
-- **Prettier must be run before committing** — CI runs `format:check` first and fails fast (before type-check). Format changed files: `pnpm format` (or scope it). `prettier-plugin-organize-imports` is active.
-- Lint with `pnpm lint` / fix with `pnpm lint:fix`. Keep `nx lint @jigswap/web` at 0 errors; some `pnpm-workspace.yaml` pins exist specifically to keep lint green — don't bump them casually.
-- `pnpm arch:check` must pass: it enforces the domain-layer dependency rules (no cross-context imports, no I/O imports).
+Per the project's conventions (and team memory):
 
-### Commit & PR style
+- **Domain unit tests:** `*.spec.ts` co-located in each bounded context under
+  `packages/domain/src/`. Pure, in-memory, using the test doubles in each context's
+  `application/testing/` folder. Never hit Convex.
+- **Backend integration tests:** `*.test.ts` at the `packages/backend/convex/` root level.
+- **Web tests** (if any): `*.test.ts` under `apps/web/src/`.
+- Mapper functions are pure and unit-testable — storage URLs are passed in pre-resolved, not
+  fetched inside the mapper.
+- Mutation testing for the domain: `pnpm mutation:domain` (Stryker).
+- `routeTree.gen.ts` produces `tsc` noise; this is a known issue and can be ignored.
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>` — `feat`, `fix`, `docs`, `style`, `refactor`, `chore`). Branch off `main` with a descriptive name (`feat/...`, `fix/...`), run `pnpm lint:fix` + Prettier, open a PR against `main` and fill out the template. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+Run with `pnpm test` (all) or `nx test <project>` / `nx test web` for one.
 
-### Codegen (Convex)
+### 4.3 Prettier & lint
 
-After adding/renaming a Convex function or table, run `pnpm --filter @jigswap/backend convex:dev` to regenerate `convex/_generated/` (`api.js`, `api.d.ts`, `dataModel.d.ts`, `server.d.ts`). **In a worktree without a live deployment, hand-edit `packages/backend/convex/_generated/api.d.ts`** to declare the new function — the gateway cannot reference a function the generated API type doesn't know about. Never hand-edit `_generated/` in the main repo (it's regenerated). Never hand-edit `dataModel.d.ts` (derived from `schema.ts`).
+**CI runs `format:check` first.** Always format changed files before committing
+(`pnpm format` or `pnpm lint:fix`). ESLint config lives in the repo; Prettier uses
+`prettier-plugin-organize-imports`.
+
+### 4.4 Commit & PR style
+
+[Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <subject>` —
+types `feat`, `fix`, `docs`, `style`, `refactor`, `chore`. Branch with a descriptive name
+(`feat/add-puzzle-search`). Run `pnpm lint:fix` and ensure `pnpm format:check` passes before
+committing. Full workflow and the Code of Conduct are in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ---
 
 ## 5. How-to recipes
 
-### 5.1 Add a feature end to end (read path)
+### 5.1 Add a new feature, end to end
 
-Adding a new read that surfaces in the UI touches four packages, in dependency order:
+A feature usually touches all four tiers. Work **inside-out** (domain first):
 
-1. **Contract** — add the view interface in `packages/contracts/src/<context>/views.ts` (plain interface unless runtime validation is needed). Ensure it's re-exported from the context `index.ts`.
-2. **Backend mapper** — add a pure row→DTO function in `packages/backend/convex/<context>/mappers.ts`, typed against the contract.
-3. **Backend query** — create `packages/backend/convex/<context>/myQuery.ts` exporting a `query`/`mutation` from `../_generated/server`; auth-gate with `await requireMember(ctx)`; annotate the handler return type as `Promise<MyView | null>` so `tsc` enforces the mapper. Resolve all rows/URLs in the handler, then call the mapper (mappers stay pure/async-free).
-4. **Codegen** — run `convex:dev` (or hand-edit `_generated/api.d.ts` in a worktree).
-5. **Gateway** — add `myOp: api.<context>.myQuery.myQuery` to the right namespace in `packages/gateway/src/operations.ts`.
-6. **Web** — call `useQuery(gateway.<context>.myOp, args)` and derive types via `FunctionReturnType<typeof gateway.<context>.myOp>`. Pass `"skip"` until preconditions hold.
-
-For a write, skip the DTO unless the mutation returns a view; in the backend mutation, compose the relevant domain use case with injected adapters and publish events (see §5.4). Web side: `useMutation(gateway.<context>.myMutation)`.
+1. **Domain** (`packages/domain/src/{context}/`): add/extend the aggregate method (record an
+   event, return `Result<void, Error>`), add the event class to `domain/events.ts` and its union,
+   add value objects as needed. Write the `.spec.ts` using in-memory doubles.
+2. **Application:** define the inbound port in `application/ports/in/`, write the use-case factory
+   `makeXxx(deps) => async (cmd) => Result` in `application/use-cases/`, add any new outbound port
+   to `application/ports/out/`. Export from the respective `index.ts`.
+3. **Contracts** (`packages/contracts/src/{context}/views.ts`): add the view DTO the UI will
+   render (plain TS, `DocId` for ids, extend `ConvexSystemFields` for persisted rows, use
+   `ProjectedMember` for privacy-gated identities). Export from the context `index.ts`.
+4. **Backend** (`packages/backend/convex/{context}/`): write the composition-root function
+   (`requireMember` → wire adapters from `ctx` → call the use case → `toConvexError` on err),
+   declaring its return type as the contracts interface. Add a mapper if needed. Add the
+   `*.test.ts` integration test. Regenerate codegen (§5.4).
+5. **Gateway** (`packages/gateway/src/operations.ts`): add the operation to the context namespace:
+   `gateway.{context}.{name}: api.{context}.{file}.{exportName}`.
+6. **Web** (`apps/web/src/`): build the route/component, call `useQuery`/`useMutation` against
+   `gateway.{context}.{name}`, derive the type via `FunctionReturnType`. Add i18n keys. Wire route
+   metadata (§5.6).
 
 ### 5.2 Add a bounded context
 
-Domain side (`packages/domain/src/<context>/`):
+**Domain** — create `packages/domain/src/{context}/` with the standard layout
+(`domain/{aggregate,ids,events,errors,value-objects,index.ts}`,
+`application/{use-cases,ports/in,ports/out,testing,index.ts}`, and a top-level `index.ts`
+re-exporting both). Register cross-context branded IDs in `shared-kernel/branded-ids.ts`. Keep the
+domain layer free of imports from other contexts (use outbound ports). Follow the existing
+test-double pattern.
 
-1. Create `domain/{aggregate.ts, ids.ts, events.ts, errors.ts, index.ts}` and `application/{use-cases/, ports/{in/,out/}, testing/, index.ts}`.
-2. Implement aggregates with the static-factory + `rehydrate` + `toState` + `pullEvents` pattern, returning `Result<...>`.
-3. Declare branded IDs in `domain/ids.ts` **and** add constructors to `shared-kernel/branded-ids.ts`.
-4. Write outbound port interfaces for any repository/external service; for cross-context data add an ACL port (never import another context's aggregate).
-5. Implement in-memory adapters in `testing/` for all outbound ports; write `*.spec.ts` use-case tests.
-6. Re-export from the context `index.ts`.
+**Contracts** — `packages/contracts/src/{context}/views.ts` + `index.ts`, then add
+`export * from './{context}'` to `packages/contracts/src/index.ts`.
 
-Contracts side: add `packages/contracts/src/<context>/{views.ts,index.ts}` and `export * from "./<context>"` in `packages/contracts/src/index.ts`.
+**Backend** — create `packages/backend/convex/{context}/` with an `adapters/` subfolder
+implementing the domain port interfaces, an `inProcessEventPublisher.ts` (via `makeEventPublisher`
+with the context name + any sync handlers), and the public query/mutation composition roots. Add
+tables to `schema.ts` if needed (§5.4). Register async event handling in `events/dispatch.ts` if
+the context subscribes to events.
 
-Backend side: create `packages/backend/convex/<context>/` with `adapters/` (repositories, an `inProcessEventPublisher` if it needs sync reactions, a system clock, id generators), one file per use case, an `errors.ts` mapping domain errors to `ConvexError`, and a `subscriber.ts` if it reacts to foreign events (register it in `events/dispatch.ts`). Add any new tables to `schema.ts` with `by_aggregate_id` indexes, then run codegen.
-
-Gateway side: add a new top-level namespace key to the `gateway` object in `packages/gateway/src/operations.ts`.
+**Gateway** — add a new namespace block to the `gateway` const in
+`packages/gateway/src/operations.ts`.
 
 ### 5.3 Add a contract + gateway operation
 
-1. **Contract**: `packages/contracts/src/<context>/views.ts` — interface (or Zod schema + inferred type if validated). Re-export via the context `index.ts`. No build step; consumers pick it up by type reference.
-2. **Backend**: mapper in `mappers.ts` + a query/mutation with the contract as its annotated return type.
-3. **Codegen** then **gateway**: `myOp: api.<context>.<file>.<fn>` under the correct namespace in `operations.ts`.
-4. **Web**: consume via `useQuery`/`useMutation(gateway.<context>.myOp, …)` and `FunctionReturnType`.
+1. Add or extend the DTO in `packages/contracts/src/{context}/views.ts` and export it from the
+   context `index.ts`. No build step — the package points directly at `src/` TypeScript files.
+2. (Optional, for future BFF input validation) add a Zod schema following
+   `packages/contracts/src/shared/pagination.ts`, per
+   [`03-bff-tanstack-start.md` §3.3](../spec/architecture/03-bff-tanstack-start.md).
+3. Write the Convex handler with its return type declared as the contracts interface (§5.4).
+4. Regenerate codegen (§5.4).
+5. Add the gateway entry: `gateway.{context}.{name}: api.{context}.{file}.{exportName}` in
+   `packages/gateway/src/operations.ts`.
+6. In the UI: `useQuery(gateway.{context}.{name}, args)` / `useMutation(...)`.
 
-> Some legacy operations still point at old modules (e.g. `gateway.library.generateUploadUrl` → `api.puzzles.generateUploadUrl`); these are noted in the gateway source and should migrate to domain modules over time.
+> New operations should follow the domain-module pattern
+> `api.context.functionFile.exportName`. A few legacy entries
+> (`api.puzzles.generateUploadUrl`, `api.users.updateUserProfile`,
+> `api.exchanges.sendExchangeMessage`) predate the bounded-context structure — don't copy them.
 
-### 5.4 Add a Convex function / table (with codegen)
+### 5.4 Add a Convex function / table (codegen workflow)
 
-**New function**: create the `.ts` file under `packages/backend/convex/<context>/`, export a named `query`/`mutation`/`action`/`internalQuery`/… from `../_generated/server`. Auth-gate member operations with `await requireMember(ctx)` (never trust a client-supplied user id). For mutations that change domain state, build the publisher via `makeEventPublisher(ctx, "<context>", syncHandlers?)` (or the context's `inProcessEventPublisher`); use `noopEventPublisher` when events are only needed to satisfy a use case's signature without async dispatch. Driven adapters are factory functions called once per invocation (composition root). Then run codegen / hand-edit `_generated/api.d.ts` in a worktree.
+**Add a function:** create a `.ts` file in the context folder
+(e.g. `packages/backend/convex/library/pinCopy.ts`). Use `query()` for user-facing reads,
+`mutation()` for writes, `internalMutation()` for background reactions, `httpAction()` for
+webhooks. First line of any protected function: `requireMember(ctx)`. Export it as a named export
+matching the filename.
 
-**New table / index**: add a `defineTable(...)` (or `.index()` / `.searchIndex()`) in `convex/schema.ts`. For aggregate-managed tables use `aggregateId: v.optional(v.string())` + `.index("by_aggregate_id", ["aggregateId"])`. Run `convex:dev` to push the schema and regenerate `dataModel.d.ts`.
+**Add a table:** add the `defineTable(...)` to `schema.ts`. Every domain-aggregate table must
+include `aggregateId: v.optional(v.string())` and `.index('by_aggregate_id', ['aggregateId'])`.
+Add an `adapters/` repository implementing the domain port (`find`/`save`/`remove`, keyed on
+`by_aggregate_id`, upsert by checking for an existing row), plus a mapper between the Convex `Doc`
+shape and the aggregate state.
 
-**New domain-event subscriber**: export `handleDomainEvent(ctx, event)` from `<context>/subscriber.ts` and register it in `events/dispatch.ts` before the `processedAt` stamp. Subscribers run inside the dispatch transaction; throwing rolls back all side effects and the scheduler retries cleanly.
+**Codegen workflow:**
 
-**New Node action** (third-party APIs, image work, push): add `'use node';` at the top, export an `internalAction`/`action`, use `ctx.runQuery`/`ctx.runMutation` for DB access, and schedule it from a mutation with `ctx.scheduler.runAfter(0, internal.<path>.<name>, args)`.
+- Normally: run `pnpm convex:dev` (or `npx convex codegen`) in `packages/backend` to regenerate
+  `_generated/api.js` and `_generated/dataModel.d.ts`. The function is then callable as
+  `api.{context}.{file}.{export}`.
+- **In a worktree without a deployment** (per team memory): hand-edit
+  `packages/backend/convex/_generated/api.d.ts` to add the new function signature. The gateway
+  re-exports from `_generated`, so any new Convex function needs a corresponding gateway export
+  (§5.3) before the web app can call it.
 
-### 5.5 Add a web route / component
+**Error mapping:** domain errors carry a stable `.code`; the `toConvexError` helper in each
+context's `errors.ts` maps them to `ConvexError<{code, message}>`; the UI branches on `code`.
 
-**Authenticated dashboard page**:
+### 5.5 Add a domain event subscriber
 
-1. Create `apps/web/src/routes/_dashboard/<path>.tsx` exporting `Route = createFileRoute('/_dashboard/<path>')(...)`.
-2. Add an entry to `ROUTE_META` in `components/dashboard-layout/route-meta.ts` with `pageKey` (+ optional `group`).
-3. Add `shell.pages.<pageKey>.title` (and `.subtitle` if needed) to `apps/web/locales/source.json`.
-4. To appear in the sidebar, add a `ShellNavItem` to the relevant `NAV_GROUPS` array in `route-meta.ts`.
+Add a `handleDomainEvent(ctx, event)` function in your subscriber file
+(e.g. `insights/subscriber.ts`). Import and call it inside the `dispatch` internalMutation in
+`events/dispatch.ts`, after existing subscribers. The event is already in `domainEvents` when
+`dispatch` runs; `processedAt` is stamped only after all subscribers succeed. **Order matters** for
+`OwnershipTransferred` (custody before library transfer). The Notifications subscriber must use a
+**no-op event publisher** for its own events to avoid infinite recursion. To start reacting to an
+event a context already emits, replace `noopEventPublisher(ctx)` with the real `makeEventPublisher`
+and add the event name to the relevant subscriber `switch`.
 
-The shell renders the page head, breadcrumbs, and nav highlight automatically. Do **not** render your own `<h1>`/title; publish dynamic header content with `usePageHeaderActions(() => <node>, deps)` or `usePageHeader(() => ({ title, crumbs, actions }), deps)` (both clear on unmount).
+### 5.6 Add a web route / component
 
-**Marketing page**: create `apps/web/src/routes/_public/<name>.tsx` via `createFileRoute('/_public/<name>')`; the `_public.tsx` layout supplies the marketing header/footer. Build from primitives in `components/marketing/`.
+**Dashboard (authenticated) page:**
 
-**Auth in components**: `useUser()` (from `@/compat/clerk`) for the Clerk user; `useQuery(gateway.identity.currentUser, {})` for the Convex `MemberView`. Many mutations expect the domain ULID `aggregateId` (not the Convex `_id`) — guard with `if (!row.aggregateId) return;` since legacy rows may lack it.
+1. Create `apps/web/src/routes/_dashboard/my-new-page.tsx` with
+   `createFileRoute('/_dashboard/my-new-page')({...})`.
+2. Add a `ROUTE_META` entry in `apps/web/src/components/dashboard-layout/route-meta.ts`:
+   `{ pageKey: 'myNewPage', group: 'library' | 'community' }`. Optionally add a `ShellNavItem`
+   to a `NAV_GROUPS` array to surface it in the sidebar.
+3. Add `shell.pages.myNewPage.title/.subtitle/.description` keys to `locales/source.json` (and
+   `en.json`, `nl.json`). Optionally add `titles.myNewPage` for the browser `<title>`.
 
-### 5.6 Add a new language
+The shell `PageHead`, breadcrumbs, sidebar highlight, and command-palette entry all derive from
+`ROUTE_META` automatically. **No shell component edits required.** To add a primary action / count
+badge / dynamic title, call `usePageHeaderActions(render, deps)` or `usePageHeader(factory, deps)`
+from `page-header-slot.tsx` — **do not render a duplicate `<h1>` or action in the page body.**
 
-i18n uses `use-intl` (not `next-intl`). Catalogs live in `apps/web/locales/` (`source.json` is the dev/source-of-truth that feeds Crowdin; `en.json` / `nl.json` are the production catalogs). The active locale is detected server-side from the `jigswap-intl` cookie (falling back to `Accept-Language`, then `en`) in `apps/web/src/lib/i18n.ts`; the timezone is fixed to `Europe/Amsterdam`.
+**Public marketing page:** create `apps/web/src/routes/_public/my-page.tsx`; the `_public` layout
+(`MarketingHeader` + `MarketingFooter`) wraps it automatically. Add a `marketing.titles.myPage`
+key.
 
-To add a string: add the key to `apps/web/locales/source.json` under the right namespace, and use it via `useTranslations('namespace')`. In dev, `source.json` is always used regardless of locale.
+**Authenticated page outside `_dashboard`** (like `/admin`): create a path layout file with its own
+`beforeLoad` guard (e.g. `requireAdmin`).
 
-To add a new language (e.g. `de`):
+### 5.7 Add a new language
 
-1. Add the locale code to the supported-locale list in `apps/web/src/lib/i18n.ts` (the detection/matcher logic and catalog loader).
-2. Add the production catalog `apps/web/locales/de.json` (Crowdin manages translations from `source.json`).
-3. Update the language switcher UI so users can pick it (writes the `jigswap-intl` cookie via the `setLocale` server fn, which clears the intl cache and invalidates the router so the new catalog loads).
-4. Confirm Clerk localization: `ClerkProvider` is locale-reactive, so add/verify the matching Clerk localization import if you want Clerk UI translated too.
+1. Add the locale code to the `locales` array in `apps/web/src/lib/i18n.ts`.
+2. Create `apps/web/locales/{code}.json` (translate from `source.json`).
+3. Add a Clerk localization import in `apps/web/src/routes/__root.tsx` and handle the new locale in
+   the `ClerkProvider` `localization` prop.
+
+Translation strings are managed via Crowdin; `source.json` is the source language (English).
 
 ---
 
-## 6. Quick reference — where things live
+## 6. Where to look next
 
-| You want to…                        | Go to                                                                  |
-| ----------------------------------- | ---------------------------------------------------------------------- |
-| Change a domain rule / invariant    | `packages/domain/src/<context>/domain/` (+ `*.spec.ts`)                |
-| Add a use case                      | `packages/domain/src/<context>/application/use-cases/`                 |
-| Add/adjust a wire shape             | `packages/contracts/src/<context>/views.ts`                            |
-| Add a Convex query/mutation/action  | `packages/backend/convex/<context>/`                                   |
-| Change the DB schema                | `packages/backend/convex/schema.ts` (then codegen)                     |
-| Expose a backend fn to the UI       | `packages/gateway/src/operations.ts`                                   |
-| Add a page                          | `apps/web/src/routes/` (+ `components/dashboard-layout/route-meta.ts`) |
-| Add navigation / page-head metadata | `apps/web/src/components/dashboard-layout/route-meta.ts`               |
-| Add a translation string            | `apps/web/locales/source.json`                                         |
-| Understand intent                   | `spec/architecture/` and `spec/features/`                              |
+- **Architecture intent:** [`spec/architecture/`](../spec/architecture) — bounded contexts (01),
+  hexagonal tactical design (02), the BFF/gateway seam (03), the migration roadmap (04), and the
+  current-state appendix.
+- **Product features:** [`spec/features/`](../spec/features) — personal-library, puzzle-exchange,
+  friend-circles, community, analytics, advanced-features.
+- **Contribution mechanics:** [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **Schema:** `packages/backend/convex/schema.ts` is the single source of truth for tables and
+  indexes.
+
+---
+
+_Made with care by the JigSwap contributors. When in doubt, read the spec and follow the existing
+pattern in the nearest sibling file._

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,535 +1,525 @@
 # JigSwap User Guide
 
-Welcome to **JigSwap** — your personal jigsaw puzzle library and exchange platform. JigSwap helps you keep track of the puzzles you own, record every puzzle you complete, set solving goals, and share or swap puzzles with friends, family, and the wider community.
+Welcome to **JigSwap** — your personal jigsaw puzzle library and exchange platform. JigSwap lets you catalog the puzzles you own, track every puzzle you solve, set goals, and lend, swap, or trade puzzles with friends, family, and the wider puzzle community.
 
-This guide is written for everyday users. It explains what you can do and walks you through _how_ to do it, step by step. You don't need any technical knowledge to follow along.
+This guide is written for puzzle owners and swappers. It walks you through everything you can do, step by step, organized by what you're trying to accomplish. No technical knowledge required.
 
 ---
 
 ## Table of Contents
 
-1. [Getting Started: Account & Sign-In](#1-getting-started-account--sign-in)
+1. [Getting Started — Account & Sign In](#1-getting-started--account--sign-in)
 2. [Finding Your Way Around](#2-finding-your-way-around)
-3. [Managing Your Puzzle Library](#3-managing-your-puzzle-library)
-4. [Adding & Importing Puzzles](#4-adding--importing-puzzles)
-5. [Organizing with Collections](#5-organizing-with-collections)
-6. [Recording Completions, Solving History & Goals](#6-recording-completions-solving-history--goals)
-7. [Personal Insights & Stats](#7-personal-insights--stats)
-8. [Sharing & Visibility Controls](#8-sharing--visibility-controls)
-9. [The Exchange System: Lend, Swap & Trade](#9-the-exchange-system-lend-swap--trade)
-10. [Discovering Puzzles & People](#10-discovering-puzzles--people)
-11. [Friend Circles](#11-friend-circles)
-12. [Social & Community Features](#12-social--community-features)
-13. [Your Profile & the 3D Shelf](#13-your-profile--the-3d-shelf)
-14. [Notifications](#14-notifications)
-15. [Language & Region (i18n)](#15-language--region-i18n)
-16. [FAQ & Troubleshooting](#16-faq--troubleshooting)
+3. [Your Dashboard (Morning Briefing)](#3-your-dashboard-morning-briefing)
+4. [Managing Your Puzzle Library](#4-managing-your-puzzle-library)
+5. [Adding & Importing Puzzles](#5-adding--importing-puzzles)
+6. [Collections — Organizing Your Shelves](#6-collections--organizing-your-shelves)
+7. [Recording Completions — Your Solving History](#7-recording-completions--your-solving-history)
+8. [Goals](#8-goals)
+9. [Insights & Stats](#9-insights--stats)
+10. [Discovering Puzzles — Browse & Catalogue](#10-discovering-puzzles--browse--catalogue)
+11. [The Exchange System — Lend, Swap & Sell](#11-the-exchange-system--lend-swap--sell)
+12. [Visibility & Sharing Controls](#12-visibility--sharing-controls)
+13. [Friend Circles](#13-friend-circles)
+14. [Social & Community Features](#14-social--community-features)
+15. [Your Profile & the 3D Shelf](#15-your-profile--the-3d-shelf)
+16. [Reputation & Reviews](#16-reputation--reviews)
+17. [Notifications](#17-notifications)
+18. [Language Settings (English / Dutch)](#18-language-settings-english--dutch)
+19. [Quick Search (Command Palette)](#19-quick-search-command-palette)
+20. [FAQ & Troubleshooting](#20-faq--troubleshooting)
 
 ---
 
-## 1. Getting Started: Account & Sign-In
+## 1. Getting Started — Account & Sign In
 
-JigSwap uses a secure sign-in system (powered by Clerk). Everything in your library, your solving history, and your exchanges is tied to your account.
+JigSwap uses a secure sign-in system (powered by Clerk). You'll need an account to use the personal library, exchange, and community features.
 
 ### Create an account
 
-1. Open JigSwap in your browser. You'll land on the public welcome page.
+1. Visit the JigSwap landing page.
 2. Click **Sign Up**.
-3. Enter your details (email and password, or use a supported social sign-in option if available).
-4. Confirm your email if prompted.
-5. After signing up you'll be taken to your **Dashboard** — your personal home screen inside JigSwap.
+3. Follow the prompts to register (email/password or any sign-in option offered).
+4. Once registered, you'll be taken into the app's **Dashboard**.
 
-### Sign in to an existing account
+### Sign in
 
-1. Click **Sign In** from the welcome page.
+1. Click **Sign In**.
 2. Enter your credentials.
-3. You'll be returned to wherever you were trying to go, or to your Dashboard.
+3. You'll land on your personal dashboard.
 
-> **Note:** All the personal areas of JigSwap (your library, trades, profile, etc.) require you to be signed in. If you try to open one of those pages while signed out, JigSwap will send you to the sign-in screen first and bring you back automatically once you're in.
+> **Tip:** If you try to open any private page (your library, trades, profile, etc.) while signed out, JigSwap automatically sends you to the sign-in screen and brings you back to where you were headed after you log in.
 
-### Sign out
+### Public pages (no account needed)
 
-Use the account menu in the sidebar (bottom of the navigation) to sign out. After signing out, protected pages will again ask you to sign in.
+Anyone can read the **landing page**, plus **About**, **Features**, **How It Works**, **Contact**, **Privacy Policy**, and **Terms** without signing in.
 
 ---
 
 ## 2. Finding Your Way Around
 
-After signing in, you're in the **dashboard area**. Navigation is grouped to match the things you'll typically want to do.
+Once signed in, JigSwap presents a **dashboard** with a few consistent navigation pieces:
 
-### The Dashboard (your morning briefing)
+- **On desktop:** a top bar (with a search pill) and a grouped sidebar on the left holding links to all your areas (Library, Community, etc.). Your content appears in a card in the middle.
+- **On mobile (phones/small screens):** a slim top bar plus a **bottom tab bar**. A center **quick-action button** opens a sheet with common actions.
 
-Your Dashboard is the first thing you see after signing in. It gives you an at-a-glance overview:
-
-- A **briefing** banner that highlights pending trade requests and quick actions.
-- A **3D shelf** preview of your puzzles with a count of how many you own.
-- An **In Motion / Goals / Latest** section summarizing active activity and progress.
-- A **fresh** section showing recently added puzzles from the wider catalog.
-
-### Navigation groups
-
-The sidebar organizes pages into two main groups:
-
-- **Library** — your own things: My Puzzles, Collections, Completions, Goals, Insights.
-- **Community** — shared and public things: Browse, the Puzzles catalogue, Exchanges, Circles, People, Messages.
-
-On a **phone or small screen**, the sidebar is replaced by a top bar and a bottom tab bar so everything stays within thumb's reach. The same features are available; only the layout changes.
-
-### Global search (the command palette)
-
-You can jump anywhere or search instantly:
-
-1. Press **Cmd+K** (Mac) or **Ctrl+K** (Windows/Linux), or click the search pill in the top bar.
-2. Start typing (at least 2 characters) to search across **puzzles, people, circles, and collections** at once.
-3. With the box empty, the palette becomes a quick navigator with shortcuts like _Add Puzzle_, _Log Completion_, _Create Circle_, and _Browse Community_.
-4. Use the arrow keys and **Enter** to go to a result.
+Most pages also show a **primary action button** (for example, _Add Puzzle_) and any relevant counts in the page header.
 
 ---
 
-## 3. Managing Your Puzzle Library
+## 3. Your Dashboard (Morning Briefing)
 
-Your library — **My Puzzles** — is the collection of physical puzzle _copies_ you actually own. Each copy is one real puzzle box sitting on your shelf.
+**Where:** the home screen after sign-in (`/dashboard`).
+
+Your dashboard is a personal briefing that summarizes your puzzle life at a glance:
+
+- A **headline sentence** summarizing your active exchanges and goal progress.
+- A **pending-request banner** if someone has sent you an incoming exchange request that needs a response.
+- **Quick-action chips**: _Add Puzzle_, _Browse_, and _Log Completion_.
+- A **3D shelf** ("plank") showing your real puzzle copies as physical objects you can look at.
+- **Live stats**: how many puzzles you own, trades completed, your average rating, and active exchanges.
+- A **pulse section**: exchanges in motion, goal progress, and your latest activity.
+- A **fresh-puzzles scroller** to discover newly added community puzzles.
+
+---
+
+## 4. Managing Your Puzzle Library
+
+Your library is the set of physical puzzle **copies** you personally own. (A "copy" is one physical puzzle you own — the platform tracks each copy separately so your history stays with you.)
+
+**Where:** **My Puzzles** (`/my-puzzles`).
 
 ### View your puzzles
 
-1. Open **My Puzzles** from the Library group.
-2. You'll see all your owned copies as cards (or as a list).
-3. Use the **status filter pills** to narrow the view:
-   - **All** — everything you own
-   - **Available** — copies you've made available to others
-   - **For Trade** — copies you'll swap or trade away
-   - **For Lend** — copies you'll lend out
-   - **In Progress** — puzzles you're currently solving
-   - **Completed** — puzzles you've finished at least once
+1. Open **My Puzzles** from the sidebar or tab bar.
+2. Switch between **grid** and **list** layouts.
+3. Use the **status filter pills** to narrow what you see:
+   - **All**
+   - **Available**
+   - **For Trade**
+   - **For Lend**
+   - **In Progress**
+   - **Completed**
 
-### Per-puzzle actions
+Each puzzle card shows its loan status (who currently has it, if lent out) and gives you quick actions.
 
-Each puzzle card has actions available from its menu:
+### Actions on each puzzle
 
-- **View detail** — open the full copy page (see below).
-- **Edit** — change condition, notes, availability, cover, etc.
-- **Delete** — remove the copy from your library (you'll be asked to confirm).
-- **Log a solve** — record that you completed (or started) this puzzle.
-- **Recall a loan** — if you've lent this copy out, ask for it back.
-- A **loan badge** appears on copies that are currently lent out.
+From a puzzle card you can:
+
+- **View** — open the full copy detail page.
+- **Edit** — change the copy's details.
+- **Delete** — remove the copy from your library (with confirmation).
+- **Log Solve** — record that you've completed (or started) the puzzle.
+- **Recall** — if a puzzle is currently lent out, recall it to get it back.
 
 ### The copy detail page
 
-Click a puzzle to open its full detail page. This is the rich "story" of that single physical copy and includes:
+**Where:** click **View** on a puzzle, or go to `/my-puzzles/<id>`.
 
-- **Cover image** and availability badges.
-- **Condition** and **difficulty**.
-- **Meta** — acquisition date and source, how long it's been in your library, and tags.
-- **Sharing toggles** — quickly mark the copy as For Trade or For Lend.
-- A **stats strip** — number of completions, fastest finish, times lent, average rating.
-- A **photo gallery** where you can upload photos of the copy.
-- Timelines for **completion history**, **lending history**, and **swap history**.
-- A **community rating** breakdown.
-- **Comments** — notes and optional star ratings on the copy.
+The detail page is the rich record of a single owned copy. It includes:
 
-> **Adding photos:** On the copy detail page, choose a photo to upload. Uploaded photos are checked automatically before they appear publicly. Your own pending photos are visible to you while they're being processed.
+- A **hero image** with the availability badge and condition/difficulty chips.
+- **Acquisition details** (how/when you got it) and your private notes.
+- A **stats strip**: times completed, fastest finish, times lent out, and average rating.
+- A **photo strip** with a lightbox. As the owner you can upload photos, set a cover image, and leave per-photo comments.
+- A two-column **history**: your completion timeline (with ratings), lending history (with status pills), and swap/transfer history.
+- A **community rating breakdown** and a comment area.
 
----
-
-## 4. Adding & Importing Puzzles
-
-There are two related concepts in JigSwap:
-
-- A **catalog puzzle** is the shared definition of a puzzle title (e.g. "Ravensburger — Cozy Cabin, 1000 pieces"). It's shared across all users.
-- An **owned copy** is _your_ physical box of that puzzle, with your own condition, notes, and availability.
-
-When you add a puzzle to your library, you create an owned copy that links to a catalog puzzle.
-
-### Add a puzzle to your library
-
-1. Open **My Puzzles** and click **Add Puzzle** (in the page header), or use the quick action from the command palette.
-2. **Step 1 — Choose the puzzle.** On the chooser screen you can search the catalog and scroll through results to find a puzzle that already exists.
-3. **Step 2 — Fill in your copy's details.** Once you pick a catalog puzzle, enter your copy-specific information:
-   - **Condition** (from New to Damaged)
-   - **Availability** (private, or for trade/lend — see [Sharing & Visibility](#8-sharing--visibility-controls))
-   - **Cover** image or cover color
-   - **Notes** and tags
-4. Save. Your new copy appears in My Puzzles.
-
-### Add a brand-new puzzle (not yet in the catalog)
-
-If the puzzle doesn't exist in the catalog yet, you can create the catalog definition and your copy together in one go:
-
-1. From the Add Puzzle flow, go to the **new puzzle form** without selecting an existing puzzle.
-2. Fill in both the puzzle details (title, brand, piece count, difficulty, optional barcode/EAN/UPC and dimensions) and your copy details.
-3. A **live preview card** shows how your puzzle will look as you type.
-4. Save to add it to your library.
-
-### Import a puzzle from a store URL
-
-You don't have to type everything by hand — JigSwap can read a product page for you.
-
-1. On the Add Puzzle form, find the **Import** box at the top.
-2. Paste the web address (URL) of a puzzle product page from a puzzle store.
-3. JigSwap fetches the page and pulls out a draft: **title, brand, piece count, images, and barcode (EAN/UPC)** when available.
-4. If JigSwap finds a matching puzzle already in the catalog, it shows a **match banner**. You can choose to **use the existing puzzle** instead of creating a duplicate.
-5. Review the pre-filled fields, adjust anything that's off, and save.
-
-> **Tip:** Using the existing catalog match keeps community stats and reviews unified, instead of splitting them across duplicate entries.
-
-### Contribute a puzzle to the shared catalog
-
-If you want to add a puzzle definition to the shared catalog _without_ adding a copy to your own library:
-
-1. Go to the **Puzzles** catalogue page (Community group) and click **Contribute**.
-2. Fill in the puzzle details (you can use the same import-from-URL helper here).
-3. Submit. Your contribution goes to **moderation** and becomes publicly visible once an administrator approves it.
+**Owner actions** on this page include toggling _for-trade_ / _for-lend_, logging a completion, and editing.
+**Visitors** (other members) see a public version with _Request Swap_ and _Message_ actions instead.
 
 ---
 
-## 5. Organizing with Collections
+## 5. Adding & Importing Puzzles
 
-Collections are your own named shelves for grouping puzzles however you like (e.g. "Landscapes", "Kids' puzzles", "To solve in winter").
+**Where:** **My Puzzles → Add Puzzle** (`/my-puzzles/add`).
+
+Adding a puzzle is a two-step flow:
+
+### Step 1 — Choose or search
+
+1. Click **Add Puzzle**.
+2. You'll see a chooser page. It lists:
+   - Your own submissions that aren't approved yet (at the top).
+   - The full **approved catalogue**, with infinite scroll and a free-text search box.
+3. If your puzzle already exists in the catalogue, select it to add a copy of it to your library. If it's new, continue to create it.
+
+### Step 2 — Create or copy
+
+You'll land on the creation/copy form (`/my-puzzles/add/new`).
+
+**Import from a store URL (fastest way):**
+
+1. Find the **import zone** at the top of the form.
+2. Paste a puzzle's web address from a retailer.
+3. JigSwap fetches the puzzle details and auto-fills the form fields for you.
+4. If the puzzle already exists in the catalogue, you'll see a **match banner** offering to use the existing entry instead of creating a duplicate.
+
+**Fill in the details manually (or adjust the imported ones):**
+
+- **Title**, **brand**, **piece count**, **difficulty**, **condition**.
+- **Availability chips**: mark it _for trade_, _for lend_, and/or _for sale_.
+- A **cover** — pick a color swatch, or upload/scrape a photo.
+- **Tags** and **notes**.
+- **Advanced fields** (collapsible): EAN, UPC, model number, artist, series, shape, dimensions.
+
+A **live preview card** and a **readiness checklist** sit alongside the form so you can see how your puzzle will look.
+
+> **Adding a copy of an existing puzzle:** When you add from the catalogue (copy mode), the puzzle's catalogue definition is locked read-only, and you only fill in the copy-specific fields (your condition, availability, notes, photos, etc.).
+
+### Contributing a brand-new puzzle to the catalogue
+
+If a puzzle isn't in the catalogue yet, you can contribute its definition for everyone. Use **Puzzles → Add** (`/puzzles/add`). This uses the same form (without the copy-specific fields) and sends your submission to the **moderation queue** for an admin to approve.
+
+---
+
+## 6. Collections — Organizing Your Shelves
+
+Collections are named shelves you create to organize your copies.
+
+**Where:** **Collections** (`/collections`).
 
 ### Create a collection
 
-1. Open **Collections** (Library group).
+1. Open **Collections**.
 2. Click to create a new collection.
-3. Give it a **name**, choose an **emoji icon** and a **color**, write an optional **description**, and set its **visibility** (private or public).
+3. Set:
+   - A **name**.
+   - An **emoji icon**.
+   - A **color**.
+   - A **description**.
+   - **Visibility** — public or private.
 4. Save.
 
 ### Add puzzles to a collection
 
-1. Open a collection, then use **Add Puzzles**.
-2. Pick the owned copies you want to include.
-3. Remove copies from a collection at any time from the collection's detail view.
+1. Open a collection tile to see its detail.
+2. Use **Add puzzles** (`/collections/<id>/add-puzzles`) to attach copies from your library.
 
-### What a collection shows
-
-Each collection has a stats bar with the total **piece count**, **average difficulty**, a **difficulty mix** chart, and how many puzzles in it are **up for trade**.
-
-### Share a collection
-
-If a collection is **public**, you can share it via a link. If it's private, JigSwap will offer to make it public so you can share it.
+Each collection tile shows its puzzle count and whether it's the default.
 
 ---
 
-## 6. Recording Completions, Solving History & Goals
+## 7. Recording Completions — Your Solving History
 
-JigSwap keeps a permanent record of every puzzle you finish — even if you later trade the puzzle away.
+JigSwap keeps a full **solve log** of every puzzle you've worked on — even after you trade the puzzle away, your completion records stay with you.
 
-### Log a solve
+**Where:** **Completions** (`/completions`).
 
-You can record a solve from a puzzle card menu, from the copy detail page, or via the command palette quick action.
+### Log a completion
 
-1. Choose **Log a solve** for the puzzle.
-2. Enter the details:
-   - **Start date** and **end date**
-   - **Time** spent (in minutes)
-   - **Notes** about the experience
-   - A **rating** (1–5 stars), optional
-3. Save. You can log a puzzle as already-finished, or start one as **in progress** and finish it later.
+1. Go to **My Puzzles**.
+2. On the copy you solved, click **Log Solve**.
+3. In the dialog, record your solve. A completion can be:
+   - **Started** (in-progress) and finished later, or
+   - **Recorded** after the fact (already finished).
+4. Add **start and end dates**, your **solve time**, optional **notes**, and (if you wish) a **review** with a 1–5 star rating.
 
-### Finish an in-progress solve
+> You can attach up to **5 photos** per completion, and edits are allowed within a **24-hour** window after completing.
 
-If you logged a puzzle as in progress, open it from your completions and use **Finish** to record the end date and total time.
+### The Completions page
 
-### Edit a completion
+The Completions page shows all your solve records, newest first, with a three-stat summary at the top: **total finished**, **pieces placed**, and **finishes this year**.
 
-You can edit a completion (for example, to fix the time or add notes) within a short window after logging it.
+Each row shows the title, a status badge, a piece/days line, optional notes and review quote, a star rating, and the finish date. Per-row actions:
 
-### Review a puzzle
-
-From a completed solve you can **Review** the puzzle, attaching a star rating that feeds into the puzzle's community rating.
-
-### View your solving history
-
-1. Open **Completions** (Library group).
-2. You'll see your full history with a stats bar: **total finished**, **pieces placed**, and how many you've finished **this year**.
-
-### Track goals
-
-Set challenges for yourself and watch your progress.
-
-1. Open **Goals** (Library group).
-2. Create a goal with a **title**, **description**, a **target number of completions**, and an optional **due date**.
-3. Each goal shows a **progress bar**, a percentage, and a current/target counter.
-4. When you reach the target, the goal earns a **trophy badge** — and you'll get a notification.
-
-> Goal progress updates automatically as you log completions; you don't need to update goals by hand.
+- **Finish** — for an in-progress solve.
+- **Add/Edit Review** — set or change your star rating and review text.
+- **Edit** — adjust date range, time, and notes.
 
 ---
 
-## 7. Personal Insights & Stats
+## 8. Goals
 
-The **Insights** page (Library group) turns your activity into a personal dashboard:
+Set personal challenges and track them automatically against your solve log.
 
-- Four **stat cards** summarizing your activity (completions, solving time, ratings, exchanges, goals).
-- A **completion trends** chart over time.
+**Where:** **Goals** (`/goals`).
+
+### Create a goal
+
+1. Open **Goals**.
+2. Create a new goal with:
+   - A **title** and **description**.
+   - A **target completion count**.
+   - An optional **due date**.
+3. Save.
+
+Each active goal shows a **progress bar**, a percentage, your current/target count, and a **trophy badge** once achieved. Progress updates automatically as you log completions — you don't have to update goals manually.
+
+---
+
+## 9. Insights & Stats
+
+**Where:** **Insights** (`/insights`).
+
+Your personal analytics dashboard shows:
+
+- Four **stat cards**: total puzzles, completions, trades, and average rating.
+- A **completion trends** line chart (over the past 12 months).
 - A **trade activity** chart.
-- A **collection breakdown** chart (e.g. by piece count, difficulty, or condition).
-- A **CSV export** button so you can download your data for your own records.
-
-To export: open **Insights** and click **Export** (CSV). The file downloads to your device.
+- A **collection breakdown** chart (by piece count, brand, difficulty, condition).
+- A **data export** button to download your personal data.
 
 ---
 
-## 8. Sharing & Visibility Controls
+## 10. Discovering Puzzles — Browse & Catalogue
 
-You decide exactly who can see and request each puzzle. Every owned copy has its own sharing settings, and you can change them at any time.
+### Browse community puzzles
 
-### Visibility levels
+**Where:** **Browse** (`/browse`).
 
-JigSwap uses a layered model. From most private to most open:
+Browse searches all community-owned copies that are currently **available** (for trade, lend, or sale).
 
-1. **Private** — only you can see it.
-2. **Friend circle** — visible only to members of circles you've shared it into (see [Friend Circles](#11-friend-circles)).
-3. **Visible** — publicly viewable, but not offered for any exchange.
-4. **Lendable** — others can ask to borrow it.
-5. **Swappable** — others can propose a puzzle-for-puzzle swap.
-6. **Tradeable** — available to trade (and, where supported, sale).
+1. Open **Browse**.
+2. Build your filter with the **query builder**, combining:
+   - Free-text search.
+   - Category, difficulty, condition.
+   - Piece-count range.
+   - Availability flags (for trade / lend / sale).
+3. Results appear as a grid or list of cards, each showing the owner, a swap/lend/sale badge, and quick actions: **View**, **Request Exchange**, **Message**, **Favorite**.
 
-### Set a copy's availability
+### The puzzle catalogue
 
-1. Open the copy's detail page (or use **Edit** from My Puzzles).
-2. Toggle **For Trade** and/or **For Lend** as desired, or set the visibility level.
-3. Save. The change is reflected immediately, including in others' Browse results.
+**Where:** **Puzzles** (`/puzzles`).
 
-> **Important:** A puzzle that isn't publicly visible (private or friend-circle only) will **not** appear to people outside your circles — JigSwap keeps those copies, and your identity, hidden from non-members. Owners with a **private profile** only surface copies to people in the same circle.
+The catalogue is the community-curated list of approved puzzle definitions (not individual copies).
+
+- Browse the infinite-scroll grid with filters.
+- Open a definition (`/puzzles/<id>`) to see the cover, rating with breakdown, difficulty, category/tag pills, community stats (owners, completions, average solve days, copies available to swap), and a list of available copies with their owners.
+- If you own it, you'll see an ownership banner linking to your copy.
+- You can **add it to your library** from this page, **write a review**, or **contribute a new definition**.
 
 ---
 
-## 9. The Exchange System: Lend, Swap & Trade
+## 11. The Exchange System — Lend, Swap & Sell
 
-Exchanges let you move puzzles between people. JigSwap tracks the whole lifecycle and keeps your completion history intact even after a puzzle changes hands.
+JigSwap supports three kinds of exchanges:
 
-### Types of exchange
+- **Swap** — trade one of your puzzles for one of theirs (puzzle-for-puzzle).
+- **Sale** — sell a puzzle for a price.
+- **Lend (loan)** — let someone borrow a puzzle and get it back later. Ownership never changes hands on a loan.
 
-- **Swap** — puzzle-for-puzzle. The person starting the swap offers one of their own copies in return.
-- **Trade / Sale** — a puzzle changes ownership (a sale records a price and currency).
-- **Lend** — you keep ownership, but possession moves to the borrower for a while. Lending is open-ended, with an optional advisory return date.
+> **Your history is safe.** When a puzzle changes ownership through a swap or sale, your completion history stays with _you_ — it doesn't transfer to the new owner.
+
+**Where:** **Trades** (`/trades`).
 
 ### Propose an exchange
 
-1. Find a puzzle you want — for example on the **Browse** page or a catalog puzzle's detail page.
-2. Choose to request it (e.g. **Find Copy to Swap** from a puzzle's catalog page leads you to available copies).
-3. Select the kind of exchange (swap/lend/trade). For a swap, choose which of _your_ copies you're offering.
-4. Submit your proposal. The owner receives a notification.
+1. Find a puzzle you want via **Browse** or a copy detail page.
+2. Click **Request Exchange** / **Request Swap**.
+3. Set the terms appropriate to the kind (which puzzle you're offering for a swap, a price for a sale, or an optional return date for a loan).
+4. Submit. The owner receives an incoming request.
 
 ### Manage your exchanges
 
-1. Open **Exchanges** (Community group).
-2. Use the tabs to focus:
-   - **All** — every exchange you're involved in
-   - **Incoming** — requests sent to you
-   - **Outgoing** — requests you've sent
-   - **Completed** — finished exchanges
-   - **Borrowed** — puzzles you currently hold on loan
-3. Expand any exchange row to see the requested/offered puzzles and your partner (with their reputation badge).
+The **Trades** page organizes everything into tabs:
 
-### Actions during an exchange
+- **All**
+- **Incoming** — requests sent to you.
+- **Outgoing** — requests you sent.
+- **Completed**
+- **Borrowed** — open loans where you're currently holding someone else's puzzle.
 
-Depending on the stage, you'll see actions such as:
+Click **View** on any exchange to expand its details: both puzzle summaries, the partner's trust badge, and lifecycle action buttons.
 
-- **Accept** or **Decline** a request
-- **Cancel** a request you sent
-- **Mark Complete** — confirm the physical hand-over happened
-- **Return** — (on the Borrowed tab) return a puzzle you borrowed
-- **Leave Review** — rate your exchange partner afterward
-- **Message** — coordinate details (see [Messages](#12-social--community-features))
+### The exchange lifecycle
 
-### Completing an exchange
+An exchange moves through clear steps:
 
-Completion uses **dual confirmation** — both people confirm the hand-over took place. Once both confirm:
+1. **Proposed** — the request has been sent.
+2. **Accepted / Declined** — the recipient responds. (As the recipient of an incoming request, use **Accept** or **Decline**. As the sender of an outgoing request, you can **Cancel**.)
+3. **Completion** — once accepted, **both parties must confirm** completion (dual confirmation). Use **Mark Complete**.
+4. **Completed** — when both confirm, ownership (swap/sale) or possession (loan) transfers, and you can **Leave a Review** of your partner.
 
-- For a **swap/trade**, ownership transfers and the puzzle's sharing resets to private for the new owner.
-- For a **lend**, possession moves to the borrower and an open **loan** is tracked until it's returned or recalled.
-- The full **chain of custody** is recorded, and both parties can leave a partner review.
+### Returning a borrowed puzzle
 
-> Your personal completion history stays with **you**, not with the puzzle — so trading a puzzle away never erases your record of having solved it.
+If you've borrowed a puzzle (it's on the **Borrowed** tab), use the **Return** action to give it back. If you're the lender, you can **Recall** a lent-out copy from your library.
 
-### Reviewing your partner
-
-After an exchange completes, use **Leave Review** to rate the other person (overall rating plus sub-scores like communication and how accurately the puzzle was described). Reviews build each member's reputation, shown as a badge on their profile and on exchange rows.
+You can also **Message** your exchange partner to coordinate details.
 
 ---
 
-## 10. Discovering Puzzles & People
+## 12. Visibility & Sharing Controls
 
-### Browse available copies
+You decide who can see and interact with each puzzle copy. JigSwap uses a layered visibility model:
 
-1. Open **Browse** (Community group).
-2. You'll see copies other people have made available.
-3. Filter by **search text**, **category**, **difficulty**, **condition**, **piece count range**, and **availability type** (trade/lend/sale).
-4. Toggle between **grid** and **list** view.
+- **Private** — only you can see it.
+- **Friend circle** — visible to members of circles you've shared it with.
+- **Visible** — publicly viewable in the community.
+- **Lendable** — others can request to borrow it.
+- **Swappable** — others can propose a swap for it.
+- **Tradeable** — available for trade/sale.
 
-### Browse the puzzle catalogue
+### How to set visibility
 
-1. Open **Puzzles** (Community group) to scroll the full catalogue of approved puzzle definitions.
-2. The list loads more puzzles automatically as you scroll.
-3. Use the **Cmd/Ctrl+K** search to jump to a specific title.
+- **When adding a puzzle:** use the **availability chips** (for trade / lend / sale) and the visibility setting on the add form.
+- **On an owned puzzle later:** open the copy detail page and use the **toggle for-trade / for-lend** controls, or **Edit** the copy.
+- **To share with a specific group:** share the copy to a **friend circle** (see below).
 
-### Puzzle detail (catalog view)
-
-Opening a catalog puzzle shows an aggregated view across the community:
-
-- Cover, **community star rating** with breakdown bars, and difficulty/category/tag chips.
-- A stats strip: how many community members own it, total completions, average days to complete, and how many are available to swap.
-- A list of **available copies** with each owner's name, location, and rating.
-- Reviews and comments.
-- Actions: **Add to Library**, **Find Copy to Swap**, **Write a Review**.
+> A copy that's currently out on loan is automatically made unavailable for new exchanges until it's returned.
 
 ---
 
-## 11. Friend Circles
+## 13. Friend Circles
 
-Circles are private groups for sharing puzzles with people you trust — family, friends, a local puzzle club — without making those puzzles public.
+Friend circles are private groups for sharing puzzles only with people you trust (family, close friends).
 
-### Create a circle
+**Where:** **Circles** (`/circles`).
 
-1. Open **Circles** (Community group).
-2. Create a new circle and give it a name.
+### Create and manage a circle
 
-### Manage members
+1. Open **Circles**.
+2. Create a named circle. As the creator, you are permanently the **Owner/Admin**.
+3. Click **Manage** (owners only) to open the management dialog, where you can:
+   - **Search for and add members** (type at least 2 characters to search).
+   - Set each member's **permission level**: **View Only**, **Exchange**, or **Admin**.
+   - **Remove** members.
+   - **Share a specific owned copy** to the circle so members can see it.
 
-In a circle's **Manage** dialog you can:
-
-1. **Add members** — search for a user (type at least 2 characters) and add them.
-2. **Set permissions** for each member:
-   - **View Only** — can see shared puzzles
-   - **Exchange** — can also propose exchanges
-   - **Admin** — can manage the circle
-3. **Remove members** when needed.
-
-### Share a puzzle into a circle
-
-From the **Manage** dialog (or a copy's sharing settings), share a specific owned copy into the circle. That copy then becomes visible to circle members in their Browse — even if your profile is otherwise private.
+Each circle row shows its icon, your role (Owner/Member), the member count with overlapping avatars, and a Manage button for owners.
 
 ---
 
-## 12. Social & Community Features
+## 14. Social & Community Features
 
-### People (your network)
+### People / Social Hub
 
-1. Open **People** (Community group).
-2. See a grid of users **you follow** and users **following you**, with a _Follows you_ badge on mutual connections.
-3. View an **activity feed** of what you and the people you follow have been doing (completions, new puzzles, completed exchanges).
-4. Edit your own profile inline from here.
+**Where:** **People** (`/people`).
 
-### Following
-
-Follow other members to keep up with their activity and new additions. Following is one-directional — when someone follows you back, you're mutual connections.
+- See your **network** — everyone you follow and everyone who follows you (with a "Follows you" badge).
+- **Follow / Unfollow** members.
+- Read an **activity feed** of recent community activity (completions, acquisitions, completed exchanges).
+- Edit your **public profile** from here too.
 
 ### Comments & reviews
 
-- On a **catalog puzzle**, you can write a **review** with an optional 1–5 star rating to help the community.
-- On an individual **copy photo**, you can leave a **photo comment** in the lightbox.
-- On a **copy**, you can leave comments with an optional star rating.
+- **Puzzle reviews:** On a catalogue definition page, post a community comment with a 1–5 star rating.
+- **Copy comments:** Discuss a specific copy on its detail page.
+- **Photo comments:** In the photo lightbox, leave text comments on individual photos.
 
 ### Messages
 
-Open **Messages** (Community group) to see conversations and threads with other members, including a composer for sending messages.
+**Where:** **Messages** (`/messages`).
 
-> **Note:** The Messages screen is still being connected to live data. The conversation list and chat layout are in place, and exchange coordination is also available directly from the **Message** action on each exchange.
+A two-pane chat interface with a conversation list and a message thread.
 
----
-
-## 13. Your Profile & the 3D Shelf
-
-Your **Profile** is your public face on JigSwap.
-
-### Open and edit your profile
-
-1. Open **Profile** from the sidebar account area (or navigation).
-2. Your profile shows an identity header: **avatar, name, username, location, bio**, and a **trust badge** based on your reputation.
-3. Click to toggle the **inline edit** form, where you can update your display name, bio, and other profile fields.
-
-### The 3D shelf (puzzle plank)
-
-A standout feature of your profile (and your Dashboard) is the **3D shelf** — a visual "plank" that displays your puzzles like boxes standing on a real shelf.
-
-- It appears on your Dashboard with a count of how many puzzles you own.
-- On your profile, you can **curate a featured shelf** of up to six puzzles you want to highlight, arranging which copies appear.
-
-### Profile stats & reputation
-
-Your profile also shows your **personal stats** columns and your **received reputation** (the reviews exchange partners have left for you).
-
-### Profile visibility
-
-You can set your profile to **public** or **private**. A private profile hides your copies and identity from people who aren't in a shared circle with you.
+> **Note:** The messages screen is currently a preview and is **not yet connected to live conversations**. Messaging tied to specific exchanges is planned but not fully wired up yet.
 
 ---
 
-## 14. Notifications
+## 15. Your Profile & the 3D Shelf
 
-JigSwap keeps you informed about trade requests, acceptances, completions, messages, partner reviews, goal achievements, and puzzle approvals/rejections.
+**Where:** **Profile** (`/profile`).
 
-### Read your notifications
+Your profile is your public face on JigSwap. It shows:
 
-1. Click the **bell icon** in the top bar, or open **Notifications**.
-2. Each notification has a type badge and an unread indicator.
-3. Click a notification to jump to the relevant item (e.g. the exchange or puzzle it's about).
-4. Use **Mark as read** on individual items, or **Mark all as read**.
+- An **identity header**: avatar, name, a meta row, and your trust/reputation badge.
+- An **edit toggle** that opens an inline form to update your **display name**, **bio**, **location**, and other identity fields.
+- **"{Your Name}'s Shelf"** — a **3D physics-based plank** rendering your recent puzzle copies as objects on a shelf.
+- Four **stat columns**.
+- A **received reputation** section showing reviews others have left you.
+
+You can also set your profile **visibility** (public or private) and **arrange your shelf** to feature up to six copies.
+
+> The same 3D shelf also appears on your **dashboard**, showing your real owned copies.
+
+---
+
+## 16. Reputation & Reviews
+
+After a completed exchange, either party can leave a **partner review** to help the community gauge reliability.
+
+A partner review includes:
+
+- An overall **1–5 star** rating.
+- Four sub-scores: **communication**, **packaging**, **condition**, and **timeliness**.
+- An optional **text comment**.
+
+To leave one, complete an exchange and use **Leave Review** on the completed exchange (in **Trades**). You can't review yourself. Your received reviews roll up into a **reputation badge** (average rating + a credibility score) shown on your profile.
+
+---
+
+## 17. Notifications
+
+**Where:** **Notifications** (`/notifications`).
+
+JigSwap notifies you about exchange activity, goal achievements, reviews received, and puzzle moderation outcomes.
+
+### Reading notifications
+
+- Each notification has a type-specific icon and color, plus a read/unread indicator (unread shows a blue dot / accent background).
+- **Click a notification** to jump to the relevant page; it's marked read automatically.
+- Use **Mark Read** on a single item, or **Mark All Read** in the header.
 
 ### Notification preferences
 
-Choose exactly what reaches you and how:
+**Where:** **Notifications → Settings** (`/notifications/preferences`).
 
-1. From the Notifications page, open **Settings** (preferences).
-2. You'll see a **matrix of toggles** — one row per notification type, with columns for each channel:
-   - **In-app** — shown inside JigSwap
-   - **Email** — sent to your email address
-   - **Push** — browser/web push notifications
-3. Turn each combination on or off to suit you.
-
-### Web push devices
-
-In the preferences page, the **Push device** section lets you enable web push on your current browser/device and manage your push subscriptions. Your browser will ask permission the first time you enable push.
+- Toggle each notification **type** across each **channel**: **in-app**, **email**, and **push**.
+- By default, all types are on for **in-app**; email and push are off until you enable them.
+- Register a device for **push notifications** in the same screen.
 
 ---
 
-## 15. Language & Region (i18n)
+## 18. Language Settings (English / Dutch)
 
-JigSwap is available in **English** and **Dutch**.
+JigSwap is available in **English (en)** and **Dutch (nl)**.
 
-### Switch languages
+1. Find the **language switcher** in the app.
+2. Select your preferred language.
+3. The interface (and the sign-in screens) switch immediately, and your choice is remembered for future visits.
 
-1. Find the **language switcher** (in the app's settings/menu area).
-2. Choose your preferred language.
-3. The interface reloads in the new language. Your choice is remembered for next time via a cookie — there's no need to change the web address.
-
-> JigSwap detects a sensible default from your browser's language settings the first time you visit, then respects whatever you pick afterward. Dates and times are shown in the Europe/Amsterdam time zone.
+JigSwap automatically picks a starting language based on your saved preference, then your browser's language, defaulting to English.
 
 ---
 
-## 16. FAQ & Troubleshooting
+## 19. Quick Search (Command Palette)
 
-**I added a puzzle but it doesn't show up in the public catalogue.**
-Puzzles you _contribute to the catalog_ go through moderation and only appear publicly once an administrator approves them. A copy you add to _your own library_ shows up in My Puzzles right away regardless of moderation.
+JigSwap has a global search that finds anything quickly.
 
-**Why can't anyone see my puzzle in Browse?**
-A copy only appears in others' Browse results when (1) it has an availability flag set (For Trade, For Lend, etc.) **and** (2) either your profile is public or you've shared the copy into a circle the viewer belongs to. Check the copy's sharing settings and your profile visibility.
-
-**My imported puzzle details are wrong or incomplete.**
-The import reads a store page automatically and may not catch everything. Review the pre-filled fields and edit anything that's off before saving. If a match banner appears, consider using the existing catalog entry to avoid duplicates.
-
-**My uploaded photo isn't visible yet.**
-Photos are checked automatically before becoming public. Your own pending photos are visible to you in the meantime; once approved they appear to everyone.
-
-**I traded a puzzle away — did I lose my solving history?**
-No. Your completion history belongs to you, not the puzzle. Trading or lending a puzzle never deletes your records.
-
-**How do I get a puzzle back that I lent out?**
-Use **Recall a loan** on the copy (from My Puzzles or the copy detail). The borrower can also use **Return** from their **Borrowed** tab in Exchanges.
-
-**An exchange is stuck as "accepted" and won't complete.**
-Completion requires **both** people to confirm the hand-over. Make sure both parties have used **Mark Complete**; until both confirm, the exchange stays open.
-
-**I can't reach a page — it keeps sending me to sign in.**
-Personal pages require you to be signed in. Sign in, and JigSwap will return you to the page you wanted. If it keeps happening, try signing out and back in to refresh your session.
-
-**My language won't switch / reverts.**
-The language preference is stored in a cookie. If your browser blocks cookies for the site, the choice can't be saved. Allow cookies for JigSwap and switch again.
-
-**Where can I get more help?**
-Use the **Contact** page (from the public site) to send a message, or open an issue on the project's GitHub repository.
+- **Open it:** press **Cmd/Ctrl + K**, or click the **search pill** in the desktop top bar.
+- **With nothing typed:** you'll see jump-to navigation destinations and quick-action shortcuts.
+- **Type 2+ characters:** live results appear, grouped into **Puzzles**, **People**, **Circles**, and **Collections**.
+- **Select a result** to navigate straight there.
 
 ---
 
-_Happy puzzling! 🧩_
+## 20. FAQ & Troubleshooting
+
+**Q: I added a puzzle, but it's not showing in the public catalogue. Why?**
+New puzzle _definitions_ you contribute go to a moderation queue and must be **approved by an admin** before they appear publicly. Your own copy is still in your library — only the shared catalogue listing waits for approval. Until then it shows at the top of your Add-Puzzle chooser as an unapproved submission.
+
+**Q: What's the difference between a "puzzle" and a "copy"?**
+A **puzzle** (catalogue definition) is the product — title, brand, piece count, artwork. A **copy** is the specific physical puzzle _you_ own, with its own condition, photos, notes, and completion history. Multiple people can own copies of the same puzzle.
+
+**Q: I traded a puzzle away. Did I lose my solving history?**
+No. Your completion records and stats stay with **you**, not with the puzzle. The new owner gets a fresh history for their copy.
+
+**Q: Why can't I see a puzzle I know someone owns?**
+Visibility is controlled by the owner. If a copy is **private** or only shared to a **friend circle** you're not in, it won't appear in Browse for you.
+
+**Q: A puzzle I lent out isn't available for new exchanges.**
+That's expected — a copy that's on loan is automatically marked unavailable until it's returned. Use **Recall** (owner) or **Return** (borrower) to close the loan.
+
+**Q: How do I complete an exchange? I clicked "Mark Complete" but nothing finalized.**
+Exchanges use **dual confirmation** — _both_ parties must confirm completion before ownership/possession transfers. Wait for your partner to also mark it complete.
+
+**Q: Messaging doesn't seem to work / my message didn't send.**
+The Messages screen is currently a preview and is **not yet connected to live data**. Real in-exchange messaging is planned but not fully available yet.
+
+**Q: I can't access the Admin area.**
+The Admin panel (categories management and puzzle moderation) is restricted to users with the **admin role**. Regular members don't have access.
+
+**Q: I got signed out unexpectedly.**
+JigSwap keeps your session in sync; if you sign out in another tab or your session expires, you'll be returned to the sign-in screen. Sign back in and you'll resume where you were.
+
+**Q: How do I export my data?**
+Go to **Insights** and use the **data export** button to download your personal data.
+
+**Q: How do I change the app's language?**
+Use the language switcher to pick **English** or **Dutch**; your choice is saved automatically.
+
+---
+
+_JigSwap was made with care by a puzzle-loving family for the jigsaw puzzle community. Happy puzzling!_

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,535 @@
+# JigSwap User Guide
+
+Welcome to **JigSwap** — your personal jigsaw puzzle library and exchange platform. JigSwap helps you keep track of the puzzles you own, record every puzzle you complete, set solving goals, and share or swap puzzles with friends, family, and the wider community.
+
+This guide is written for everyday users. It explains what you can do and walks you through _how_ to do it, step by step. You don't need any technical knowledge to follow along.
+
+---
+
+## Table of Contents
+
+1. [Getting Started: Account & Sign-In](#1-getting-started-account--sign-in)
+2. [Finding Your Way Around](#2-finding-your-way-around)
+3. [Managing Your Puzzle Library](#3-managing-your-puzzle-library)
+4. [Adding & Importing Puzzles](#4-adding--importing-puzzles)
+5. [Organizing with Collections](#5-organizing-with-collections)
+6. [Recording Completions, Solving History & Goals](#6-recording-completions-solving-history--goals)
+7. [Personal Insights & Stats](#7-personal-insights--stats)
+8. [Sharing & Visibility Controls](#8-sharing--visibility-controls)
+9. [The Exchange System: Lend, Swap & Trade](#9-the-exchange-system-lend-swap--trade)
+10. [Discovering Puzzles & People](#10-discovering-puzzles--people)
+11. [Friend Circles](#11-friend-circles)
+12. [Social & Community Features](#12-social--community-features)
+13. [Your Profile & the 3D Shelf](#13-your-profile--the-3d-shelf)
+14. [Notifications](#14-notifications)
+15. [Language & Region (i18n)](#15-language--region-i18n)
+16. [FAQ & Troubleshooting](#16-faq--troubleshooting)
+
+---
+
+## 1. Getting Started: Account & Sign-In
+
+JigSwap uses a secure sign-in system (powered by Clerk). Everything in your library, your solving history, and your exchanges is tied to your account.
+
+### Create an account
+
+1. Open JigSwap in your browser. You'll land on the public welcome page.
+2. Click **Sign Up**.
+3. Enter your details (email and password, or use a supported social sign-in option if available).
+4. Confirm your email if prompted.
+5. After signing up you'll be taken to your **Dashboard** — your personal home screen inside JigSwap.
+
+### Sign in to an existing account
+
+1. Click **Sign In** from the welcome page.
+2. Enter your credentials.
+3. You'll be returned to wherever you were trying to go, or to your Dashboard.
+
+> **Note:** All the personal areas of JigSwap (your library, trades, profile, etc.) require you to be signed in. If you try to open one of those pages while signed out, JigSwap will send you to the sign-in screen first and bring you back automatically once you're in.
+
+### Sign out
+
+Use the account menu in the sidebar (bottom of the navigation) to sign out. After signing out, protected pages will again ask you to sign in.
+
+---
+
+## 2. Finding Your Way Around
+
+After signing in, you're in the **dashboard area**. Navigation is grouped to match the things you'll typically want to do.
+
+### The Dashboard (your morning briefing)
+
+Your Dashboard is the first thing you see after signing in. It gives you an at-a-glance overview:
+
+- A **briefing** banner that highlights pending trade requests and quick actions.
+- A **3D shelf** preview of your puzzles with a count of how many you own.
+- An **In Motion / Goals / Latest** section summarizing active activity and progress.
+- A **fresh** section showing recently added puzzles from the wider catalog.
+
+### Navigation groups
+
+The sidebar organizes pages into two main groups:
+
+- **Library** — your own things: My Puzzles, Collections, Completions, Goals, Insights.
+- **Community** — shared and public things: Browse, the Puzzles catalogue, Exchanges, Circles, People, Messages.
+
+On a **phone or small screen**, the sidebar is replaced by a top bar and a bottom tab bar so everything stays within thumb's reach. The same features are available; only the layout changes.
+
+### Global search (the command palette)
+
+You can jump anywhere or search instantly:
+
+1. Press **Cmd+K** (Mac) or **Ctrl+K** (Windows/Linux), or click the search pill in the top bar.
+2. Start typing (at least 2 characters) to search across **puzzles, people, circles, and collections** at once.
+3. With the box empty, the palette becomes a quick navigator with shortcuts like _Add Puzzle_, _Log Completion_, _Create Circle_, and _Browse Community_.
+4. Use the arrow keys and **Enter** to go to a result.
+
+---
+
+## 3. Managing Your Puzzle Library
+
+Your library — **My Puzzles** — is the collection of physical puzzle _copies_ you actually own. Each copy is one real puzzle box sitting on your shelf.
+
+### View your puzzles
+
+1. Open **My Puzzles** from the Library group.
+2. You'll see all your owned copies as cards (or as a list).
+3. Use the **status filter pills** to narrow the view:
+   - **All** — everything you own
+   - **Available** — copies you've made available to others
+   - **For Trade** — copies you'll swap or trade away
+   - **For Lend** — copies you'll lend out
+   - **In Progress** — puzzles you're currently solving
+   - **Completed** — puzzles you've finished at least once
+
+### Per-puzzle actions
+
+Each puzzle card has actions available from its menu:
+
+- **View detail** — open the full copy page (see below).
+- **Edit** — change condition, notes, availability, cover, etc.
+- **Delete** — remove the copy from your library (you'll be asked to confirm).
+- **Log a solve** — record that you completed (or started) this puzzle.
+- **Recall a loan** — if you've lent this copy out, ask for it back.
+- A **loan badge** appears on copies that are currently lent out.
+
+### The copy detail page
+
+Click a puzzle to open its full detail page. This is the rich "story" of that single physical copy and includes:
+
+- **Cover image** and availability badges.
+- **Condition** and **difficulty**.
+- **Meta** — acquisition date and source, how long it's been in your library, and tags.
+- **Sharing toggles** — quickly mark the copy as For Trade or For Lend.
+- A **stats strip** — number of completions, fastest finish, times lent, average rating.
+- A **photo gallery** where you can upload photos of the copy.
+- Timelines for **completion history**, **lending history**, and **swap history**.
+- A **community rating** breakdown.
+- **Comments** — notes and optional star ratings on the copy.
+
+> **Adding photos:** On the copy detail page, choose a photo to upload. Uploaded photos are checked automatically before they appear publicly. Your own pending photos are visible to you while they're being processed.
+
+---
+
+## 4. Adding & Importing Puzzles
+
+There are two related concepts in JigSwap:
+
+- A **catalog puzzle** is the shared definition of a puzzle title (e.g. "Ravensburger — Cozy Cabin, 1000 pieces"). It's shared across all users.
+- An **owned copy** is _your_ physical box of that puzzle, with your own condition, notes, and availability.
+
+When you add a puzzle to your library, you create an owned copy that links to a catalog puzzle.
+
+### Add a puzzle to your library
+
+1. Open **My Puzzles** and click **Add Puzzle** (in the page header), or use the quick action from the command palette.
+2. **Step 1 — Choose the puzzle.** On the chooser screen you can search the catalog and scroll through results to find a puzzle that already exists.
+3. **Step 2 — Fill in your copy's details.** Once you pick a catalog puzzle, enter your copy-specific information:
+   - **Condition** (from New to Damaged)
+   - **Availability** (private, or for trade/lend — see [Sharing & Visibility](#8-sharing--visibility-controls))
+   - **Cover** image or cover color
+   - **Notes** and tags
+4. Save. Your new copy appears in My Puzzles.
+
+### Add a brand-new puzzle (not yet in the catalog)
+
+If the puzzle doesn't exist in the catalog yet, you can create the catalog definition and your copy together in one go:
+
+1. From the Add Puzzle flow, go to the **new puzzle form** without selecting an existing puzzle.
+2. Fill in both the puzzle details (title, brand, piece count, difficulty, optional barcode/EAN/UPC and dimensions) and your copy details.
+3. A **live preview card** shows how your puzzle will look as you type.
+4. Save to add it to your library.
+
+### Import a puzzle from a store URL
+
+You don't have to type everything by hand — JigSwap can read a product page for you.
+
+1. On the Add Puzzle form, find the **Import** box at the top.
+2. Paste the web address (URL) of a puzzle product page from a puzzle store.
+3. JigSwap fetches the page and pulls out a draft: **title, brand, piece count, images, and barcode (EAN/UPC)** when available.
+4. If JigSwap finds a matching puzzle already in the catalog, it shows a **match banner**. You can choose to **use the existing puzzle** instead of creating a duplicate.
+5. Review the pre-filled fields, adjust anything that's off, and save.
+
+> **Tip:** Using the existing catalog match keeps community stats and reviews unified, instead of splitting them across duplicate entries.
+
+### Contribute a puzzle to the shared catalog
+
+If you want to add a puzzle definition to the shared catalog _without_ adding a copy to your own library:
+
+1. Go to the **Puzzles** catalogue page (Community group) and click **Contribute**.
+2. Fill in the puzzle details (you can use the same import-from-URL helper here).
+3. Submit. Your contribution goes to **moderation** and becomes publicly visible once an administrator approves it.
+
+---
+
+## 5. Organizing with Collections
+
+Collections are your own named shelves for grouping puzzles however you like (e.g. "Landscapes", "Kids' puzzles", "To solve in winter").
+
+### Create a collection
+
+1. Open **Collections** (Library group).
+2. Click to create a new collection.
+3. Give it a **name**, choose an **emoji icon** and a **color**, write an optional **description**, and set its **visibility** (private or public).
+4. Save.
+
+### Add puzzles to a collection
+
+1. Open a collection, then use **Add Puzzles**.
+2. Pick the owned copies you want to include.
+3. Remove copies from a collection at any time from the collection's detail view.
+
+### What a collection shows
+
+Each collection has a stats bar with the total **piece count**, **average difficulty**, a **difficulty mix** chart, and how many puzzles in it are **up for trade**.
+
+### Share a collection
+
+If a collection is **public**, you can share it via a link. If it's private, JigSwap will offer to make it public so you can share it.
+
+---
+
+## 6. Recording Completions, Solving History & Goals
+
+JigSwap keeps a permanent record of every puzzle you finish — even if you later trade the puzzle away.
+
+### Log a solve
+
+You can record a solve from a puzzle card menu, from the copy detail page, or via the command palette quick action.
+
+1. Choose **Log a solve** for the puzzle.
+2. Enter the details:
+   - **Start date** and **end date**
+   - **Time** spent (in minutes)
+   - **Notes** about the experience
+   - A **rating** (1–5 stars), optional
+3. Save. You can log a puzzle as already-finished, or start one as **in progress** and finish it later.
+
+### Finish an in-progress solve
+
+If you logged a puzzle as in progress, open it from your completions and use **Finish** to record the end date and total time.
+
+### Edit a completion
+
+You can edit a completion (for example, to fix the time or add notes) within a short window after logging it.
+
+### Review a puzzle
+
+From a completed solve you can **Review** the puzzle, attaching a star rating that feeds into the puzzle's community rating.
+
+### View your solving history
+
+1. Open **Completions** (Library group).
+2. You'll see your full history with a stats bar: **total finished**, **pieces placed**, and how many you've finished **this year**.
+
+### Track goals
+
+Set challenges for yourself and watch your progress.
+
+1. Open **Goals** (Library group).
+2. Create a goal with a **title**, **description**, a **target number of completions**, and an optional **due date**.
+3. Each goal shows a **progress bar**, a percentage, and a current/target counter.
+4. When you reach the target, the goal earns a **trophy badge** — and you'll get a notification.
+
+> Goal progress updates automatically as you log completions; you don't need to update goals by hand.
+
+---
+
+## 7. Personal Insights & Stats
+
+The **Insights** page (Library group) turns your activity into a personal dashboard:
+
+- Four **stat cards** summarizing your activity (completions, solving time, ratings, exchanges, goals).
+- A **completion trends** chart over time.
+- A **trade activity** chart.
+- A **collection breakdown** chart (e.g. by piece count, difficulty, or condition).
+- A **CSV export** button so you can download your data for your own records.
+
+To export: open **Insights** and click **Export** (CSV). The file downloads to your device.
+
+---
+
+## 8. Sharing & Visibility Controls
+
+You decide exactly who can see and request each puzzle. Every owned copy has its own sharing settings, and you can change them at any time.
+
+### Visibility levels
+
+JigSwap uses a layered model. From most private to most open:
+
+1. **Private** — only you can see it.
+2. **Friend circle** — visible only to members of circles you've shared it into (see [Friend Circles](#11-friend-circles)).
+3. **Visible** — publicly viewable, but not offered for any exchange.
+4. **Lendable** — others can ask to borrow it.
+5. **Swappable** — others can propose a puzzle-for-puzzle swap.
+6. **Tradeable** — available to trade (and, where supported, sale).
+
+### Set a copy's availability
+
+1. Open the copy's detail page (or use **Edit** from My Puzzles).
+2. Toggle **For Trade** and/or **For Lend** as desired, or set the visibility level.
+3. Save. The change is reflected immediately, including in others' Browse results.
+
+> **Important:** A puzzle that isn't publicly visible (private or friend-circle only) will **not** appear to people outside your circles — JigSwap keeps those copies, and your identity, hidden from non-members. Owners with a **private profile** only surface copies to people in the same circle.
+
+---
+
+## 9. The Exchange System: Lend, Swap & Trade
+
+Exchanges let you move puzzles between people. JigSwap tracks the whole lifecycle and keeps your completion history intact even after a puzzle changes hands.
+
+### Types of exchange
+
+- **Swap** — puzzle-for-puzzle. The person starting the swap offers one of their own copies in return.
+- **Trade / Sale** — a puzzle changes ownership (a sale records a price and currency).
+- **Lend** — you keep ownership, but possession moves to the borrower for a while. Lending is open-ended, with an optional advisory return date.
+
+### Propose an exchange
+
+1. Find a puzzle you want — for example on the **Browse** page or a catalog puzzle's detail page.
+2. Choose to request it (e.g. **Find Copy to Swap** from a puzzle's catalog page leads you to available copies).
+3. Select the kind of exchange (swap/lend/trade). For a swap, choose which of _your_ copies you're offering.
+4. Submit your proposal. The owner receives a notification.
+
+### Manage your exchanges
+
+1. Open **Exchanges** (Community group).
+2. Use the tabs to focus:
+   - **All** — every exchange you're involved in
+   - **Incoming** — requests sent to you
+   - **Outgoing** — requests you've sent
+   - **Completed** — finished exchanges
+   - **Borrowed** — puzzles you currently hold on loan
+3. Expand any exchange row to see the requested/offered puzzles and your partner (with their reputation badge).
+
+### Actions during an exchange
+
+Depending on the stage, you'll see actions such as:
+
+- **Accept** or **Decline** a request
+- **Cancel** a request you sent
+- **Mark Complete** — confirm the physical hand-over happened
+- **Return** — (on the Borrowed tab) return a puzzle you borrowed
+- **Leave Review** — rate your exchange partner afterward
+- **Message** — coordinate details (see [Messages](#12-social--community-features))
+
+### Completing an exchange
+
+Completion uses **dual confirmation** — both people confirm the hand-over took place. Once both confirm:
+
+- For a **swap/trade**, ownership transfers and the puzzle's sharing resets to private for the new owner.
+- For a **lend**, possession moves to the borrower and an open **loan** is tracked until it's returned or recalled.
+- The full **chain of custody** is recorded, and both parties can leave a partner review.
+
+> Your personal completion history stays with **you**, not with the puzzle — so trading a puzzle away never erases your record of having solved it.
+
+### Reviewing your partner
+
+After an exchange completes, use **Leave Review** to rate the other person (overall rating plus sub-scores like communication and how accurately the puzzle was described). Reviews build each member's reputation, shown as a badge on their profile and on exchange rows.
+
+---
+
+## 10. Discovering Puzzles & People
+
+### Browse available copies
+
+1. Open **Browse** (Community group).
+2. You'll see copies other people have made available.
+3. Filter by **search text**, **category**, **difficulty**, **condition**, **piece count range**, and **availability type** (trade/lend/sale).
+4. Toggle between **grid** and **list** view.
+
+### Browse the puzzle catalogue
+
+1. Open **Puzzles** (Community group) to scroll the full catalogue of approved puzzle definitions.
+2. The list loads more puzzles automatically as you scroll.
+3. Use the **Cmd/Ctrl+K** search to jump to a specific title.
+
+### Puzzle detail (catalog view)
+
+Opening a catalog puzzle shows an aggregated view across the community:
+
+- Cover, **community star rating** with breakdown bars, and difficulty/category/tag chips.
+- A stats strip: how many community members own it, total completions, average days to complete, and how many are available to swap.
+- A list of **available copies** with each owner's name, location, and rating.
+- Reviews and comments.
+- Actions: **Add to Library**, **Find Copy to Swap**, **Write a Review**.
+
+---
+
+## 11. Friend Circles
+
+Circles are private groups for sharing puzzles with people you trust — family, friends, a local puzzle club — without making those puzzles public.
+
+### Create a circle
+
+1. Open **Circles** (Community group).
+2. Create a new circle and give it a name.
+
+### Manage members
+
+In a circle's **Manage** dialog you can:
+
+1. **Add members** — search for a user (type at least 2 characters) and add them.
+2. **Set permissions** for each member:
+   - **View Only** — can see shared puzzles
+   - **Exchange** — can also propose exchanges
+   - **Admin** — can manage the circle
+3. **Remove members** when needed.
+
+### Share a puzzle into a circle
+
+From the **Manage** dialog (or a copy's sharing settings), share a specific owned copy into the circle. That copy then becomes visible to circle members in their Browse — even if your profile is otherwise private.
+
+---
+
+## 12. Social & Community Features
+
+### People (your network)
+
+1. Open **People** (Community group).
+2. See a grid of users **you follow** and users **following you**, with a _Follows you_ badge on mutual connections.
+3. View an **activity feed** of what you and the people you follow have been doing (completions, new puzzles, completed exchanges).
+4. Edit your own profile inline from here.
+
+### Following
+
+Follow other members to keep up with their activity and new additions. Following is one-directional — when someone follows you back, you're mutual connections.
+
+### Comments & reviews
+
+- On a **catalog puzzle**, you can write a **review** with an optional 1–5 star rating to help the community.
+- On an individual **copy photo**, you can leave a **photo comment** in the lightbox.
+- On a **copy**, you can leave comments with an optional star rating.
+
+### Messages
+
+Open **Messages** (Community group) to see conversations and threads with other members, including a composer for sending messages.
+
+> **Note:** The Messages screen is still being connected to live data. The conversation list and chat layout are in place, and exchange coordination is also available directly from the **Message** action on each exchange.
+
+---
+
+## 13. Your Profile & the 3D Shelf
+
+Your **Profile** is your public face on JigSwap.
+
+### Open and edit your profile
+
+1. Open **Profile** from the sidebar account area (or navigation).
+2. Your profile shows an identity header: **avatar, name, username, location, bio**, and a **trust badge** based on your reputation.
+3. Click to toggle the **inline edit** form, where you can update your display name, bio, and other profile fields.
+
+### The 3D shelf (puzzle plank)
+
+A standout feature of your profile (and your Dashboard) is the **3D shelf** — a visual "plank" that displays your puzzles like boxes standing on a real shelf.
+
+- It appears on your Dashboard with a count of how many puzzles you own.
+- On your profile, you can **curate a featured shelf** of up to six puzzles you want to highlight, arranging which copies appear.
+
+### Profile stats & reputation
+
+Your profile also shows your **personal stats** columns and your **received reputation** (the reviews exchange partners have left for you).
+
+### Profile visibility
+
+You can set your profile to **public** or **private**. A private profile hides your copies and identity from people who aren't in a shared circle with you.
+
+---
+
+## 14. Notifications
+
+JigSwap keeps you informed about trade requests, acceptances, completions, messages, partner reviews, goal achievements, and puzzle approvals/rejections.
+
+### Read your notifications
+
+1. Click the **bell icon** in the top bar, or open **Notifications**.
+2. Each notification has a type badge and an unread indicator.
+3. Click a notification to jump to the relevant item (e.g. the exchange or puzzle it's about).
+4. Use **Mark as read** on individual items, or **Mark all as read**.
+
+### Notification preferences
+
+Choose exactly what reaches you and how:
+
+1. From the Notifications page, open **Settings** (preferences).
+2. You'll see a **matrix of toggles** — one row per notification type, with columns for each channel:
+   - **In-app** — shown inside JigSwap
+   - **Email** — sent to your email address
+   - **Push** — browser/web push notifications
+3. Turn each combination on or off to suit you.
+
+### Web push devices
+
+In the preferences page, the **Push device** section lets you enable web push on your current browser/device and manage your push subscriptions. Your browser will ask permission the first time you enable push.
+
+---
+
+## 15. Language & Region (i18n)
+
+JigSwap is available in **English** and **Dutch**.
+
+### Switch languages
+
+1. Find the **language switcher** (in the app's settings/menu area).
+2. Choose your preferred language.
+3. The interface reloads in the new language. Your choice is remembered for next time via a cookie — there's no need to change the web address.
+
+> JigSwap detects a sensible default from your browser's language settings the first time you visit, then respects whatever you pick afterward. Dates and times are shown in the Europe/Amsterdam time zone.
+
+---
+
+## 16. FAQ & Troubleshooting
+
+**I added a puzzle but it doesn't show up in the public catalogue.**
+Puzzles you _contribute to the catalog_ go through moderation and only appear publicly once an administrator approves them. A copy you add to _your own library_ shows up in My Puzzles right away regardless of moderation.
+
+**Why can't anyone see my puzzle in Browse?**
+A copy only appears in others' Browse results when (1) it has an availability flag set (For Trade, For Lend, etc.) **and** (2) either your profile is public or you've shared the copy into a circle the viewer belongs to. Check the copy's sharing settings and your profile visibility.
+
+**My imported puzzle details are wrong or incomplete.**
+The import reads a store page automatically and may not catch everything. Review the pre-filled fields and edit anything that's off before saving. If a match banner appears, consider using the existing catalog entry to avoid duplicates.
+
+**My uploaded photo isn't visible yet.**
+Photos are checked automatically before becoming public. Your own pending photos are visible to you in the meantime; once approved they appear to everyone.
+
+**I traded a puzzle away — did I lose my solving history?**
+No. Your completion history belongs to you, not the puzzle. Trading or lending a puzzle never deletes your records.
+
+**How do I get a puzzle back that I lent out?**
+Use **Recall a loan** on the copy (from My Puzzles or the copy detail). The borrower can also use **Return** from their **Borrowed** tab in Exchanges.
+
+**An exchange is stuck as "accepted" and won't complete.**
+Completion requires **both** people to confirm the hand-over. Make sure both parties have used **Mark Complete**; until both confirm, the exchange stays open.
+
+**I can't reach a page — it keeps sending me to sign in.**
+Personal pages require you to be signed in. Sign in, and JigSwap will return you to the page you wanted. If it keeps happening, try signing out and back in to refresh your session.
+
+**My language won't switch / reverts.**
+The language preference is stored in a cookie. If your browser blocks cookies for the site, the choice can't be saved. Allow cookies for JigSwap and switch again.
+
+**Where can I get more help?**
+Use the **Contact** page (from the public site) to send a message, or open an issue on the project's GitHub repository.
+
+---
+
+_Happy puzzling! 🧩_

--- a/packages/backend/convex/adminCategories.test.ts
+++ b/packages/backend/convex/adminCategories.test.ts
@@ -1,0 +1,101 @@
+import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    await ctx.db.insert("users", {
+      clerkId: "clerk_alice",
+      email: "alice@example.com",
+      name: "Alice",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const active = await ctx.db.insert("adminCategories", {
+      name: { en: "Active Cat", nl: "Actief" },
+      isActive: true,
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const inactive = await ctx.db.insert("adminCategories", {
+      name: { en: "Hidden Cat", nl: "Verborgen" },
+      isActive: false,
+      sortOrder: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { active, inactive };
+  });
+
+const asMember = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+const asAdmin = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice", metadata: { role: "admin" } });
+
+describe("adminCategories admin-only reads", () => {
+  test("getAllAdminCategories rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      t.query(api.adminCategories.getAllAdminCategories, {}),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
+  test("getAllAdminCategories rejects a non-admin member", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      asMember(t).query(api.adminCategories.getAllAdminCategories, {}),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("getAllAdminCategories returns all (incl. inactive) for an admin", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const all = await asAdmin(t).query(
+      api.adminCategories.getAllAdminCategories,
+      {},
+    );
+    expect(all.map((c) => c.name.en).sort()).toEqual([
+      "Active Cat",
+      "Hidden Cat",
+    ]);
+  });
+
+  test("getAdminCategoryById rejects a non-admin member", async () => {
+    const t = convexTest(schema, modules);
+    const { inactive } = await seed(t);
+    await expect(
+      asMember(t).query(api.adminCategories.getAdminCategoryById, {
+        id: inactive,
+      }),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("getAdminCategoryById resolves a hidden row for an admin", async () => {
+    const t = convexTest(schema, modules);
+    const { inactive } = await seed(t);
+    const row = await asAdmin(t).query(
+      api.adminCategories.getAdminCategoryById,
+      { id: inactive },
+    );
+    expect(row?.name.en).toBe("Hidden Cat");
+  });
+
+  test("getActiveAdminCategories stays public", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const active = await t.query(
+      api.adminCategories.getActiveAdminCategories,
+      {},
+    );
+    expect(active.map((c) => c.name.en)).toEqual(["Active Cat"]);
+  });
+});

--- a/packages/backend/convex/adminCategories.ts
+++ b/packages/backend/convex/adminCategories.ts
@@ -1,10 +1,16 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { query } from "./_generated/server";
+import { isAdmin } from "./identity/isAdmin";
+import { requireMember } from "./identity/requireMember";
 
-// Get all admin categories (for admin panel)
+// Get all admin categories (for admin panel). Admin-only: returns ALL categories including the
+// inactive/hidden ones, so it is gated like the sibling catalog admin reads/mutations
+// (requireMember + isAdmin). The public surface is getActiveAdminCategories below.
 export const getAllAdminCategories = query({
   args: {},
   handler: async (ctx) => {
+    await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
     return await ctx.db.query("adminCategories").order("asc").collect();
   },
 });
@@ -21,10 +27,13 @@ export const getActiveAdminCategories = query({
   },
 });
 
-// Get admin category by ID
+// Get admin category by ID. Admin-only (can resolve inactive/hidden rows), matching
+// getAllAdminCategories and the catalog admin reads.
 export const getAdminCategoryById = query({
   args: { id: v.id("adminCategories") },
   handler: async (ctx, args) => {
+    await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
     return await ctx.db.get(args.id);
   },
 });

--- a/packages/backend/convex/arrangeShelf.test.ts
+++ b/packages/backend/convex/arrangeShelf.test.ts
@@ -122,10 +122,11 @@ describe("arrangeShelf", () => {
     );
     expect(profile).not.toBeNull();
 
-    // Verify featuredShelf returns them in order and deduped
-    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
-      userId: alice,
-    });
+    // Verify featuredShelf returns them in order and deduped (as the owner, who sees all her copies).
+    const shelf = await asAlice(t).query(
+      api.social.featuredShelf.featuredShelf,
+      { userId: alice },
+    );
     expect(shelf).toHaveLength(2);
     expect(shelf[0]._id).toBe(copy2);
     expect(shelf[1]._id).toBe(copy1);
@@ -178,9 +179,10 @@ describe("arrangeShelf", () => {
     // Delete copy1
     await t.run((ctx) => ctx.db.delete(copy1));
 
-    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
-      userId: alice,
-    });
+    const shelf = await asAlice(t).query(
+      api.social.featuredShelf.featuredShelf,
+      { userId: alice },
+    );
     // copy1 was deleted, only copy2 should remain
     expect(shelf).toHaveLength(1);
     expect(shelf[0]._id).toBe(copy2);
@@ -194,10 +196,92 @@ describe("arrangeShelf", () => {
       displayName: "Alice",
     });
 
-    const shelf = await t.query(api.social.featuredShelf.featuredShelf, {
-      userId: alice,
-    });
+    const shelf = await asAlice(t).query(
+      api.social.featuredShelf.featuredShelf,
+      { userId: alice },
+    );
     expect(shelf).toEqual([]);
+  });
+
+  test("featuredShelf is auth-gated", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seedUsers(t);
+
+    await expect(
+      t.query(api.social.featuredShelf.featuredShelf, { userId: alice }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("featuredShelf hides unreachable copies and owner-only fields from a non-owner", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seedUsers(t);
+
+    const puzzleId = await t.run((ctx) =>
+      ctx.db.insert("puzzles", {
+        title: "Shelf Puzzle",
+        pieceCount: 500,
+        status: "approved",
+        submittedBy: alice,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    // Alice's profile is PUBLIC. An OPEN (reachable) copy with owner-only data, and a CLOSED
+    // (unreachable for a non-owner) copy.
+    const openCopy = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "good",
+        availability: { forTrade: true, forSale: false, forLend: false },
+        notes: "alice private notes",
+        acquisitionPrice: { amount: 30, currency: "EUR" },
+        acquisitionSource: "bought_new",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+    const closedCopy = await t.run((ctx) =>
+      ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "like_new",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    );
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice",
+    });
+    await asAlice(t).mutation(api.social.arrangeShelf.arrangeShelf, {
+      copyIds: [openCopy, closedCopy],
+    });
+
+    // Bob (a non-owner) only sees the reachable OPEN copy, and never the owner-only fields.
+    const seenByBob = await asBob(t).query(
+      api.social.featuredShelf.featuredShelf,
+      { userId: alice },
+    );
+    expect(seenByBob.map((c) => c._id)).toEqual([openCopy]);
+    expect(seenByBob[0].notes).toBeUndefined();
+    expect(seenByBob[0].acquisitionPrice).toBeUndefined();
+    expect(seenByBob[0].acquisitionSource).toBeUndefined();
+    expect(JSON.stringify(seenByBob)).not.toContain("alice private notes");
+
+    // Alice (the owner) sees her full curated shelf with all owner-only fields.
+    const seenByAlice = await asAlice(t).query(
+      api.social.featuredShelf.featuredShelf,
+      { userId: alice },
+    );
+    expect(seenByAlice.map((c) => c._id)).toEqual([openCopy, closedCopy]);
+    expect(seenByAlice[0].notes).toBe("alice private notes");
+    expect(seenByAlice[0].acquisitionPrice).toEqual({
+      amount: 30,
+      currency: "EUR",
+    });
   });
 
   test("arrangeShelf records a ProfileShelfArranged domain event", async () => {

--- a/packages/backend/convex/browseOwnedPuzzles.test.ts
+++ b/packages/backend/convex/browseOwnedPuzzles.test.ts
@@ -174,4 +174,37 @@ describe("library.browseOwnedPuzzles privacy gating", () => {
     const view = await browse(t);
     expect(ids(view).has("copy-circle-open")).toBe(true);
   });
+
+  test("another member's copy never carries owner-only fields", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+
+    // Stamp the public owner's open copy with owner-only data; browsing it as the viewer must never
+    // surface notes / acquisition provenance.
+    await t.run(async (ctx) => {
+      const copy = await ctx.db
+        .query("ownedPuzzles")
+        .withIndex("by_aggregate_id", (q) =>
+          q.eq("aggregateId", "copy-public-open"),
+        )
+        .unique();
+      if (copy) {
+        await ctx.db.patch(copy._id, {
+          notes: "owner private notes",
+          acquisitionPrice: { amount: 42, currency: "EUR" },
+          acquisitionSource: "bought_new",
+        });
+      }
+    });
+
+    const view = await browse(t);
+    const shown = view.ownedPuzzles.find(
+      (c) => c.aggregateId === "copy-public-open",
+    );
+    expect(shown).toBeDefined();
+    expect(shown?.notes).toBeUndefined();
+    expect(shown?.acquisitionPrice).toBeUndefined();
+    expect(shown?.acquisitionSource).toBeUndefined();
+    expect(JSON.stringify(view)).not.toContain("owner private notes");
+  });
 });

--- a/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
+++ b/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
@@ -1,0 +1,47 @@
+"use node";
+import { isPrivateIp } from "@jigswap/domain";
+import { lookup as dnsLookup } from "node:dns/promises";
+
+// Centralised SSRF pre-flight for the import pipeline's INITIAL url. Enforces an http(s) scheme and
+// a DNS-resolved public host ONCE, so every fetcher tier (ogie — lexical-only; firecrawl — forwards
+// the raw url; browser — does its own per-hop guard) only ever sees a pre-validated public host.
+// Reuses the domain `isPrivateIp` rule rather than re-implementing it.
+//
+// NOTE: this guards the entry url only. Tiers that follow redirects MUST still re-validate each hop
+// (browserStorePageFetcher already does); a public->private redirect inside ogie/firecrawl is a
+// separate, deeper concern tracked as a follow-up.
+export type PublicUrlCheck =
+  | { ok: true }
+  | { ok: false; code: "InvalidUrl" | "Blocked"; reason: string };
+
+export const assertPublicUrl = async (url: string): Promise<PublicUrlCheck> => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, code: "InvalidUrl", reason: "URL parse error" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      code: "InvalidUrl",
+      reason: `Unsupported protocol: ${parsed.protocol}`,
+    };
+  }
+
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await dnsLookup(parsed.hostname, { all: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, code: "Blocked", reason: `DNS lookup failed: ${msg}` };
+  }
+  if (addresses.length === 0 || addresses.some((a) => isPrivateIp(a.address))) {
+    return {
+      ok: false,
+      code: "Blocked",
+      reason: `Refused to fetch (blocked address): ${parsed.hostname}`,
+    };
+  }
+  return { ok: true };
+};

--- a/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
+++ b/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
@@ -6,6 +6,19 @@ import { lookup as dnsLookup } from "node:dns/promises";
 // a DNS-resolved public host ONCE, so every fetcher tier only ever sees a pre-validated public host.
 // Reuses the domain `isPrivateIp` rule rather than re-implementing it.
 //
+// RESIDUAL RISK — DNS-rebinding TOCTOU on the initial request (finding #14, accepted):
+//   This guard resolves the hostname and validates the addresses, but the subsequent fetch() does
+//   its OWN independent DNS resolution. An attacker controlling authoritative DNS for an attacker-
+//   owned hostname can return a public IP here and a private/loopback IP (e.g. 169.254.169.254
+//   metadata) for the fetch's resolution, with a low TTL between the two. The redirect-hop case is
+//   re-validated per hop (see below), but this single-request rebind is NOT closed by re-validation.
+//   Fully closing it requires pinning the validated IP into the connection (a custom undici
+//   Dispatcher whose `lookup` returns ONLY the already-validated address, preserving Host/SNI) — a
+//   non-trivial change in the "use node" runtime, deferred rather than shipped as a risky partial.
+//   Defense-in-depth that IS in place: isPrivateIp blocks loopback/RFC-1918/link-local/CGNAT
+//   (100.64/10)/192.0.0.0/24 including the 169.254.169.254 metadata IP, so a rebind can only reach
+//   genuinely public IPs that happen to front internal services.
+//
 // Redirect-hop coverage (this guards the ENTRY url only; redirect-following is concentrated in the
 // single tier that DNS-validates every hop):
 //   - browserStorePageFetcher: the ONLY tier that follows redirects. It re-runs a DNS-resolving

--- a/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
+++ b/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
@@ -6,15 +6,15 @@ import { lookup as dnsLookup } from "node:dns/promises";
 // a DNS-resolved public host ONCE, so every fetcher tier only ever sees a pre-validated public host.
 // Reuses the domain `isPrivateIp` rule rather than re-implementing it.
 //
-// Redirect-hop coverage (this guards the ENTRY url only; tiers that follow redirects re-validate
-// each hop themselves):
-//   - browserStorePageFetcher: re-runs a DNS-resolving guard on EVERY hop (redirect:"manual").
-//   - ogieStorePageFetcher: ogie fetches with redirect:"manual" and re-validates every hop against
-//     literal private IPs/internal TLDs (allowPrivateUrls:false is pinned), so a redirect to a
-//     literal private IP is rejected. Its per-hop check is LEXICAL only — a public hostname that
-//     DNS-resolves to a private IP on a redirect hop falls through to the DNS-validating browser
-//     tier rather than being followed by ogie. This narrow DNS-rebinding-on-redirect residual is
-//     the only remaining gap and is acceptable given the validating fallback.
+// Redirect-hop coverage (this guards the ENTRY url only; redirect-following is concentrated in the
+// single tier that DNS-validates every hop):
+//   - browserStorePageFetcher: the ONLY tier that follows redirects. It re-runs a DNS-resolving
+//     guard on EVERY hop (redirect:"manual"), so a public hostname that DNS-resolves to a private
+//     IP on a redirect hop is caught here. The DNS-rebinding-on-redirect case is fully covered.
+//   - ogieStorePageFetcher: the primary tier does NOT follow redirects (maxRedirects:1 = fetch
+//     entry, follow zero hops). A redirecting store URL surfaces as a retryable FetchFailed and
+//     falls through to browserStorePageFetcher above. allowPrivateUrls:false is pinned so a literal
+//     private/loopback/link-local entry URL is rejected by ogie before any egress.
 //   - firecrawlStorePageFetcher: our egress only reaches api.firecrawl.dev (a public host); the
 //     target page is fetched by Firecrawl's infra, not ours, so it is not an SSRF vector here.
 export type PublicUrlCheck =

--- a/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
+++ b/packages/backend/convex/catalog/adapters/assertPublicUrl.ts
@@ -3,13 +3,20 @@ import { isPrivateIp } from "@jigswap/domain";
 import { lookup as dnsLookup } from "node:dns/promises";
 
 // Centralised SSRF pre-flight for the import pipeline's INITIAL url. Enforces an http(s) scheme and
-// a DNS-resolved public host ONCE, so every fetcher tier (ogie — lexical-only; firecrawl — forwards
-// the raw url; browser — does its own per-hop guard) only ever sees a pre-validated public host.
+// a DNS-resolved public host ONCE, so every fetcher tier only ever sees a pre-validated public host.
 // Reuses the domain `isPrivateIp` rule rather than re-implementing it.
 //
-// NOTE: this guards the entry url only. Tiers that follow redirects MUST still re-validate each hop
-// (browserStorePageFetcher already does); a public->private redirect inside ogie/firecrawl is a
-// separate, deeper concern tracked as a follow-up.
+// Redirect-hop coverage (this guards the ENTRY url only; tiers that follow redirects re-validate
+// each hop themselves):
+//   - browserStorePageFetcher: re-runs a DNS-resolving guard on EVERY hop (redirect:"manual").
+//   - ogieStorePageFetcher: ogie fetches with redirect:"manual" and re-validates every hop against
+//     literal private IPs/internal TLDs (allowPrivateUrls:false is pinned), so a redirect to a
+//     literal private IP is rejected. Its per-hop check is LEXICAL only — a public hostname that
+//     DNS-resolves to a private IP on a redirect hop falls through to the DNS-validating browser
+//     tier rather than being followed by ogie. This narrow DNS-rebinding-on-redirect residual is
+//     the only remaining gap and is acceptable given the validating fallback.
+//   - firecrawlStorePageFetcher: our egress only reaches api.firecrawl.dev (a public host); the
+//     target page is fetched by Firecrawl's infra, not ours, so it is not an SSRF vector here.
 export type PublicUrlCheck =
   | { ok: true }
   | { ok: false; code: "InvalidUrl" | "Blocked"; reason: string };

--- a/packages/backend/convex/catalog/adapters/eventPublisher.ts
+++ b/packages/backend/convex/catalog/adapters/eventPublisher.ts
@@ -6,5 +6,5 @@ import { makeEventPublisher } from "../../events/makeEventPublisher";
 // CRITICAL in-transaction reaction (no sync handlers); it durably records + schedules its events
 // for the async subscribers. Notifications maps PuzzleDefinitionApproved/Rejected -> the
 // submitter's "puzzle_approved"/"puzzle_rejected".
-export const noopEventPublisher = (ctx: MutationCtx): DomainEventPublisher =>
+export const catalogEventPublisher = (ctx: MutationCtx): DomainEventPublisher =>
   makeEventPublisher(ctx, "catalog");

--- a/packages/backend/convex/catalog/adapters/ogieStorePageFetcher.ts
+++ b/packages/backend/convex/catalog/adapters/ogieStorePageFetcher.ts
@@ -14,16 +14,17 @@ export const ogieStorePageFetcher: StorePageFetcher = {
       result = await extract(url, {
         timeout: 10000,
         userAgent: "JigSwapBot/1.0",
-        maxRedirects: 5,
-        // SSRF: ogie fetches with `redirect: "manual"` and re-validates EVERY hop (entry URL and
-        // each redirect target) against literal private/loopback/link-local IPs + internal TLDs;
-        // it also blocks https->http downgrades. We PIN allowPrivateUrls:false (rather than relying
-        // on ogie's default) so a redirect to e.g. http://169.254.169.254/ or http://127.0.0.1/ is
-        // rejected by ogie itself — closing the redirect-hop SSRF that this primary tier previously
-        // left to chance. (Residual: ogie's per-hop check is LEXICAL, so a public hostname that DNS-
-        // resolves to a private IP on a redirect hop is not caught here; that DNS-rebinding case is
-        // handled by the DNS-validating browserStorePageFetcher fallback, and the entry URL's DNS is
-        // validated up front by assertPublicUrl.)
+        // SSRF: this primary tier does NOT follow redirects. ogie fetches the entry URL once
+        // (maxRedirects:1 means "fetch entry, follow zero hops" — its loop runs exactly once and
+        // any 3xx surfaces as a REDIRECT_LIMIT error; note maxRedirects:0 would make ogie fetch
+        // NOTHING and always throw, so 1 is the correct "no-follow" value). REDIRECT_LIMIT maps to
+        // a retryable FetchFailed, so a redirecting store URL falls through to the fallback chain
+        // (browserStorePageFetcher), which DNS-validates EVERY hop. Redirect-following — and its
+        // SSRF validation — is therefore handled exclusively by the browser tier, closing the
+        // DNS-rebinding-on-redirect gap that following redirects here would have left open.
+        // allowPrivateUrls:false is still pinned so the entry URL's literal-private check throws
+        // before any egress, defending against a literal private/loopback/link-local entry URL.
+        maxRedirects: 1,
         allowPrivateUrls: false,
       });
     } catch (e) {

--- a/packages/backend/convex/catalog/adapters/ogieStorePageFetcher.ts
+++ b/packages/backend/convex/catalog/adapters/ogieStorePageFetcher.ts
@@ -15,6 +15,16 @@ export const ogieStorePageFetcher: StorePageFetcher = {
         timeout: 10000,
         userAgent: "JigSwapBot/1.0",
         maxRedirects: 5,
+        // SSRF: ogie fetches with `redirect: "manual"` and re-validates EVERY hop (entry URL and
+        // each redirect target) against literal private/loopback/link-local IPs + internal TLDs;
+        // it also blocks https->http downgrades. We PIN allowPrivateUrls:false (rather than relying
+        // on ogie's default) so a redirect to e.g. http://169.254.169.254/ or http://127.0.0.1/ is
+        // rejected by ogie itself — closing the redirect-hop SSRF that this primary tier previously
+        // left to chance. (Residual: ogie's per-hop check is LEXICAL, so a public hostname that DNS-
+        // resolves to a private IP on a redirect hop is not caught here; that DNS-rebinding case is
+        // handled by the DNS-validating browserStorePageFetcher fallback, and the entry URL's DNS is
+        // validated up front by assertPublicUrl.)
+        allowPrivateUrls: false,
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/packages/backend/convex/catalog/approvePuzzleDefinition.ts
+++ b/packages/backend/convex/catalog/approvePuzzleDefinition.ts
@@ -1,6 +1,7 @@
 import { makeApprovePuzzleDefinition } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { runDefinitionAction } from "./runDefinitionAction";
 
@@ -10,6 +11,7 @@ export const approvePuzzleDefinition = mutation({
   args: { puzzleDefinitionId: v.string() },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
     await runDefinitionAction(
       ctx,
       args.puzzleDefinitionId,

--- a/packages/backend/convex/catalog/createCatalogCategory.ts
+++ b/packages/backend/convex/catalog/createCatalogCategory.ts
@@ -1,6 +1,7 @@
 import { makeCreateCatalogCategory } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { catalogIdGenerator } from "./adapters/catalogIdGenerator";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
@@ -21,6 +22,7 @@ export const createCatalogCategory = mutation({
   },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
 
     const create = makeCreateCatalogCategory({
       categories: convexCatalogCategoryRepository(ctx),

--- a/packages/backend/convex/catalog/createCatalogCategory.ts
+++ b/packages/backend/convex/catalog/createCatalogCategory.ts
@@ -5,7 +5,7 @@ import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { catalogIdGenerator } from "./adapters/catalogIdGenerator";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -27,7 +27,7 @@ export const createCatalogCategory = mutation({
     const create = makeCreateCatalogCategory({
       categories: convexCatalogCategoryRepository(ctx),
       ids: catalogIdGenerator,
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/extractFromUrl.ts
+++ b/packages/backend/convex/catalog/extractFromUrl.ts
@@ -11,6 +11,7 @@ import { internal } from "../_generated/api";
 import { action } from "../_generated/server";
 import { ingestToAxiom } from "../lib/axiom";
 import { logEvent, type WideEvent } from "../lib/logEvent";
+import { assertPublicUrl } from "./adapters/assertPublicUrl";
 import { browserStorePageFetcher } from "./adapters/browserStorePageFetcher";
 import { firecrawlStorePageFetcher } from "./adapters/firecrawlStorePageFetcher";
 import { ogieStorePageFetcher } from "./adapters/ogieStorePageFetcher";
@@ -47,6 +48,17 @@ export const extractFromUrl = action({
       event.error = { code: "Unauthenticated" };
       await flush();
       throw new ConvexError("Unauthenticated");
+    }
+
+    // SSRF pre-flight: enforce http(s) + a public DNS host on the ENTRY url ONCE, before any tier
+    // fetches. ogie (lexical-only) and firecrawl (forwards the raw url) thus never see a private
+    // host; browserStorePageFetcher still re-validates each redirect hop.
+    const publicCheck = await assertPublicUrl(url);
+    if (!publicCheck.ok) {
+      event.outcome = "error";
+      event.error = { code: publicCheck.code, detail: publicCheck.reason };
+      await flush();
+      return { ok: false as const, code: publicCheck.code };
     }
 
     try {

--- a/packages/backend/convex/catalog/getAllBrands.ts
+++ b/packages/backend/convex/catalog/getAllBrands.ts
@@ -3,15 +3,18 @@ import { stream } from "convex-helpers/server/stream";
 import { query } from "../_generated/server";
 import schema from "../schema";
 
-// Catalog read: the distinct brand names for the filter dropdown. Logic preserved from legacy
-// puzzles.getAllBrands (distinct over the by_brand index). Brand is optional in the catalog, so the
-// list may contain `undefined` entries — the UI renders those as an empty option, as it does today.
+// Catalog read: the distinct brand names for the filter dropdown. Distinct over the by_brand index,
+// restricted to approved puzzles so brand free-text from pending/rejected submissions never leaks
+// into the public filter UI (consistent with every sibling catalog read). Brand is optional in the
+// catalog, so the list may contain `undefined` entries — the UI renders those as an empty option.
 export const getAllBrands = query({
   args: {},
   handler: async (ctx): Promise<BrandView[]> => {
     const brands = await stream(ctx.db, schema)
       .query("puzzles")
       .withIndex("by_brand", (q) => q)
+      // filterWith (not .filter, which streams reject) is applied before distinct.
+      .filterWith(async (p) => p.status === "approved")
       .distinct(["brand"])
       .collect();
     return brands.map((brand) => brand.brand);

--- a/packages/backend/convex/catalog/getAllTags.ts
+++ b/packages/backend/convex/catalog/getAllTags.ts
@@ -3,14 +3,18 @@ import { stream } from "convex-helpers/server/stream";
 import { query } from "../_generated/server";
 import schema from "../schema";
 
-// Catalog read: the distinct, flattened, de-duplicated tag set for the filter UI. Logic preserved
-// from legacy puzzles.getAllTags (distinct over by_tags, then flatten + dedupe).
+// Catalog read: the distinct, flattened, de-duplicated tag set for the filter UI (distinct over
+// by_tags, then flatten + dedupe). Restricted to approved puzzles so tag free-text from
+// pending/rejected submissions never leaks into the public filter UI (consistent with every sibling
+// catalog read).
 export const getAllTags = query({
   args: {},
   handler: async (ctx): Promise<TagView[]> => {
     const tags = await stream(ctx.db, schema)
       .query("puzzles")
       .withIndex("by_tags", (q) => q)
+      // filterWith (not .filter, which streams reject) is applied before distinct.
+      .filterWith(async (p) => p.status === "approved")
       .distinct(["tags"])
       .collect();
     return tags

--- a/packages/backend/convex/catalog/getPuzzleById.ts
+++ b/packages/backend/convex/catalog/getPuzzleById.ts
@@ -1,15 +1,46 @@
 import type { PuzzleDefinitionView } from "@jigswap/contracts";
 import { v } from "convex/values";
-import { query } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { query, type QueryCtx } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { toPuzzleDefinitionView } from "./mappers";
 
+// Resolve the acting member from auth WITHOUT throwing (unlike requireMember): an unauthenticated
+// caller, or one whose Clerk subject has no user row, simply yields null. Used only to decide
+// whether a NON-approved definition may be disclosed to its submitter.
+const optionalActingMember = async (
+  ctx: QueryCtx,
+): Promise<Id<"users"> | null> => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) return null;
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+    .unique();
+  return user?._id ?? null;
+};
+
 // Catalog read: a single puzzle definition by Convex id, with its box-art URL resolved. Returns a
-// typed DTO instead of the raw row; behaviour-preserving vs legacy puzzles.getPuzzleById.
+// typed DTO instead of the raw row.
+//
+// Moderation gate (mirrors every sibling catalog read, which filters `status === "approved"`):
+// a definition is only disclosed when it is APPROVED, OR the caller is its submitter, OR the caller
+// is an admin. This closes a by-id leak of pending/rejected definitions while preserving the
+// legitimate add/new.tsx `?puzzleId=` flow where a submitter pre-fills from their own (possibly
+// still pending) submission. Unauthenticated reads of approved definitions are unchanged.
 export const getPuzzleById = query({
   args: { puzzleId: v.id("puzzles") },
   handler: async (ctx, args): Promise<PuzzleDefinitionView | null> => {
     const puzzle = await ctx.db.get(args.puzzleId);
     if (!puzzle) return null;
+
+    if (puzzle.status !== "approved") {
+      const actingMember = await optionalActingMember(ctx);
+      const isSubmitter =
+        actingMember !== null && puzzle.submittedBy === actingMember;
+      if (!isSubmitter && !(await isAdmin(ctx))) return null;
+    }
+
     const image = puzzle.image ? await ctx.storage.getUrl(puzzle.image) : null;
     return toPuzzleDefinitionView(puzzle, image);
   },

--- a/packages/backend/convex/catalog/importPuzzleImage.ts
+++ b/packages/backend/convex/catalog/importPuzzleImage.ts
@@ -17,6 +17,13 @@ const ALLOWED_TYPES = [
 ];
 
 // Reject any hostname that resolves to a private/loopback/link-local address (SSRF guard).
+//
+// RESIDUAL RISK — DNS-rebinding TOCTOU (finding #14, accepted): this resolves DNS, then the fetch()
+// below resolves DNS again independently, so a low-TTL attacker-controlled record can differ between
+// the two. Per-hop re-validation (manual redirects) closes the redirect rebind but NOT the single-
+// request rebind. Pinning the validated IP into the connection (a custom undici Dispatcher lookup)
+// is the real fix and is deferred. isPrivateIp covers loopback/RFC-1918/link-local/CGNAT/192.0.0.0/24
+// (incl. 169.254.169.254 metadata) as defense-in-depth.
 const assertPublicHost = async (hostname: string): Promise<void> => {
   const addresses = await dnsLookup(hostname, { all: true });
   if (addresses.length === 0 || addresses.some((a) => isPrivateIp(a.address))) {

--- a/packages/backend/convex/catalog/listPendingPuzzleDefinitions.ts
+++ b/packages/backend/convex/catalog/listPendingPuzzleDefinitions.ts
@@ -1,4 +1,6 @@
+import { ConvexError } from "convex/values";
 import { query } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 
 // Read side for the moderation queue: the pending submissions awaiting approve/reject. Admin-only
@@ -7,6 +9,7 @@ export const listPendingPuzzleDefinitions = query({
   args: {},
   handler: async (ctx) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
 
     const pending = await ctx.db
       .query("puzzles")

--- a/packages/backend/convex/catalog/rejectPuzzleDefinition.ts
+++ b/packages/backend/convex/catalog/rejectPuzzleDefinition.ts
@@ -1,6 +1,7 @@
 import { makeRejectPuzzleDefinition } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { runDefinitionAction } from "./runDefinitionAction";
 
@@ -9,6 +10,7 @@ export const rejectPuzzleDefinition = mutation({
   args: { puzzleDefinitionId: v.string() },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
     await runDefinitionAction(
       ctx,
       args.puzzleDefinitionId,

--- a/packages/backend/convex/catalog/reorderCatalogCategories.ts
+++ b/packages/backend/convex/catalog/reorderCatalogCategories.ts
@@ -2,8 +2,9 @@ import {
   makeReorderCatalogCategories,
   toCatalogCategoryId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
 import { noopEventPublisher } from "./adapters/eventPublisher";
@@ -20,6 +21,7 @@ export const reorderCatalogCategories = mutation({
   },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
 
     const reorder = makeReorderCatalogCategories({
       categories: convexCatalogCategoryRepository(ctx),

--- a/packages/backend/convex/catalog/reorderCatalogCategories.ts
+++ b/packages/backend/convex/catalog/reorderCatalogCategories.ts
@@ -7,7 +7,7 @@ import { mutation } from "../_generated/server";
 import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -25,7 +25,7 @@ export const reorderCatalogCategories = mutation({
 
     const reorder = makeReorderCatalogCategories({
       categories: convexCatalogCategoryRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/runDefinitionAction.ts
+++ b/packages/backend/convex/catalog/runDefinitionAction.ts
@@ -8,7 +8,7 @@ import {
 } from "@jigswap/domain";
 import type { MutationCtx } from "../_generated/server";
 import { convexPuzzleDefinitionRepository } from "./adapters/convexPuzzleDefinitionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -26,7 +26,7 @@ export const runDefinitionAction = async (
 ): Promise<void> => {
   const action = make({
     definitions: convexPuzzleDefinitionRepository(ctx),
-    events: noopEventPublisher(ctx),
+    events: catalogEventPublisher(ctx),
     clock: systemClock,
   });
   const result = await action({

--- a/packages/backend/convex/catalog/setCatalogCategoryActive.ts
+++ b/packages/backend/convex/catalog/setCatalogCategoryActive.ts
@@ -2,8 +2,9 @@ import {
   makeSetCatalogCategoryActive,
   toCatalogCategoryId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
 import { noopEventPublisher } from "./adapters/eventPublisher";
@@ -16,6 +17,7 @@ export const setCatalogCategoryActive = mutation({
   args: { catalogCategoryId: v.string(), isActive: v.boolean() },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
 
     const setActive = makeSetCatalogCategoryActive({
       categories: convexCatalogCategoryRepository(ctx),

--- a/packages/backend/convex/catalog/setCatalogCategoryActive.ts
+++ b/packages/backend/convex/catalog/setCatalogCategoryActive.ts
@@ -7,7 +7,7 @@ import { mutation } from "../_generated/server";
 import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -21,7 +21,7 @@ export const setCatalogCategoryActive = mutation({
 
     const setActive = makeSetCatalogCategoryActive({
       categories: convexCatalogCategoryRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/submitPuzzleDefinition.ts
+++ b/packages/backend/convex/catalog/submitPuzzleDefinition.ts
@@ -9,7 +9,7 @@ import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { catalogIdGenerator } from "./adapters/catalogIdGenerator";
 import { convexPuzzleDefinitionRepository } from "./adapters/convexPuzzleDefinitionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -64,7 +64,7 @@ export const submitPuzzleDefinition = mutation({
     const submit = makeSubmitPuzzleDefinition({
       definitions: convexPuzzleDefinitionRepository(ctx),
       ids: catalogIdGenerator,
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/updateCatalogCategory.ts
+++ b/packages/backend/convex/catalog/updateCatalogCategory.ts
@@ -2,8 +2,9 @@ import {
   makeUpdateCatalogCategory,
   toCatalogCategoryId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
 import { noopEventPublisher } from "./adapters/eventPublisher";
@@ -23,6 +24,7 @@ export const updateCatalogCategory = mutation({
   },
   handler: async (ctx, args) => {
     await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
 
     const update = makeUpdateCatalogCategory({
       categories: convexCatalogCategoryRepository(ctx),

--- a/packages/backend/convex/catalog/updateCatalogCategory.ts
+++ b/packages/backend/convex/catalog/updateCatalogCategory.ts
@@ -7,7 +7,7 @@ import { mutation } from "../_generated/server";
 import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogCategoryRepository } from "./adapters/convexCatalogCategoryRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -28,7 +28,7 @@ export const updateCatalogCategory = mutation({
 
     const update = makeUpdateCatalogCategory({
       categories: convexCatalogCategoryRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/updatePuzzleDefinition.ts
+++ b/packages/backend/convex/catalog/updatePuzzleDefinition.ts
@@ -9,7 +9,7 @@ import { mutation } from "../_generated/server";
 import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexPuzzleDefinitionRepository } from "./adapters/convexPuzzleDefinitionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { catalogEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -72,7 +72,7 @@ export const updatePuzzleDefinition = mutation({
 
     const update = makeUpdatePuzzleDefinition({
       definitions,
-      events: noopEventPublisher(ctx),
+      events: catalogEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/catalog/updatePuzzleDefinition.ts
+++ b/packages/backend/convex/catalog/updatePuzzleDefinition.ts
@@ -4,8 +4,9 @@ import {
   toCatalogCategoryId,
   toPuzzleDefinitionId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
 import { requireMember } from "../identity/requireMember";
 import { convexPuzzleDefinitionRepository } from "./adapters/convexPuzzleDefinitionRepository";
 import { noopEventPublisher } from "./adapters/eventPublisher";
@@ -55,10 +56,22 @@ export const updatePuzzleDefinition = mutation({
     image: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await requireMember(ctx);
+    const actingMember = await requireMember(ctx);
+
+    const definitions = convexPuzzleDefinitionRepository(ctx);
+
+    // Ownership ACL: only the original submitter or an admin may edit a definition.
+    const existing = await definitions.findById(
+      toPuzzleDefinitionId(args.puzzleDefinitionId),
+    );
+    if (!existing) throw new ConvexError("Not found");
+    const submittedBy = existing.toState().submittedBy as unknown as string;
+    if (submittedBy !== (actingMember as unknown as string)) {
+      if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
+    }
 
     const update = makeUpdatePuzzleDefinition({
-      definitions: convexPuzzleDefinitionRepository(ctx),
+      definitions,
       events: noopEventPublisher(ctx),
       clock: systemClock,
     });

--- a/packages/backend/convex/catalogMutations.test.ts
+++ b/packages/backend/convex/catalogMutations.test.ts
@@ -27,6 +27,12 @@ const seedMember = async (t: ReturnType<typeof convexTest>) =>
 const asAlice = (t: ReturnType<typeof convexTest>) =>
   t.withIdentity({ subject: "clerk_alice" });
 
+// Alice acting as an admin: the moderation + taxonomy mutations now assert isAdmin server-side
+// (the role lives in the Clerk JWT's metadata.role claim). Keep the same Clerk subject so the
+// resolved member is still the seeded `clerk_alice`.
+const asAdmin = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice", metadata: { role: "admin" } });
+
 const puzzleRow = (t: ReturnType<typeof convexTest>, aggregateId: string) =>
   t.run(async (ctx) =>
     ctx.db
@@ -153,7 +159,7 @@ describe("catalog.submitPuzzleDefinition", () => {
   test("submits with a category, persisting the real id and round-tripping the aggregateId", async () => {
     const t = convexTest(schema, modules);
     await seedMember(t);
-    const categoryId = (await asAlice(t).mutation(
+    const categoryId = (await asAdmin(t).mutation(
       api.catalog.createCatalogCategory.createCatalogCategory,
       { name: { en: "Animals", nl: "Dieren" }, sortOrder: 1 },
     )) as string;
@@ -197,7 +203,7 @@ describe("catalog moderation lifecycle", () => {
   test("approve moves pending -> approved", async () => {
     const t = convexTest(schema, modules);
     const id = await submitPending(t);
-    await asAlice(t).mutation(
+    await asAdmin(t).mutation(
       api.catalog.approvePuzzleDefinition.approvePuzzleDefinition,
       {
         puzzleDefinitionId: id,
@@ -209,7 +215,7 @@ describe("catalog moderation lifecycle", () => {
   test("reject moves pending -> rejected", async () => {
     const t = convexTest(schema, modules);
     const id = await submitPending(t);
-    await asAlice(t).mutation(
+    await asAdmin(t).mutation(
       api.catalog.rejectPuzzleDefinition.rejectPuzzleDefinition,
       {
         puzzleDefinitionId: id,
@@ -221,14 +227,14 @@ describe("catalog moderation lifecycle", () => {
   test("illegal transition rejected (approve an already-rejected definition)", async () => {
     const t = convexTest(schema, modules);
     const id = await submitPending(t);
-    await asAlice(t).mutation(
+    await asAdmin(t).mutation(
       api.catalog.rejectPuzzleDefinition.rejectPuzzleDefinition,
       {
         puzzleDefinitionId: id,
       },
     );
     await expectConvexCode(
-      asAlice(t).mutation(
+      asAdmin(t).mutation(
         api.catalog.approvePuzzleDefinition.approvePuzzleDefinition,
         {
           puzzleDefinitionId: id,
@@ -242,7 +248,7 @@ describe("catalog moderation lifecycle", () => {
     const t = convexTest(schema, modules);
     await seedMember(t);
     await expectConvexCode(
-      asAlice(t).mutation(
+      asAdmin(t).mutation(
         api.catalog.approvePuzzleDefinition.approvePuzzleDefinition,
         {
           puzzleDefinitionId: crypto.randomUUID(),
@@ -295,7 +301,7 @@ describe("catalog category management", () => {
     sortOrder: number,
     name = NAME,
   ) =>
-    (await asAlice(t).mutation(
+    (await asAdmin(t).mutation(
       api.catalog.createCatalogCategory.createCatalogCategory,
       { name, sortOrder },
     )) as string;
@@ -314,7 +320,7 @@ describe("catalog category management", () => {
     const t = convexTest(schema, modules);
     await seedMember(t);
     await expectConvexCode(
-      asAlice(t).mutation(
+      asAdmin(t).mutation(
         api.catalog.createCatalogCategory.createCatalogCategory,
         {
           name: { en: "Animals", nl: "  " },
@@ -330,7 +336,7 @@ describe("catalog category management", () => {
     await seedMember(t);
     const a = await createCategory(t, 1, { en: "A", nl: "A" });
     const b = await createCategory(t, 2, { en: "B", nl: "B" });
-    await asAlice(t).mutation(
+    await asAdmin(t).mutation(
       api.catalog.reorderCatalogCategories.reorderCatalogCategories,
       {
         order: [
@@ -347,7 +353,7 @@ describe("catalog category management", () => {
     const t = convexTest(schema, modules);
     await seedMember(t);
     const id = await createCategory(t, 1);
-    await asAlice(t).mutation(
+    await asAdmin(t).mutation(
       api.catalog.setCatalogCategoryActive.setCatalogCategoryActive,
       { catalogCategoryId: id, isActive: false },
     );

--- a/packages/backend/convex/catalogReads.test.ts
+++ b/packages/backend/convex/catalogReads.test.ts
@@ -177,19 +177,25 @@ describe("catalog reads", () => {
     expect(categories.map((c) => c.name.en)).toEqual(["Landscapes"]);
   });
 
-  test("getAllBrands returns the distinct brand set", async () => {
+  test("getAllBrands returns approved brands only (pending brand excluded)", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
 
     const brands = await t.query(api.catalog.getAllBrands.getAllBrands, {});
-    expect(new Set(brands)).toEqual(new Set(["Ravensburger", "Clementoni"]));
+    // Only the approved puzzle's brand surfaces; the pending puzzle's brand
+    // ("Clementoni") must NOT leak into the public filter dropdown.
+    expect(new Set(brands)).toEqual(new Set(["Ravensburger"]));
+    expect(brands).not.toContain("Clementoni");
   });
 
-  test("getAllTags returns the flattened, de-duplicated tag set", async () => {
+  test("getAllTags returns approved tags only (pending-only tag excluded)", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
 
     const tags = await t.query(api.catalog.getAllTags.getAllTags, {});
-    expect(new Set(tags)).toEqual(new Set(["nature", "mountains", "ocean"]));
+    // Approved puzzle's tags surface; "ocean" only exists on the pending puzzle
+    // and must NOT leak. "nature" is shared, so it still appears.
+    expect(new Set(tags)).toEqual(new Set(["nature", "mountains"]));
+    expect(tags).not.toContain("ocean");
   });
 });

--- a/packages/backend/convex/catalogReads.test.ts
+++ b/packages/backend/convex/catalogReads.test.ts
@@ -36,6 +36,16 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       updatedAt: now,
     });
 
+    // A second member who is NOT the submitter of the pending definition below.
+    const bob = await ctx.db.insert("users", {
+      clerkId: "clerk_bob",
+      email: "bob@example.com",
+      name: "Bob",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
     const approved = await ctx.db.insert("puzzles", {
       aggregateId: "def-approved",
       title: "Mountain Vista",
@@ -50,8 +60,8 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       createdAt: now,
       updatedAt: now,
     });
-    // Pending: excluded from public lists/suggestions.
-    await ctx.db.insert("puzzles", {
+    // Pending: excluded from public lists/suggestions. Submitted by Alice.
+    const pending = await ctx.db.insert("puzzles", {
       aggregateId: "def-pending",
       title: "Secret Ocean",
       brand: "Clementoni",
@@ -64,7 +74,7 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       updatedAt: now,
     });
 
-    return { alice, category, approved };
+    return { alice, bob, category, approved, pending };
   });
 
 describe("catalog reads", () => {
@@ -81,6 +91,38 @@ describe("catalog reads", () => {
     expect(view?.status).toBe("approved");
     // Box-art unset -> resolved as null (DTO contract), not the raw storage id.
     expect(view?.image).toBeNull();
+  });
+
+  test("getPuzzleById hides a pending definition from a non-submitter but reveals it to the submitter/admin", async () => {
+    const t = convexTest(schema, modules);
+    const { pending } = await seed(t);
+
+    // Unauthenticated: a pending definition's id must NOT leak.
+    expect(
+      await t.query(api.catalog.getPuzzleById.getPuzzleById, {
+        puzzleId: pending,
+      }),
+    ).toBeNull();
+
+    // A different, authenticated member is still not allowed to see it.
+    expect(
+      await t
+        .withIdentity({ subject: "clerk_bob" })
+        .query(api.catalog.getPuzzleById.getPuzzleById, { puzzleId: pending }),
+    ).toBeNull();
+
+    // The submitter (Alice) sees her own pending definition (the add/new.tsx ?puzzleId flow).
+    const asSubmitter = await t
+      .withIdentity({ subject: "clerk_alice" })
+      .query(api.catalog.getPuzzleById.getPuzzleById, { puzzleId: pending });
+    expect(asSubmitter?.title).toBe("Secret Ocean");
+    expect(asSubmitter?.status).toBe("pending");
+
+    // An admin (role claim) sees it too, even though they did not submit it.
+    const asAdmin = await t
+      .withIdentity({ subject: "clerk_bob", metadata: { role: "admin" } })
+      .query(api.catalog.getPuzzleById.getPuzzleById, { puzzleId: pending });
+    expect(asAdmin?.title).toBe("Secret Ocean");
   });
 
   test("listAllPuzzles returns only approved definitions", async () => {

--- a/packages/backend/convex/custody/getCopyCustodyTimeline.ts
+++ b/packages/backend/convex/custody/getCopyCustodyTimeline.ts
@@ -1,20 +1,26 @@
 import type {
   CopyCustodyTimelineView,
   CustodyTransferView,
+  ProjectedMember,
 } from "@jigswap/contracts";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
-import { toMemberView } from "../identity/toMemberView";
+import { requireMember } from "../identity/requireMember";
+import { projectMemberIdentity } from "../social/privacy";
 
 // Chain-of-Custody read: a Copy's full provenance assembled from the custody projection. Ownership
 // IS reassigned on a swap/sale, so the copy's stored ownerId is the CURRENT holder; the chain is
 // derived from the projected entries — the original owner is the first transfer's previousOwner and
 // the current owner is the last transfer's recipient (falling back to the copy's owner when it was
-// never transferred). Member views are resolved via the shared identity mapper; null when unresolved.
+// never transferred). Auth-gated; every surfaced member is run through `projectMemberIdentity`
+// (salt = copyId) so a hidden member's real identity never enters the returned DTO — mirroring
+// getCopyInstanceView's privacy contract.
 export const getCopyCustodyTimeline = query({
   args: { copyId: v.id("ownedPuzzles") },
   handler: async (ctx, args): Promise<CopyCustodyTimelineView | null> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const copy = await ctx.db.get(args.copyId);
     if (!copy) return null;
 
@@ -24,37 +30,43 @@ export const getCopyCustodyTimeline = query({
       .order("asc")
       .collect();
 
-    // Resolve every distinct member once (current owner + each transfer's from/to).
-    const memberIds = new Set<string>([
-      copy.ownerId,
-      ...entries.flatMap((e) => [e.previousOwner, e.newOwner]),
-    ]);
-    const members = new Map(
-      await Promise.all(
-        [...memberIds].map(async (id) => {
-          const user = await ctx.db.get(id as Id<"users">);
-          return [id, user ? toMemberView(user) : null] as const;
-        }),
-      ),
-    );
+    const salt = args.copyId as string;
+    // Memoise the projection per target so a hidden member yields one stable anonRef across every
+    // surfaced reference (same target + same salt -> same token).
+    const projections = new Map<string, Promise<ProjectedMember>>();
+    const project = (targetId: string): Promise<ProjectedMember> => {
+      const existing = projections.get(targetId);
+      if (existing) return existing;
+      const p = projectMemberIdentity(
+        ctx,
+        viewerId,
+        targetId as Id<"users">,
+        salt,
+      );
+      projections.set(targetId, p);
+      return p;
+    };
 
-    const transfers: CustodyTransferView[] = entries.map((e) => ({
-      exchangeId: e.exchangeId,
-      newOwner: members.get(e.newOwner) ?? null,
-      occurredAt: e.occurredAt,
-    }));
+    const transfers: CustodyTransferView[] = await Promise.all(
+      entries.map(async (e) => ({
+        exchangeId: e.exchangeId,
+        newOwner: await project(e.newOwner),
+        occurredAt: e.occurredAt,
+      })),
+    );
 
     const first = entries.at(0);
     const last = entries.at(-1);
+    const originalOwner = await project(
+      first ? first.previousOwner : copy.ownerId,
+    );
+    const currentOwner = await project(last ? last.newOwner : copy.ownerId);
+
     return {
       copyId: args.copyId,
-      originalOwner:
-        (first
-          ? members.get(first.previousOwner)
-          : members.get(copy.ownerId)) ?? null,
+      originalOwner,
       transfers,
-      currentOwner:
-        (last ? members.get(last.newOwner) : members.get(copy.ownerId)) ?? null,
+      currentOwner,
     };
   },
 });

--- a/packages/backend/convex/custody/getCopyCustodyTimeline.ts
+++ b/packages/backend/convex/custody/getCopyCustodyTimeline.ts
@@ -7,6 +7,7 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { canViewCopy } from "../library/canViewCopy";
 import { projectMemberIdentity } from "../social/privacy";
 
 // Chain-of-Custody read: a Copy's full provenance assembled from the custody projection. Ownership
@@ -23,6 +24,9 @@ export const getCopyCustodyTimeline = query({
 
     const copy = await ctx.db.get(args.copyId);
     if (!copy) return null;
+    // Copy-reachability gate (identical to browseOwnedPuzzles / getCopyInstanceView): a non-owner
+    // may not read the custody chain of a private/unreachable copy.
+    if (!(await canViewCopy(ctx, viewerId, copy))) return null;
 
     const entries = await ctx.db
       .query("copyCustodyEntries")

--- a/packages/backend/convex/custody/subscriber.ts
+++ b/packages/backend/convex/custody/subscriber.ts
@@ -23,7 +23,9 @@ export const handleDomainEvent = async (
   if (!copy) return;
 
   await ctx.db.insert("copyCustodyEntries", {
-    copyId: p.copyId as string,
+    // Persist the resolved row's `_id`, not the raw payload value, so `copyId` always matches the
+    // `ownedPuzzles._id` the timeline query indexes by (avoids _id vs aggregateId drift).
+    copyId: copy._id as string,
     exchangeId: p.exchangeId as string,
     previousOwner: copy.ownerId,
     newOwner: p.newOwner as string,

--- a/packages/backend/convex/custodyTimeline.test.ts
+++ b/packages/backend/convex/custodyTimeline.test.ts
@@ -209,6 +209,9 @@ describe("custody.getCopyCustodyTimeline", () => {
     // After the first sale the copy belongs to Alice; Bob now buys it FROM Alice.
     const secondExchange = await settleSaleToBob(t, copy, alice, "clerk_alice");
     await flushScheduled(t);
+    // Settlement closes the copy; re-open it so the (public-owner) reachability gate lets a third
+    // party reach the copy-detail timeline.
+    await reopenForSale(t, copy);
 
     const timeline = await asCarol(t).query(
       api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline,
@@ -235,6 +238,29 @@ describe("custody.getCopyCustodyTimeline", () => {
     );
   });
 
+  test("returns null for a non-owner when the copy is unreachable (private+closed owner)", async () => {
+    const t = convexTest(schema, modules);
+    const { copy, owner } = await seed(t);
+    // Owner is private and the copy is closed -> unreachable for a non-owner (Carol).
+    await t.run(async (ctx) => {
+      await ctx.db.insert("profiles", {
+        memberId: owner,
+        displayName: "clerk_owner",
+        visibility: "private",
+        updatedAt: Date.now(),
+      });
+      await ctx.db.patch(copy, {
+        availability: { forTrade: false, forSale: false, forLend: false },
+      });
+    });
+
+    const timeline = await asCarol(t).query(
+      api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline,
+      { copyId: copy },
+    );
+    expect(timeline).toBeNull();
+  });
+
   test("anonymises a private member the viewer is not connected to", async () => {
     const t = convexTest(schema, modules);
     const { copy, owner } = await seed(t);
@@ -251,6 +277,9 @@ describe("custody.getCopyCustodyTimeline", () => {
         updatedAt: Date.now(),
       }),
     );
+    // The CURRENT owner (Alice) is public; re-open the copy so Carol can reach the copy-detail
+    // timeline (the gate keys on the current owner's profile + the copy being open).
+    await reopenForSale(t, copy);
 
     const timeline = await asCarol(t).query(
       api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline,
@@ -294,10 +323,12 @@ describe("ownership move on settlement", () => {
     const row = await t.run(async (ctx) => ctx.db.get(copy));
     expect(row?.ownerId).toBe(owner); // a loan is possession only — ownership stays with the lender
 
-    const timeline = await asAlice(t).query(
-      api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline,
-      { copyId: copy },
-    );
+    // The copy is reset to closed after settlement; the owner can always view their own timeline.
+    const timeline = await t
+      .withIdentity({ subject: "clerk_owner" })
+      .query(api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline, {
+        copyId: copy,
+      });
     expect(timeline!.transfers).toEqual([]);
     expect(projectedName(timeline!.currentOwner)).toBe("clerk_owner");
   });

--- a/packages/backend/convex/custodyTimeline.test.ts
+++ b/packages/backend/convex/custodyTimeline.test.ts
@@ -129,25 +129,28 @@ const settleLoanToAlice = async (
   return id;
 };
 
+// Bob buys the copy from its CURRENT owner (`seller`). After the first sale the copy belongs to
+// Alice, so the second sale must name Alice as the recipient/seller (she now owns the copy).
 const settleSaleToBob = async (
   t: ReturnType<typeof convexTest>,
   copy: Id<"ownedPuzzles">,
-  owner: Id<"users">,
+  seller: Id<"users">,
+  sellerAuth: string,
 ) => {
   const id = await asBob(t).mutation(api.exchange.propose.propose, {
-    recipientId: owner,
+    recipientId: seller,
     type: "sale",
     requestedPuzzleId: copy,
     salePrice: 1200,
   });
   await t
-    .withIdentity({ subject: "clerk_owner" })
+    .withIdentity({ subject: sellerAuth })
     .mutation(api.exchange.accept.accept, { exchangeId: id });
   await asBob(t).mutation(api.exchange.confirmCompletion.confirmCompletion, {
     exchangeId: id,
   });
   await t
-    .withIdentity({ subject: "clerk_owner" })
+    .withIdentity({ subject: sellerAuth })
     .mutation(api.exchange.confirmCompletion.confirmCompletion, {
       exchangeId: id,
     });
@@ -181,12 +184,13 @@ describe("custody.getCopyCustodyTimeline", () => {
 
   test("projects two settled transfers in chronological order with exchange + owner", async () => {
     const t = convexTest(schema, modules);
-    const { copy, owner } = await seed(t);
+    const { copy, owner, alice } = await seed(t);
 
     const firstExchange = await settleSaleToAlice(t, copy, owner);
     await flushScheduled(t);
     await reopenForSale(t, copy);
-    const secondExchange = await settleSaleToBob(t, copy, owner);
+    // After the first sale the copy belongs to Alice; Bob now buys it FROM Alice.
+    const secondExchange = await settleSaleToBob(t, copy, alice, "clerk_alice");
     await flushScheduled(t);
 
     const timeline = await asCarol(t).query(

--- a/packages/backend/convex/custodyTimeline.test.ts
+++ b/packages/backend/convex/custodyTimeline.test.ts
@@ -1,8 +1,15 @@
+import type { ProjectedMember } from "@jigswap/contracts";
 import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
+
+// Read a privacy-projected member's name: revealed -> their name; anonymised -> null. The members in
+// this suite have no profiles row (default "public"), so they always resolve revealed.
+const projectedName = (m: ProjectedMember): string | null =>
+  m.anonymous ? null : m.member.name;
 
 // Bundle every Convex module for the in-memory runtime, excluding test files.
 const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
@@ -158,6 +165,16 @@ const settleSaleToBob = async (
 };
 
 describe("custody.getCopyCustodyTimeline", () => {
+  test("rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    const { copy } = await seed(t);
+    await expect(
+      t.query(api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline, {
+        copyId: copy,
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
   test("returns null for a missing copy", async () => {
     const t = convexTest(schema, modules);
     const { copy } = await seed(t);
@@ -178,8 +195,8 @@ describe("custody.getCopyCustodyTimeline", () => {
     );
     expect(timeline).not.toBeNull();
     expect(timeline!.transfers).toEqual([]);
-    expect(timeline!.originalOwner?.name).toBe("clerk_owner");
-    expect(timeline!.currentOwner?.name).toBe("clerk_owner");
+    expect(projectedName(timeline!.originalOwner)).toBe("clerk_owner");
+    expect(projectedName(timeline!.currentOwner)).toBe("clerk_owner");
   });
 
   test("projects two settled transfers in chronological order with exchange + owner", async () => {
@@ -200,11 +217,11 @@ describe("custody.getCopyCustodyTimeline", () => {
 
     expect(timeline).not.toBeNull();
     // Original owner is the copy creator; current owner is the LAST transfer's recipient.
-    expect(timeline!.originalOwner?.name).toBe("clerk_owner");
-    expect(timeline!.currentOwner?.name).toBe("clerk_bob");
+    expect(projectedName(timeline!.originalOwner)).toBe("clerk_owner");
+    expect(projectedName(timeline!.currentOwner)).toBe("clerk_bob");
 
     expect(timeline!.transfers).toHaveLength(2);
-    expect(timeline!.transfers.map((x) => x.newOwner?.name)).toEqual([
+    expect(timeline!.transfers.map((x) => projectedName(x.newOwner))).toEqual([
       "clerk_alice",
       "clerk_bob",
     ]);
@@ -216,6 +233,37 @@ describe("custody.getCopyCustodyTimeline", () => {
     expect(timeline!.transfers[0].occurredAt).toBeLessThanOrEqual(
       timeline!.transfers[1].occurredAt,
     );
+  });
+
+  test("anonymises a private member the viewer is not connected to", async () => {
+    const t = convexTest(schema, modules);
+    const { copy, owner } = await seed(t);
+
+    await settleSaleToAlice(t, copy, owner);
+    await flushScheduled(t);
+
+    // Make the original owner private; Carol (the viewer) does not follow them.
+    await t.run(async (ctx) =>
+      ctx.db.insert("profiles", {
+        memberId: owner,
+        displayName: "clerk_owner",
+        visibility: "private",
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const timeline = await asCarol(t).query(
+      api.custody.getCopyCustodyTimeline.getCopyCustodyTimeline,
+      { copyId: copy },
+    );
+
+    // The private original owner is anonymised — no real name crosses the wire.
+    expect(timeline!.originalOwner.anonymous).toBe(true);
+    if (timeline!.originalOwner.anonymous) {
+      expect(timeline!.originalOwner.anonRef).toBeTruthy();
+    }
+    // Alice (public) is still revealed as the recipient/current owner.
+    expect(projectedName(timeline!.currentOwner)).toBe("clerk_alice");
   });
 });
 
@@ -251,6 +299,6 @@ describe("ownership move on settlement", () => {
       { copyId: copy },
     );
     expect(timeline!.transfers).toEqual([]);
-    expect(timeline!.currentOwner?.name).toBe("clerk_owner");
+    expect(projectedName(timeline!.currentOwner)).toBe("clerk_owner");
   });
 });

--- a/packages/backend/convex/exchange/getExchangeById.ts
+++ b/packages/backend/convex/exchange/getExchangeById.ts
@@ -33,8 +33,10 @@ export const getExchangeById = query({
       ...toExchangeFields(exchange),
       requester: requester ? toMemberView(requester) : null,
       owner: owner ? toMemberView(owner) : null,
-      ownerPuzzle: toOwnedPuzzleView(ownerPuzzle),
-      requesterPuzzle: toOwnedPuzzleView(requesterPuzzle),
+      // Gate each copy independently on the acting member: a party never sees the counterparty's
+      // owner-only fields (notes / acquisition provenance), only those on the copy they own.
+      ownerPuzzle: toOwnedPuzzleView(ownerPuzzle, member),
+      requesterPuzzle: toOwnedPuzzleView(requesterPuzzle, member),
     };
   },
 });

--- a/packages/backend/convex/exchange/getExchangeById.ts
+++ b/packages/backend/convex/exchange/getExchangeById.ts
@@ -1,6 +1,8 @@
 import type { ExchangeView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
 import { toExchangeFields, toOwnedPuzzleView } from "./readViews";
 
@@ -10,8 +12,15 @@ import { toExchangeFields, toOwnedPuzzleView } from "./readViews";
 export const getExchangeById = query({
   args: { exchangeId: v.id("exchanges") },
   handler: async (ctx, args): Promise<ExchangeView | null> => {
+    const member = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const exchange = await ctx.db.get(args.exchangeId);
     if (!exchange) return null;
+
+    // Party-only: parties are the initiator/recipient; others get null (leaks emails/prices).
+    if (member !== exchange.initiatorId && member !== exchange.recipientId) {
+      return null;
+    }
 
     const [requester, owner, ownerPuzzle, requesterPuzzle] = await Promise.all([
       ctx.db.get(exchange.initiatorId),

--- a/packages/backend/convex/exchange/getExchangeMessages.ts
+++ b/packages/backend/convex/exchange/getExchangeMessages.ts
@@ -1,6 +1,8 @@
 import type { ExchangeMessageView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 
 // Exchange read (thin adapter): the conversation on an exchange, oldest-first, each message carrying
 // a resolved sender summary (_id/name/avatar only). Ordering and sender shape match legacy
@@ -8,6 +10,15 @@ import { query } from "../_generated/server";
 export const getExchangeMessages = query({
   args: { exchangeId: v.id("exchanges") },
   handler: async (ctx, args): Promise<ExchangeMessageView[]> => {
+    const member = (await requireMember(ctx)) as unknown as Id<"users">;
+
+    // Party-only: only the exchange's initiator/recipient may read its thread.
+    const exchange = await ctx.db.get(args.exchangeId);
+    if (!exchange) return [];
+    if (member !== exchange.initiatorId && member !== exchange.recipientId) {
+      return [];
+    }
+
     const messages = await ctx.db
       .query("messages")
       .withIndex("by_exchange", (q) => q.eq("exchangeId", args.exchangeId))

--- a/packages/backend/convex/exchange/getExchangesByOwner.ts
+++ b/packages/backend/convex/exchange/getExchangesByOwner.ts
@@ -22,7 +22,7 @@ export const getExchangesByOwner = query({
       .collect();
 
     const enriched = await Promise.all(
-      exchanges.map((tr) => enrichExchangeSummary(ctx, tr)),
+      exchanges.map((tr) => enrichExchangeSummary(ctx, tr, user._id)),
     );
     return enriched.sort((a, b) => b.createdAt - a.createdAt);
   },

--- a/packages/backend/convex/exchange/getExchangesByRequester.ts
+++ b/packages/backend/convex/exchange/getExchangesByRequester.ts
@@ -22,7 +22,7 @@ export const getExchangesByRequester = query({
       .collect();
 
     const enriched = await Promise.all(
-      exchanges.map((tr) => enrichExchangeSummary(ctx, tr)),
+      exchanges.map((tr) => enrichExchangeSummary(ctx, tr, user._id)),
     );
     return enriched.sort((a, b) => b.createdAt - a.createdAt);
   },

--- a/packages/backend/convex/exchange/getUserExchanges.ts
+++ b/packages/backend/convex/exchange/getUserExchanges.ts
@@ -11,7 +11,6 @@ type Roled = Doc<"exchanges"> & { userRole: "requester" | "owner" };
 // exchanges.getUserExchanges; only the per-row shape is now a typed ExchangeSummaryView.
 export const getUserExchanges = query({
   args: {
-    userId: v.id("users"),
     status: v.optional(
       v.union(
         v.literal("proposed"),
@@ -25,12 +24,22 @@ export const getUserExchanges = query({
     asOwner: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<ExchangeSummaryView[]> => {
+    // Scope to the authenticated member; never trust a client-supplied id (would leak any user's
+    // exchange history + partner emails). Mirror getExchangesByOwner: [] when unauthenticated.
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .unique();
+    if (!user) return [];
+
     let exchanges: Roled[] = [];
 
     if (args.asRequester !== false) {
       const requesterExchanges = await ctx.db
         .query("exchanges")
-        .withIndex("by_initiator", (q) => q.eq("initiatorId", args.userId))
+        .withIndex("by_initiator", (q) => q.eq("initiatorId", user._id))
         .collect();
       exchanges.push(
         ...requesterExchanges.map((tr) => ({
@@ -43,7 +52,7 @@ export const getUserExchanges = query({
     if (args.asOwner !== false) {
       const ownerExchanges = await ctx.db
         .query("exchanges")
-        .withIndex("by_recipient", (q) => q.eq("recipientId", args.userId))
+        .withIndex("by_recipient", (q) => q.eq("recipientId", user._id))
         .collect();
       exchanges.push(
         ...ownerExchanges.map((tr) => ({ ...tr, userRole: "owner" as const })),

--- a/packages/backend/convex/exchange/getUserExchanges.ts
+++ b/packages/backend/convex/exchange/getUserExchanges.ts
@@ -15,9 +15,10 @@ export const getUserExchanges = query({
       v.union(
         v.literal("proposed"),
         v.literal("accepted"),
-        v.literal("declined"),
+        v.literal("rejected"),
         v.literal("completed"),
         v.literal("cancelled"),
+        v.literal("disputed"),
       ),
     ),
     asRequester: v.optional(v.boolean()),

--- a/packages/backend/convex/exchange/getUserExchanges.ts
+++ b/packages/backend/convex/exchange/getUserExchanges.ts
@@ -67,7 +67,9 @@ export const getUserExchanges = query({
     exchanges.sort((a, b) => b.createdAt - a.createdAt);
 
     return Promise.all(
-      exchanges.map((tr) => enrichExchangeSummary(ctx, tr, tr.userRole)),
+      exchanges.map((tr) =>
+        enrichExchangeSummary(ctx, tr, user._id, tr.userRole),
+      ),
     );
   },
 });

--- a/packages/backend/convex/exchange/readViews.ts
+++ b/packages/backend/convex/exchange/readViews.ts
@@ -4,7 +4,7 @@ import type {
   ExchangePuzzleView,
   ExchangeSummaryView,
 } from "@jigswap/contracts";
-import type { Doc } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { toMemberView } from "../identity/toMemberView";
 
@@ -29,31 +29,45 @@ export const toExchangeFields = (e: Doc<"exchanges">): ExchangeFields => ({
   updatedAt: e.updatedAt,
 });
 
+/**
+ * SECURITY: an exchange shows BOTH parties two owned copies (the requested copy owned by the
+ * recipient, the offered copy owned by the initiator) to BOTH parties. The owner-only personal
+ * fields — `notes` and the acquisition provenance (`acquisitionDate` / `acquisitionSource` /
+ * `acquisitionPrice`, i.e. where/when/what-was-paid) — must never cross to the counterparty, so they
+ * are OMITTED unless `viewerId` owns THIS specific copy (`c.ownerId === viewerId`). Mirrors
+ * `library/mappers.ts` `toOwnedCopyView` and `getCopyInstanceView`. `salePrice` is NOT owner-only:
+ * it is the public asking price for a copy listed for sale (and intrinsic to the exchange), so it is
+ * always carried. Each copy is gated independently — pass the acting member as `viewerId`.
+ */
 export const toOwnedPuzzleView = (
   c: Doc<"ownedPuzzles"> | null,
-): ExchangeOwnedPuzzleView | null =>
-  c
-    ? {
-        _id: c._id,
-        _creationTime: c._creationTime,
-        aggregateId: c.aggregateId,
-        puzzleId: c.puzzleId,
-        puzzleDefinitionId: c.puzzleDefinitionId,
-        snapshot: c.snapshot,
-        ownerId: c.ownerId,
-        condition: c.condition,
-        missingPiecesCount: c.missingPiecesCount,
-        notes: c.notes,
-        availability: c.availability,
-        visibility: c.visibility,
-        salePrice: c.salePrice,
-        acquisitionDate: c.acquisitionDate,
-        acquisitionSource: c.acquisitionSource,
-        acquisitionPrice: c.acquisitionPrice,
-        createdAt: c.createdAt,
-        updatedAt: c.updatedAt,
-      }
-    : null;
+  viewerId: Id<"users">,
+): ExchangeOwnedPuzzleView | null => {
+  if (!c) return null;
+  const viewerIsOwner = c.ownerId === viewerId;
+  return {
+    _id: c._id,
+    _creationTime: c._creationTime,
+    aggregateId: c.aggregateId,
+    puzzleId: c.puzzleId,
+    puzzleDefinitionId: c.puzzleDefinitionId,
+    snapshot: c.snapshot,
+    ownerId: c.ownerId,
+    condition: c.condition,
+    missingPiecesCount: c.missingPiecesCount,
+    // Owner-only personal fields: only surfaced when the viewer owns this copy.
+    notes: viewerIsOwner ? c.notes : undefined,
+    availability: c.availability,
+    visibility: c.visibility,
+    // Public asking price for a copy listed for sale — always carried.
+    salePrice: c.salePrice,
+    acquisitionDate: viewerIsOwner ? c.acquisitionDate : undefined,
+    acquisitionSource: viewerIsOwner ? c.acquisitionSource : undefined,
+    acquisitionPrice: viewerIsOwner ? c.acquisitionPrice : undefined,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  };
+};
 
 export const toPuzzleView = (
   p: Doc<"puzzles"> | null,
@@ -92,6 +106,7 @@ export const toPuzzleView = (
 export const enrichExchangeSummary = async (
   ctx: QueryCtx,
   e: Doc<"exchanges">,
+  viewerId: Id<"users">,
   userRole?: "requester" | "owner",
 ): Promise<ExchangeSummaryView> => {
   const [requester, owner, requestedOwnedPuzzle, offeredOwnedPuzzle] =
@@ -112,9 +127,10 @@ export const enrichExchangeSummary = async (
     ...(userRole ? { userRole } : {}),
     requester: requester ? toMemberView(requester) : null,
     owner: owner ? toMemberView(owner) : null,
-    requestedOwnedPuzzle: toOwnedPuzzleView(requestedOwnedPuzzle),
+    // Gate each copy independently: the viewer sees owner-only fields only on the copy they own.
+    requestedOwnedPuzzle: toOwnedPuzzleView(requestedOwnedPuzzle, viewerId),
     requestedPuzzle: toPuzzleView(requestedPuzzle),
-    offeredOwnedPuzzle: toOwnedPuzzleView(offeredOwnedPuzzle),
+    offeredOwnedPuzzle: toOwnedPuzzleView(offeredOwnedPuzzle, viewerId),
     offeredPuzzle: toPuzzleView(offeredPuzzle),
   };
 };

--- a/packages/backend/convex/exchangeQueries.test.ts
+++ b/packages/backend/convex/exchangeQueries.test.ts
@@ -52,6 +52,11 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       ownerId: bob,
       condition: "good",
       availability: { forTrade: true, forSale: false, forLend: false },
+      // Owner-only personal fields — must never reach the counterparty (Alice).
+      notes: "bob-private-note-mountain",
+      acquisitionSource: "bought_used",
+      acquisitionDate: now - 99_999,
+      acquisitionPrice: { amount: 4321, currency: "EUR" },
       createdAt: now,
       updatedAt: now,
     });
@@ -60,6 +65,11 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       ownerId: alice,
       condition: "like_new",
       availability: { forTrade: true, forSale: false, forLend: false },
+      // Owner-only personal fields — must never reach the counterparty (Bob).
+      notes: "alice-private-note-ocean",
+      acquisitionSource: "gift",
+      acquisitionDate: now - 88_888,
+      acquisitionPrice: { amount: 1234, currency: "USD" },
       createdAt: now,
       updatedAt: now,
     });
@@ -164,6 +174,101 @@ describe("exchange.getExchangeById", () => {
       },
     );
     expect(view).toBeNull();
+  });
+});
+
+describe("exchange owner-only field gating (counterparty must not see private copy data)", () => {
+  // Alice owns Ocean Calm (offered), Bob owns Mountain Vista (requested). On the shared exchange
+  // view each party must see owner-only fields (notes + acquisition provenance) ONLY on their own
+  // copy, never on the counterparty's. salePrice is public and is not asserted here.
+  const BOB_SECRETS = [
+    "bob-private-note-mountain",
+    "bought_used",
+    "4321",
+  ] as const;
+  const ALICE_SECRETS = ["alice-private-note-ocean", "gift", "1234"] as const;
+
+  test("getExchangeById: each party sees only their own copy's owner-only fields", async () => {
+    const t = convexTest(schema, modules);
+    const { older } = await seed(t);
+
+    // Alice is the initiator: ownerPuzzle = Bob's requested copy, requesterPuzzle = Alice's offered.
+    const aliceView = await asAlice(t).query(
+      api.exchange.getExchangeById.getExchangeById,
+      { exchangeId: older },
+    );
+    expect(aliceView?.requesterPuzzle?.notes).toBe("alice-private-note-ocean");
+    expect(aliceView?.requesterPuzzle?.acquisitionSource).toBe("gift");
+    expect(aliceView?.requesterPuzzle?.acquisitionPrice?.amount).toBe(1234);
+    expect(aliceView?.requesterPuzzle?.acquisitionDate).toBeDefined();
+    // Bob's copy (the counterparty's) must be stripped of every owner-only field.
+    expect(aliceView?.ownerPuzzle?.notes).toBeUndefined();
+    expect(aliceView?.ownerPuzzle?.acquisitionSource).toBeUndefined();
+    expect(aliceView?.ownerPuzzle?.acquisitionPrice).toBeUndefined();
+    expect(aliceView?.ownerPuzzle?.acquisitionDate).toBeUndefined();
+    const aliceJson = JSON.stringify(aliceView);
+    for (const secret of BOB_SECRETS) {
+      expect(aliceJson).not.toContain(secret);
+    }
+
+    // Bob is the recipient: he must see his own copy's fields and none of Alice's.
+    const bobView = await asBob(t).query(
+      api.exchange.getExchangeById.getExchangeById,
+      { exchangeId: older },
+    );
+    expect(bobView?.ownerPuzzle?.notes).toBe("bob-private-note-mountain");
+    expect(bobView?.ownerPuzzle?.acquisitionSource).toBe("bought_used");
+    expect(bobView?.ownerPuzzle?.acquisitionPrice?.amount).toBe(4321);
+    expect(bobView?.requesterPuzzle?.notes).toBeUndefined();
+    expect(bobView?.requesterPuzzle?.acquisitionSource).toBeUndefined();
+    expect(bobView?.requesterPuzzle?.acquisitionPrice).toBeUndefined();
+    expect(bobView?.requesterPuzzle?.acquisitionDate).toBeUndefined();
+    const bobJson = JSON.stringify(bobView);
+    for (const secret of ALICE_SECRETS) {
+      expect(bobJson).not.toContain(secret);
+    }
+  });
+
+  test("getUserExchanges: initiator never receives the recipient's owner-only fields", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const list = await asAlice(t).query(
+      api.exchange.getUserExchanges.getUserExchanges,
+      {},
+    );
+    const older = list.find((e) => e.aggregateId === "exch-1");
+    // Alice owns the offered copy; she sees its owner-only fields.
+    expect(older?.offeredOwnedPuzzle?.notes).toBe("alice-private-note-ocean");
+    // Bob's requested copy is the counterparty's — stripped.
+    expect(older?.requestedOwnedPuzzle?.notes).toBeUndefined();
+    expect(older?.requestedOwnedPuzzle?.acquisitionSource).toBeUndefined();
+    expect(older?.requestedOwnedPuzzle?.acquisitionPrice).toBeUndefined();
+    const json = JSON.stringify(list);
+    for (const secret of BOB_SECRETS) {
+      expect(json).not.toContain(secret);
+    }
+  });
+
+  test("getExchangesByOwner: recipient never receives the initiator's owner-only fields", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const incoming = await asBob(t).query(
+      api.exchange.getExchangesByOwner.getExchangesByOwner,
+      {},
+    );
+    const older = incoming.find((e) => e.aggregateId === "exch-1");
+    // Bob owns the requested copy; he sees its owner-only fields.
+    expect(older?.requestedOwnedPuzzle?.notes).toBe(
+      "bob-private-note-mountain",
+    );
+    // Alice's offered copy is the counterparty's — stripped.
+    expect(older?.offeredOwnedPuzzle?.notes).toBeUndefined();
+    expect(older?.offeredOwnedPuzzle?.acquisitionSource).toBeUndefined();
+    expect(older?.offeredOwnedPuzzle?.acquisitionPrice).toBeUndefined();
+    const json = JSON.stringify(incoming);
+    for (const secret of ALICE_SECRETS) {
+      expect(json).not.toContain(secret);
+    }
   });
 });
 

--- a/packages/backend/convex/exchangeQueries.test.ts
+++ b/packages/backend/convex/exchangeQueries.test.ts
@@ -117,9 +117,12 @@ describe("exchange.getExchangeById", () => {
   test("returns the exchange with parties and the owned copies", async () => {
     const t = convexTest(schema, modules);
     const { older } = await seed(t);
-    const view = await t.query(api.exchange.getExchangeById.getExchangeById, {
-      exchangeId: older,
-    });
+    const view = await asAlice(t).query(
+      api.exchange.getExchangeById.getExchangeById,
+      {
+        exchangeId: older,
+      },
+    );
     expect(view?.requester?.name).toBe("Alice");
     expect(view?.owner?.name).toBe("Bob");
     // Legacy naming: ownerPuzzle = requested owned copy, requesterPuzzle = offered owned copy.
@@ -127,13 +130,39 @@ describe("exchange.getExchangeById", () => {
     expect(view?.requesterPuzzle?.condition).toBe("like_new");
   });
 
+  test("returns null for a non-party caller", async () => {
+    const t = convexTest(schema, modules);
+    const { older } = await seed(t);
+    // Carol is neither initiator nor recipient.
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_carol",
+        email: "carol@example.com",
+        name: "Carol",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    const view = await t
+      .withIdentity({ subject: "clerk_carol" })
+      .query(api.exchange.getExchangeById.getExchangeById, {
+        exchangeId: older,
+      });
+    expect(view).toBeNull();
+  });
+
   test("returns null for a missing exchange", async () => {
     const t = convexTest(schema, modules);
     const { older } = await seed(t);
     await t.run(async (ctx) => ctx.db.delete(older));
-    const view = await t.query(api.exchange.getExchangeById.getExchangeById, {
-      exchangeId: older,
-    });
+    const view = await asAlice(t).query(
+      api.exchange.getExchangeById.getExchangeById,
+      {
+        exchangeId: older,
+      },
+    );
     expect(view).toBeNull();
   });
 });
@@ -141,10 +170,11 @@ describe("exchange.getExchangeById", () => {
 describe("exchange.getUserExchanges", () => {
   test("tags roles, joins puzzles and sorts newest-first", async () => {
     const t = convexTest(schema, modules);
-    const { alice } = await seed(t);
-    const list = await t.query(api.exchange.getUserExchanges.getUserExchanges, {
-      userId: alice,
-    });
+    await seed(t);
+    const list = await asAlice(t).query(
+      api.exchange.getUserExchanges.getUserExchanges,
+      {},
+    );
     // Alice is initiator on both (asRequester + asOwner default true; she is recipient on neither).
     expect(list).toHaveLength(2);
     expect(list[0].createdAt).toBeGreaterThanOrEqual(list[1].createdAt);
@@ -156,10 +186,10 @@ describe("exchange.getUserExchanges", () => {
 
   test("filters by status", async () => {
     const t = convexTest(schema, modules);
-    const { alice } = await seed(t);
-    const completed = await t.query(
+    await seed(t);
+    const completed = await asAlice(t).query(
       api.exchange.getUserExchanges.getUserExchanges,
-      { userId: alice, status: "completed" },
+      { status: "completed" },
     );
     expect(completed).toHaveLength(1);
     expect(completed[0].aggregateId).toBe("exch-2");
@@ -223,7 +253,7 @@ describe("exchange.getExchangeMessages", () => {
   test("returns messages oldest-first with resolved senders", async () => {
     const t = convexTest(schema, modules);
     const { older } = await seed(t);
-    const messages = await t.query(
+    const messages = await asAlice(t).query(
       api.exchange.getExchangeMessages.getExchangeMessages,
       { exchangeId: older },
     );

--- a/packages/backend/convex/exchangeQueries.test.ts
+++ b/packages/backend/convex/exchangeQueries.test.ts
@@ -194,6 +194,47 @@ describe("exchange.getUserExchanges", () => {
     expect(completed).toHaveLength(1);
     expect(completed[0].aggregateId).toBe("exch-2");
   });
+
+  test("filters by the schema status 'rejected' (not the legacy 'declined')", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+    // A rejected exchange that the legacy `declined` literal could never match.
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      const puzzle = await ctx.db.insert("puzzles", {
+        title: "Forest",
+        pieceCount: 250,
+        status: "approved",
+        submittedBy: bob,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const copy = await ctx.db.insert("ownedPuzzles", {
+        puzzleId: puzzle,
+        ownerId: bob,
+        condition: "good",
+        availability: { forTrade: true, forSale: false, forLend: false },
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("exchanges", {
+        aggregateId: "exch-3",
+        initiatorId: alice,
+        recipientId: bob,
+        type: "trade",
+        requestedPuzzleId: copy,
+        status: "rejected",
+        createdAt: now + 1000,
+        updatedAt: now + 1000,
+      });
+    });
+    const rejected = await asAlice(t).query(
+      api.exchange.getUserExchanges.getUserExchanges,
+      { status: "rejected" },
+    );
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].aggregateId).toBe("exch-3");
+  });
 });
 
 describe("exchange.getExchangesByOwner / getExchangesByRequester", () => {

--- a/packages/backend/convex/exchanges.ts
+++ b/packages/backend/convex/exchanges.ts
@@ -1,5 +1,7 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import { mutation } from "./_generated/server";
+import { requireMember } from "./identity/requireMember";
 
 // Reads were cut over to thin driving adapters under convex/exchange/* (returning typed view DTOs
 // from @jigswap/contracts). Only the write mutation remains on this legacy module.
@@ -8,27 +10,37 @@ import { mutation } from "./_generated/server";
 export const sendExchangeMessage = mutation({
   args: {
     exchangeId: v.id("exchanges"),
-    senderId: v.id("users"),
     content: v.string(),
     messageType: v.optional(
       v.union(v.literal("text"), v.literal("image"), v.literal("system")),
     ),
   },
   handler: async (ctx, args) => {
+    // Sender is the authenticated member, never a client-supplied id (spoofing).
+    const senderId = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const exchange = await ctx.db.get(args.exchangeId);
     if (!exchange) {
       throw new Error("Exchange request not found");
     }
 
-    // Determine receiver
+    // Only a party to the exchange may post into its thread.
+    if (
+      senderId !== exchange.initiatorId &&
+      senderId !== exchange.recipientId
+    ) {
+      throw new ConvexError("Forbidden");
+    }
+
+    // Determine receiver from the exchange, not the client.
     const receiverId =
-      args.senderId === exchange.initiatorId
+      senderId === exchange.initiatorId
         ? exchange.recipientId
         : exchange.initiatorId;
 
     const messageId = await ctx.db.insert("messages", {
       exchangeId: args.exchangeId,
-      senderId: args.senderId,
+      senderId,
       receiverId,
       content: args.content,
       messageType: args.messageType ?? "text",

--- a/packages/backend/convex/exchanges.ts
+++ b/packages/backend/convex/exchanges.ts
@@ -11,9 +11,10 @@ export const sendExchangeMessage = mutation({
   args: {
     exchangeId: v.id("exchanges"),
     content: v.string(),
-    messageType: v.optional(
-      v.union(v.literal("text"), v.literal("image"), v.literal("system")),
-    ),
+    // Client may only post 'text'/'image'. 'system' is reserved for server-side
+    // service code (status announcements rendered with authoritative styling); a
+    // party must not be able to spoof a system message inside an exchange thread.
+    messageType: v.optional(v.union(v.literal("text"), v.literal("image"))),
   },
   handler: async (ctx, args) => {
     // Sender is the authenticated member, never a client-supplied id (spoofing).

--- a/packages/backend/convex/getCopyInstanceView.test.ts
+++ b/packages/backend/convex/getCopyInstanceView.test.ts
@@ -299,6 +299,65 @@ describe("getCopyInstanceView privacy gating", () => {
     expect(transfer2.from.anonRef).not.toBe(ref1);
   });
 
+  test("a non-owned UNREACHABLE copy returns null (private/closed owner)", async () => {
+    const t = convexTest(schema, modules);
+    const { viewer, prevOwner, copy } = await seedCopy(t);
+    // Hand the copy to prevOwner and make their profile private + the copy closed: unreachable.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(copy, { ownerId: prevOwner });
+    });
+    await setVisibility(t, prevOwner, "private");
+    void viewer;
+
+    const view = await asViewer(t).query(
+      api.library.getCopyInstanceView.getCopyInstanceView,
+      { copyId: copy },
+    );
+    expect(view).toBeNull();
+  });
+
+  test("a non-owned PUBLIC, OPEN copy is visible but omits owner-only fields", async () => {
+    const t = convexTest(schema, modules);
+    const { prevOwner, copy } = await seedCopy(t);
+    // Hand the copy to prevOwner, mark it open, give it owner-only data, and make prevOwner public.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(copy, {
+        ownerId: prevOwner,
+        availability: { forTrade: true, forSale: false, forLend: false },
+        notes: "private owner note",
+        acquisitionSource: "bought_used",
+        acquisitionDate: 12345,
+      });
+    });
+    await setVisibility(t, prevOwner, "public");
+
+    const view = await asViewer(t).query(
+      api.library.getCopyInstanceView.getCopyInstanceView,
+      { copyId: copy },
+    );
+    expect(view).not.toBeNull();
+    expect(view?.viewerIsOwner).toBe(false);
+    // Owner-only snapshot fields are omitted for a non-owner.
+    expect(view?.snapshot.notes).toBeUndefined();
+    expect(view?.snapshot.acquisitionSource).toBeUndefined();
+    expect(view?.snapshot.acquisitionDate).toBeUndefined();
+    // Adversarial: the private note value never appears anywhere in the payload.
+    expect(JSON.stringify(view)).not.toContain("private owner note");
+
+    // The owner, by contrast, sees those fields.
+    await t.run(async (ctx) =>
+      mkUser(ctx, "clerk_owner_check", "Owner Check", 1),
+    );
+    const ownerView = await t
+      .withIdentity({ subject: "clerk_prev" })
+      .query(api.library.getCopyInstanceView.getCopyInstanceView, {
+        copyId: copy,
+      });
+    expect(ownerView?.viewerIsOwner).toBe(true);
+    expect(ownerView?.snapshot.notes).toBe("private owner note");
+    expect(ownerView?.snapshot.acquisitionSource).toBe("bought_used");
+  });
+
   test("owner sees since/before split around acquiredByViewerAt; non-owner gets all in before", async () => {
     const t = convexTest(schema, modules);
     const { now, viewer, prevOwner, solver, copy } = await seedCopy(t);
@@ -346,9 +405,13 @@ describe("getCopyInstanceView privacy gating", () => {
     const stranger = await t.run(async (ctx) =>
       mkUser(ctx, "clerk_stranger", "Stranger", now),
     );
-    // Reassign ownership away from the viewer so the acting member is no longer the owner.
+    // Reassign ownership away from the viewer so the acting member is no longer the owner. Make the
+    // copy OPEN so the public-owner reachability gate lets the non-owner view it.
     await t.run(async (ctx) => {
-      await ctx.db.patch(copy, { ownerId: stranger });
+      await ctx.db.patch(copy, {
+        ownerId: stranger,
+        availability: { forTrade: true, forSale: false, forLend: false },
+      });
     });
     await setVisibility(t, stranger, "public");
     const notOwner = await asViewer(t).query(
@@ -669,10 +732,14 @@ describe("getCopyInstanceView rich detail", () => {
 
     // A DIFFERENT viewer (who uploaded none of these) sees ONLY approved + legacy — no pending
     // (none are theirs), no rejected. Gating keys on the UPLOADER, not the copy owner, so we query
-    // as a fresh identity rather than reassigning ownership.
-    await t.run(async (ctx) =>
-      mkUser(ctx, "clerk_stranger2", "Stranger2", now),
-    );
+    // as a fresh identity rather than reassigning ownership. The copy must be OPEN so the
+    // public-owner reachability gate lets this non-owner reach it.
+    await t.run(async (ctx) => {
+      await mkUser(ctx, "clerk_stranger2", "Stranger2", now);
+      await ctx.db.patch(copy, {
+        availability: { forTrade: true, forSale: false, forLend: false },
+      });
+    });
     const strangerView = await t
       .withIdentity({ subject: "clerk_stranger2" })
       .query(api.library.getCopyInstanceView.getCopyInstanceView, {

--- a/packages/backend/convex/globalSearch.test.ts
+++ b/packages/backend/convex/globalSearch.test.ts
@@ -1,0 +1,111 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const insertUser = (
+  t: ReturnType<typeof convexTest>,
+  clerkId: string,
+  name: string,
+  username: string,
+) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    return ctx.db.insert("users", {
+      clerkId,
+      email: `${clerkId}@example.com`,
+      name,
+      username,
+      searchableName: `${name} ${username}`.toLowerCase(),
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+const setVisibility = (
+  t: ReturnType<typeof convexTest>,
+  memberId: Id<"users">,
+  visibility: "public" | "private",
+) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("profiles", {
+      memberId,
+      displayName: "x",
+      visibility,
+      updatedAt: Date.now(),
+    });
+  });
+
+const follow = (
+  t: ReturnType<typeof convexTest>,
+  followerId: Id<"users">,
+  followeeId: Id<"users">,
+) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("follows", { followerId, followeeId, createdAt: 1 });
+  });
+
+const asUser = (t: ReturnType<typeof convexTest>, clerkId: string) =>
+  t.withIdentity({ subject: clerkId });
+
+describe("search.global people results", () => {
+  test("finds a public member via the name/username search index", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_searcher", "Sam Searcher", "sam");
+    await insertUser(t, "clerk_target", "Patricia Public", "patricia");
+
+    const res = await asUser(t, "clerk_searcher").query(
+      api.search.globalSearch.global,
+      { term: "patricia" },
+    );
+    expect(res.people.map((p) => p.name)).toContain("Patricia Public");
+  });
+
+  test("hides a private-profile member from a non-connected searcher", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_searcher", "Sam Searcher", "sam");
+    const target = await insertUser(t, "clerk_priv", "Priv Person", "priv");
+    await setVisibility(t, target, "private");
+
+    const res = await asUser(t, "clerk_searcher").query(
+      api.search.globalSearch.global,
+      { term: "priv" },
+    );
+    expect(res.people).toHaveLength(0);
+  });
+
+  test("reveals a private member to a mutual follower", async () => {
+    const t = convexTest(schema, modules);
+    const searcher = await insertUser(
+      t,
+      "clerk_searcher",
+      "Sam Searcher",
+      "sam",
+    );
+    const target = await insertUser(t, "clerk_priv", "Priv Person", "priv");
+    await setVisibility(t, target, "private");
+    await follow(t, searcher, target);
+    await follow(t, target, searcher);
+
+    const res = await asUser(t, "clerk_searcher").query(
+      api.search.globalSearch.global,
+      { term: "priv" },
+    );
+    expect(res.people.map((p) => p.name)).toContain("Priv Person");
+  });
+
+  test("excludes the searcher themself from people results", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_self", "Self Searcher", "self");
+
+    const res = await asUser(t, "clerk_self").query(
+      api.search.globalSearch.global,
+      { term: "self" },
+    );
+    expect(res.people).toHaveLength(0);
+  });
+});

--- a/packages/backend/convex/identity/getCurrentUser.ts
+++ b/packages/backend/convex/identity/getCurrentUser.ts
@@ -1,12 +1,13 @@
-import type { MemberView } from "@jigswap/contracts";
+import type { CurrentMemberView } from "@jigswap/contracts";
 import { query } from "../_generated/server";
-import { toMemberView } from "./toMemberView";
+import { toCurrentMemberView } from "./toMemberView";
 
-// Identity read (thin adapter): the signed-in member, or null when unauthenticated. Auth gating and
-// the by_clerk_id lookup match the legacy users.getCurrentUser exactly; only the shape is typed now.
+// Identity read (thin adapter): the signed-in member, or null when unauthenticated. Returns the
+// self-only CurrentMemberView (includes the caller's own email + clerkId) — safe because it only
+// ever returns the caller's own account.
 export const getCurrentUser = query({
   args: {},
-  handler: async (ctx): Promise<MemberView | null> => {
+  handler: async (ctx): Promise<CurrentMemberView | null> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return null;
 
@@ -14,6 +15,6 @@ export const getCurrentUser = query({
       .query("users")
       .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
       .unique();
-    return user ? toMemberView(user) : null;
+    return user ? toCurrentMemberView(user) : null;
   },
 });

--- a/packages/backend/convex/identity/getUserByClerkId.ts
+++ b/packages/backend/convex/identity/getUserByClerkId.ts
@@ -1,13 +1,15 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import { query } from "../_generated/server";
+import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
-// Identity read (thin adapter): resolve a member by Clerk subject. Matches legacy
-// users.getUserByClerkId; most callers use it only to obtain the member _id.
+// Identity read (thin adapter): resolve a member by Clerk subject. Authenticated members only;
+// most callers use it only to obtain the member _id. Emits the PII-free MemberView.
 export const getUserByClerkId = query({
   args: { clerkId: v.string() },
   handler: async (ctx, args): Promise<MemberView | null> => {
+    await requireMember(ctx);
     const user = await ctx.db
       .query("users")
       .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))

--- a/packages/backend/convex/identity/getUserById.ts
+++ b/packages/backend/convex/identity/getUserById.ts
@@ -1,12 +1,15 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import { query } from "../_generated/server";
+import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
-// Identity read (thin adapter): a member by their _id. Matches legacy users.getUserById.
+// Identity read (thin adapter): a member by their _id. Authenticated members only; emits the
+// PII-free MemberView.
 export const getUserById = query({
   args: { userId: v.id("users") },
   handler: async (ctx, args): Promise<MemberView | null> => {
+    await requireMember(ctx);
     const user = await ctx.db.get(args.userId);
     return user ? toMemberView(user) : null;
   },

--- a/packages/backend/convex/identity/getUserById.ts
+++ b/packages/backend/convex/identity/getUserById.ts
@@ -1,16 +1,33 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { areMutualFollowers, profileVisibilityOf } from "../social/privacy";
 import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
 // Identity read (thin adapter): a member by their _id. Authenticated members only; emits the
-// PII-free MemberView.
+// PII-free MemberView. Honours the profile-visibility chokepoint (see social/privacy.ts): a member
+// who went "private" is hidden (returns null) from everyone except themselves and their mutual
+// followers, so private identities can't be enumerated id-by-id. Default/unset visibility is public.
 export const getUserById = query({
   args: { userId: v.id("users") },
   handler: async (ctx, args): Promise<MemberView | null> => {
-    await requireMember(ctx);
-    const user = await ctx.db.get(args.userId);
-    return user ? toMemberView(user) : null;
+    const viewer = (await requireMember(ctx)) as unknown as Id<"users">;
+    const target = args.userId;
+
+    const user = await ctx.db.get(target);
+    if (!user) return null;
+
+    // Visibility ACL: a private member is visible only to themselves and their mutual followers.
+    if (
+      target !== viewer &&
+      (await profileVisibilityOf(ctx, target)) === "private" &&
+      !(await areMutualFollowers(ctx, viewer, target))
+    ) {
+      return null;
+    }
+
+    return toMemberView(user);
   },
 });

--- a/packages/backend/convex/identity/getUserStats.ts
+++ b/packages/backend/convex/identity/getUserStats.ts
@@ -1,13 +1,16 @@
 import type { MemberStatsView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import { query } from "../_generated/server";
+import { requireMember } from "./requireMember";
 
 // Identity read (thin adapter): a member's public stat card. Counts owned copies, completed
 // exchanges (as initiator + recipient) and averages received review ratings. Math, rounding and
 // the puzzlesAvailable == puzzlesOwned quirk match legacy users.getUserStats exactly.
+// Authenticated members only — matches the other identity reads (getUserById, searchUsers, etc.).
 export const getUserStats = query({
   args: { userId: v.id("users") },
   handler: async (ctx, args): Promise<MemberStatsView> => {
+    await requireMember(ctx);
     const puzzlesOwned = await ctx.db
       .query("ownedPuzzles")
       .withIndex("by_owner", (q) => q.eq("ownerId", args.userId))

--- a/packages/backend/convex/identity/getUserStats.ts
+++ b/packages/backend/convex/identity/getUserStats.ts
@@ -1,16 +1,31 @@
 import type { MemberStatsView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { areMutualFollowers, profileVisibilityOf } from "../social/privacy";
 import { requireMember } from "./requireMember";
 
 // Identity read (thin adapter): a member's public stat card. Counts owned copies, completed
 // exchanges (as initiator + recipient) and averages received review ratings. Math, rounding and
 // the puzzlesAvailable == puzzlesOwned quirk match legacy users.getUserStats exactly.
-// Authenticated members only — matches the other identity reads (getUserById, searchUsers, etc.).
+// Authenticated members only. Honours the profile-visibility chokepoint (see social/privacy.ts): a
+// member who went "private" has their stats hidden (returns null) from everyone except themselves
+// and their mutual followers — same rule as getUserById/getProfile. Default visibility is public.
 export const getUserStats = query({
   args: { userId: v.id("users") },
-  handler: async (ctx, args): Promise<MemberStatsView> => {
-    await requireMember(ctx);
+  handler: async (ctx, args): Promise<MemberStatsView | null> => {
+    const viewer = (await requireMember(ctx)) as unknown as Id<"users">;
+    const target = args.userId;
+
+    // Visibility ACL: a private member's stats are visible only to themselves and mutual followers.
+    if (
+      target !== viewer &&
+      (await profileVisibilityOf(ctx, target)) === "private" &&
+      !(await areMutualFollowers(ctx, viewer, target))
+    ) {
+      return null;
+    }
+
     const puzzlesOwned = await ctx.db
       .query("ownedPuzzles")
       .withIndex("by_owner", (q) => q.eq("ownerId", args.userId))

--- a/packages/backend/convex/identity/searchUsers.ts
+++ b/packages/backend/convex/identity/searchUsers.ts
@@ -1,16 +1,18 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import { query } from "../_generated/server";
+import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
 // Identity read (thin adapter): case-insensitive substring search over name/username/location,
-// capped at `limit` (default 20). Filtering, ordering and cap match legacy users.searchUsers.
+// capped at `limit` (default 20). Authenticated members only; emits the PII-free MemberView.
 export const searchUsers = query({
   args: {
     searchTerm: v.string(),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<MemberView[]> => {
+    await requireMember(ctx);
     const limit = args.limit ?? 20;
     const searchTerm = args.searchTerm.toLowerCase();
 

--- a/packages/backend/convex/identity/searchUsers.ts
+++ b/packages/backend/convex/identity/searchUsers.ts
@@ -1,30 +1,53 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { areMutualFollowers, profileVisibilityOf } from "../social/privacy";
 import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
 // Identity read (thin adapter): full-text search over name/username via the `by_searchable_name`
 // index (a real index lookup, not a full-table scan), capped at `limit` (default 20). Authenticated
 // members only; emits the PII-free MemberView.
+//
+// Profile-visibility gate (mirrors search/globalSearch.ts): a member with a private profile must
+// never be surfaced by name/username/avatar to a searcher who is neither them nor a mutual follower.
+// We over-fetch candidates from the search index (since some get dropped by the gate) and stop once
+// `limit` visible matches are collected, so dropped private rows are refilled toward `limit`.
+const CANDIDATE_LIMIT = 50;
+
 export const searchUsers = query({
   args: {
     searchTerm: v.string(),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<MemberView[]> => {
-    await requireMember(ctx);
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
     const limit = args.limit ?? 20;
     const searchTerm = args.searchTerm.trim().toLowerCase();
     if (searchTerm.length === 0) return [];
 
-    const users = await ctx.db
+    const candidates = await ctx.db
       .query("users")
       .withSearchIndex("by_searchable_name", (q) =>
         q.search("searchableName", searchTerm),
       )
-      .take(limit);
+      .take(CANDIDATE_LIMIT);
 
-    return users.map(toMemberView);
+    const results: MemberView[] = [];
+    for (const u of candidates) {
+      if (results.length >= limit) break;
+      // Privacy chokepoint: surface a member only if they are the searcher, their
+      // profile is public, or they and the searcher are mutual followers. Mirrors
+      // globalSearch and getProfile so a private member is not identifiable here.
+      const visible =
+        u._id === viewerId ||
+        (await profileVisibilityOf(ctx, u._id)) === "public" ||
+        (await areMutualFollowers(ctx, viewerId, u._id));
+      if (!visible) continue;
+      results.push(toMemberView(u));
+    }
+
+    return results;
   },
 });

--- a/packages/backend/convex/identity/searchUsers.ts
+++ b/packages/backend/convex/identity/searchUsers.ts
@@ -4,8 +4,9 @@ import { query } from "../_generated/server";
 import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
 
-// Identity read (thin adapter): case-insensitive substring search over name/username/location,
-// capped at `limit` (default 20). Authenticated members only; emits the PII-free MemberView.
+// Identity read (thin adapter): full-text search over name/username via the `by_searchable_name`
+// index (a real index lookup, not a full-table scan), capped at `limit` (default 20). Authenticated
+// members only; emits the PII-free MemberView.
 export const searchUsers = query({
   args: {
     searchTerm: v.string(),
@@ -14,18 +15,16 @@ export const searchUsers = query({
   handler: async (ctx, args): Promise<MemberView[]> => {
     await requireMember(ctx);
     const limit = args.limit ?? 20;
-    const searchTerm = args.searchTerm.toLowerCase();
+    const searchTerm = args.searchTerm.trim().toLowerCase();
+    if (searchTerm.length === 0) return [];
 
-    const users = await ctx.db.query("users").collect();
-
-    return users
-      .filter(
-        (user) =>
-          user.name.toLowerCase().includes(searchTerm) ||
-          (user.username && user.username.toLowerCase().includes(searchTerm)) ||
-          (user.location && user.location.toLowerCase().includes(searchTerm)),
+    const users = await ctx.db
+      .query("users")
+      .withSearchIndex("by_searchable_name", (q) =>
+        q.search("searchableName", searchTerm),
       )
-      .slice(0, limit)
-      .map(toMemberView);
+      .take(limit);
+
+    return users.map(toMemberView);
   },
 });

--- a/packages/backend/convex/identity/toMemberView.ts
+++ b/packages/backend/convex/identity/toMemberView.ts
@@ -1,13 +1,11 @@
-import type { MemberView } from "@jigswap/contracts";
+import type { CurrentMemberView, MemberView } from "@jigswap/contracts";
 import type { Doc } from "../_generated/dataModel";
 
-// Shared row->DTO mapping for the member reads, so every identity adapter emits an identical
-// MemberView superset of the `users` document instead of leaking the raw row.
+// Shared row->DTO mapping for the member reads. Emits a PII-free MemberView (no email, no clerkId)
+// so member-to-other projections never leak a member's email or Clerk subject id.
 export const toMemberView = (user: Doc<"users">): MemberView => ({
   _id: user._id,
   _creationTime: user._creationTime,
-  clerkId: user.clerkId,
-  email: user.email,
   name: user.name,
   username: user.username,
   avatar: user.avatar,
@@ -17,4 +15,12 @@ export const toMemberView = (user: Doc<"users">): MemberView => ({
   isActive: user.isActive,
   createdAt: user.createdAt,
   updatedAt: user.updatedAt,
+});
+
+// Self-only projection: the signed-in member's own view, with email + clerkId re-added. Only the
+// `getCurrentUser` ("me") query may use this — never a member-to-other read.
+export const toCurrentMemberView = (user: Doc<"users">): CurrentMemberView => ({
+  ...toMemberView(user),
+  clerkId: user.clerkId,
+  email: user.email,
 });

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -82,6 +82,9 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
 const asAlice = (t: ReturnType<typeof convexTest>) =>
   t.withIdentity({ subject: "clerk_alice" });
 
+const asBob = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_bob" });
+
 describe("identity.getCurrentUser", () => {
   test("returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
@@ -141,11 +144,12 @@ describe("identity.getUserStats", () => {
       api.identity.getUserStats.getUserStats,
       { userId: alice },
     );
-    expect(stats.puzzlesOwned).toBe(1);
-    expect(stats.puzzlesAvailable).toBe(1); // legacy quirk: mirrors puzzlesOwned
-    expect(stats.tradesCompleted).toBe(1);
-    expect(stats.averageRating).toBe(4);
-    expect(stats.totalReviews).toBe(1);
+    expect(stats).not.toBeNull();
+    expect(stats?.puzzlesOwned).toBe(1);
+    expect(stats?.puzzlesAvailable).toBe(1); // legacy quirk: mirrors puzzlesOwned
+    expect(stats?.tradesCompleted).toBe(1);
+    expect(stats?.averageRating).toBe(4);
+    expect(stats?.totalReviews).toBe(1);
   });
 
   test("rejects an unauthenticated caller", async () => {
@@ -154,6 +158,100 @@ describe("identity.getUserStats", () => {
     await expect(
       t.query(api.identity.getUserStats.getUserStats, { userId: alice }),
     ).rejects.toBeInstanceOf(ConvexError);
+  });
+});
+
+// The profile-visibility chokepoint (social/privacy.ts) must also gate the identity reads, so a
+// private member's identity and stats can't be enumerated id-by-id by any authenticated member.
+// Mirrors the listFollowers/listFollowees visibility tests in socialMutations.test.ts.
+describe("identity.getUserById / getUserStats profile-visibility gating", () => {
+  test("a private, non-mutual member's identity and stats are hidden (null)", async () => {
+    const t = convexTest(schema, modules);
+    const { bob } = await seed(t);
+
+    // Alice follows Bob (one-directional only), then Bob goes private.
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+    await asBob(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    // Alice is not a mutual follower of Bob -> both reads are hidden.
+    expect(
+      await asAlice(t).query(api.identity.getUserById.getUserById, {
+        userId: bob,
+      }),
+    ).toBeNull();
+    expect(
+      await asAlice(t).query(api.identity.getUserStats.getUserStats, {
+        userId: bob,
+      }),
+    ).toBeNull();
+  });
+
+  test("the owner always sees their own private identity and stats", async () => {
+    const t = convexTest(schema, modules);
+    const { bob } = await seed(t);
+
+    await asBob(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    const self = await asBob(t).query(api.identity.getUserById.getUserById, {
+      userId: bob,
+    });
+    expect(self?.name).toBe("Bob Brown");
+    const selfStats = await asBob(t).query(
+      api.identity.getUserStats.getUserStats,
+      { userId: bob },
+    );
+    expect(selfStats).not.toBeNull();
+  });
+
+  test("a mutual follower sees a private member's identity and stats", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    // Mutual follow, then Bob goes private.
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+    await asBob(t).mutation(api.social.followMember.followMember, {
+      followeeId: alice,
+    });
+    await asBob(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    const view = await asAlice(t).query(api.identity.getUserById.getUserById, {
+      userId: bob,
+    });
+    expect(view?.name).toBe("Bob Brown");
+    const stats = await asAlice(t).query(
+      api.identity.getUserStats.getUserStats,
+      { userId: bob },
+    );
+    expect(stats).not.toBeNull();
+  });
+
+  test("a public member (default/unset visibility) is unaffected", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    // Bob has no profile row -> profileVisibilityOf defaults to public; Alice (a
+    // non-follower) still reads Alice... use Bob viewing Alice, who is public.
+    const view = await asBob(t).query(api.identity.getUserById.getUserById, {
+      userId: alice,
+    });
+    expect(view?.name).toBe("Alice Anderson");
+    const stats = await asBob(t).query(api.identity.getUserStats.getUserStats, {
+      userId: alice,
+    });
+    expect(stats?.puzzlesOwned).toBe(1);
   });
 });
 

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -1,4 +1,5 @@
 import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import schema from "./schema";
@@ -132,14 +133,23 @@ describe("identity.getUserStats", () => {
   test("rolls owned copies, completed exchanges and received reviews", async () => {
     const t = convexTest(schema, modules);
     const { alice } = await seed(t);
-    const stats = await t.query(api.identity.getUserStats.getUserStats, {
-      userId: alice,
-    });
+    const stats = await asAlice(t).query(
+      api.identity.getUserStats.getUserStats,
+      { userId: alice },
+    );
     expect(stats.puzzlesOwned).toBe(1);
     expect(stats.puzzlesAvailable).toBe(1); // legacy quirk: mirrors puzzlesOwned
     expect(stats.tradesCompleted).toBe(1);
     expect(stats.averageRating).toBe(4);
     expect(stats.totalReviews).toBe(1);
+  });
+
+  test("rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+    await expect(
+      t.query(api.identity.getUserStats.getUserStats, { userId: alice }),
+    ).rejects.toBeInstanceOf(ConvexError);
   });
 });
 

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -16,6 +16,9 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       email: "alice@example.com",
       name: "Alice Anderson",
       username: "alice",
+      // searchableName backs the by_searchable_name people-search index and is
+      // maintained on every user write (see convex/users.ts toSearchableName).
+      searchableName: "alice anderson alice",
       location: "Amsterdam",
       bio: "Loves 1000-piece puzzles",
       isActive: true,
@@ -26,6 +29,7 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       clerkId: "clerk_bob",
       email: "bob@example.com",
       name: "Bob Brown",
+      searchableName: "bob brown",
       isActive: true,
       createdAt: now,
       updatedAt: now,
@@ -154,23 +158,40 @@ describe("identity.getUserStats", () => {
 });
 
 describe("identity.searchUsers", () => {
-  test("matches on name/username/location, case-insensitively", async () => {
+  test("matches on name/username via the search index, case-insensitively", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
+    // Matches on name token.
     const byName = await asAlice(t).query(
       api.identity.searchUsers.searchUsers,
       {
-        searchTerm: "alice",
+        searchTerm: "anderson",
       },
     );
     expect(byName.map((u) => u.name)).toContain("Alice Anderson");
+    // Matches on username token, case-insensitively.
+    const byUsername = await asAlice(t).query(
+      api.identity.searchUsers.searchUsers,
+      {
+        searchTerm: "ALICE",
+      },
+    );
+    expect(byUsername.map((u) => u.name)).toContain("Alice Anderson");
+    // People search is now backed by a single name/username search index, so
+    // location is intentionally no longer a search field (deliberate behavior
+    // change from the old full-table scan that also matched location).
     const byLocation = await asAlice(t).query(
       api.identity.searchUsers.searchUsers,
       {
         searchTerm: "amsterdam",
       },
     );
-    expect(byLocation).toHaveLength(1);
+    expect(byLocation).toHaveLength(0);
+    // An empty/whitespace term short-circuits to no results.
+    const empty = await asAlice(t).query(api.identity.searchUsers.searchUsers, {
+      searchTerm: "   ",
+    });
+    expect(empty).toHaveLength(0);
     const none = await asAlice(t).query(api.identity.searchUsers.searchUsers, {
       searchTerm: "zzz",
     });
@@ -180,11 +201,39 @@ describe("identity.searchUsers", () => {
   test("respects the limit", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
-    // Both Alice and Bob contain no shared token except an empty term, which matches all.
+    // Two members sharing a search token ("collector") so the term matches both;
+    // limit:1 must return only one.
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_carol",
+        email: "carol@example.com",
+        name: "Carol Collector",
+        username: "carol",
+        searchableName: "carol collector carol",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("users", {
+        clerkId: "clerk_dave",
+        email: "dave@example.com",
+        name: "Dave Collector",
+        username: "dave",
+        searchableName: "dave collector dave",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    const all = await asAlice(t).query(api.identity.searchUsers.searchUsers, {
+      searchTerm: "collector",
+    });
+    expect(all.length).toBeGreaterThanOrEqual(2);
     const limited = await asAlice(t).query(
       api.identity.searchUsers.searchUsers,
       {
-        searchTerm: "",
+        searchTerm: "collector",
         limit: 1,
       },
     );

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -2,6 +2,7 @@ import { convexTest } from "convex-test";
 import { ConvexError } from "convex/values";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
 
 // Bundle every Convex module for the in-memory runtime, excluding test files.
@@ -336,6 +337,118 @@ describe("identity.searchUsers", () => {
       },
     );
     expect(limited).toHaveLength(1);
+  });
+});
+
+describe("identity.searchUsers profile-visibility gating", () => {
+  // Mirrors search.global people gating: a private member is never surfaced by
+  // name/username/avatar to a searcher who is neither them nor a mutual follower.
+  const insertUser = (
+    t: ReturnType<typeof convexTest>,
+    clerkId: string,
+    name: string,
+    username: string,
+  ) =>
+    t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name,
+        username,
+        searchableName: `${name} ${username}`.toLowerCase(),
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+  const setVisibility = (
+    t: ReturnType<typeof convexTest>,
+    memberId: Id<"users">,
+    visibility: "public" | "private",
+  ) =>
+    t.run(async (ctx) => {
+      await ctx.db.insert("profiles", {
+        memberId,
+        displayName: "x",
+        visibility,
+        updatedAt: Date.now(),
+      });
+    });
+
+  const follow = (
+    t: ReturnType<typeof convexTest>,
+    followerId: Id<"users">,
+    followeeId: Id<"users">,
+  ) =>
+    t.run(async (ctx) => {
+      await ctx.db.insert("follows", { followerId, followeeId, createdAt: 1 });
+    });
+
+  const asSearcher = (t: ReturnType<typeof convexTest>) =>
+    t.withIdentity({ subject: "clerk_searcher" });
+
+  test("surfaces a public-profile member to any searcher", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_searcher", "Sam Searcher", "sam");
+    await insertUser(t, "clerk_target", "Patricia Public", "patricia");
+
+    const res = await asSearcher(t).query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "patricia" },
+    );
+    expect(res.map((u) => u.name)).toContain("Patricia Public");
+  });
+
+  test("hides a private-profile member from a non-connected searcher", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_searcher", "Sam Searcher", "sam");
+    const target = await insertUser(t, "clerk_priv", "Priv Person", "priv");
+    await setVisibility(t, target, "private");
+
+    const res = await asSearcher(t).query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "priv" },
+    );
+    expect(res).toHaveLength(0);
+  });
+
+  test("reveals a private member to a mutual follower", async () => {
+    const t = convexTest(schema, modules);
+    const searcher = await insertUser(
+      t,
+      "clerk_searcher",
+      "Sam Searcher",
+      "sam",
+    );
+    const target = await insertUser(t, "clerk_priv", "Priv Person", "priv");
+    await setVisibility(t, target, "private");
+    await follow(t, searcher, target);
+    await follow(t, target, searcher);
+
+    const res = await asSearcher(t).query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "priv" },
+    );
+    expect(res.map((u) => u.name)).toContain("Priv Person");
+  });
+
+  test("a searcher with a private profile still finds themself", async () => {
+    const t = convexTest(schema, modules);
+    const searcher = await insertUser(
+      t,
+      "clerk_searcher",
+      "Sam Searcher",
+      "sam",
+    );
+    await setVisibility(t, searcher, "private");
+
+    const res = await asSearcher(t).query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "sam" },
+    );
+    expect(res.map((u) => u.name)).toContain("Sam Searcher");
   });
 });
 

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -103,22 +103,25 @@ describe("identity.getUserByClerkId / getUserById", () => {
   test("resolve the same member by clerk id and _id", async () => {
     const t = convexTest(schema, modules);
     const { alice } = await seed(t);
-    const byClerk = await t.query(
+    const byClerk = await asAlice(t).query(
       api.identity.getUserByClerkId.getUserByClerkId,
       { clerkId: "clerk_alice" },
     );
     expect(byClerk?._id).toBe(alice);
-    const byId = await t.query(api.identity.getUserById.getUserById, {
+    const byId = await asAlice(t).query(api.identity.getUserById.getUserById, {
       userId: alice,
     });
-    expect(byId?.email).toBe("alice@example.com");
+    // MemberView is PII-free: no email/clerkId leak to other members.
+    expect(byId?.name).toBe("Alice Anderson");
+    expect(byId && "email" in byId).toBe(false);
+    expect(byId && "clerkId" in byId).toBe(false);
   });
 
   test("return null for an unknown clerk id", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
     expect(
-      await t.query(api.identity.getUserByClerkId.getUserByClerkId, {
+      await asAlice(t).query(api.identity.getUserByClerkId.getUserByClerkId, {
         clerkId: "nope",
       }),
     ).toBeNull();
@@ -144,15 +147,21 @@ describe("identity.searchUsers", () => {
   test("matches on name/username/location, case-insensitively", async () => {
     const t = convexTest(schema, modules);
     await seed(t);
-    const byName = await t.query(api.identity.searchUsers.searchUsers, {
-      searchTerm: "alice",
-    });
+    const byName = await asAlice(t).query(
+      api.identity.searchUsers.searchUsers,
+      {
+        searchTerm: "alice",
+      },
+    );
     expect(byName.map((u) => u.name)).toContain("Alice Anderson");
-    const byLocation = await t.query(api.identity.searchUsers.searchUsers, {
-      searchTerm: "amsterdam",
-    });
+    const byLocation = await asAlice(t).query(
+      api.identity.searchUsers.searchUsers,
+      {
+        searchTerm: "amsterdam",
+      },
+    );
     expect(byLocation).toHaveLength(1);
-    const none = await t.query(api.identity.searchUsers.searchUsers, {
+    const none = await asAlice(t).query(api.identity.searchUsers.searchUsers, {
       searchTerm: "zzz",
     });
     expect(none).toHaveLength(0);
@@ -162,10 +171,13 @@ describe("identity.searchUsers", () => {
     const t = convexTest(schema, modules);
     await seed(t);
     // Both Alice and Bob contain no shared token except an empty term, which matches all.
-    const limited = await t.query(api.identity.searchUsers.searchUsers, {
-      searchTerm: "",
-      limit: 1,
-    });
+    const limited = await asAlice(t).query(
+      api.identity.searchUsers.searchUsers,
+      {
+        searchTerm: "",
+        limit: 1,
+      },
+    );
     expect(limited).toHaveLength(1);
   });
 });

--- a/packages/backend/convex/library/acquireCopy.ts
+++ b/packages/backend/convex/library/acquireCopy.ts
@@ -11,7 +11,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCatalogSnapshotProvider } from "./adapters/convexCatalogSnapshotProvider";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { copyIdGenerator } from "./adapters/idGenerators";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
@@ -55,7 +55,7 @@ export const acquireCopy = mutation({
       copies: convexCopyRepository(ctx),
       snapshots: convexCatalogSnapshotProvider(ctx),
       ids: copyIdGenerator,
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/adapters/convexCopyRepository.ts
+++ b/packages/backend/convex/library/adapters/convexCopyRepository.ts
@@ -54,12 +54,22 @@ export const convexCopyRepository = (ctx: MutationCtx): CopyRepository => {
         ? (await ctx.db.patch(existing._id, row), existing._id)
         : await ctx.db.insert("ownedPuzzles", row);
 
-      // Images belong to the Copy; persist any the aggregate carries that aren't stored yet.
+      // Images belong to the Copy; sync the persisted rows to the aggregate's image list.
       // Keyed by fileId, which is unique per uploaded file, so re-saves don't duplicate rows.
       const persisted = await loadImages(ownedPuzzleId);
       const persistedFileIds = new Set(
         persisted.map((img) => img.fileId as unknown as string),
       );
+      const currentFileIds = new Set(
+        copy.toState().images.map((img) => img.fileId as unknown as string),
+      );
+      // Delete rows whose fileId no longer exists in the aggregate (e.g. an image removed in the
+      // domain), so reduced image lists don't leave orphaned rows that queries still return.
+      for (const img of persisted) {
+        if (!currentFileIds.has(img.fileId as unknown as string)) {
+          await ctx.db.delete(img._id);
+        }
+      }
       const now = Date.now();
       for (const image of copy.toState().images) {
         const fileId = image.fileId as unknown as string;

--- a/packages/backend/convex/library/adapters/convexCopyReservationPort.ts
+++ b/packages/backend/convex/library/adapters/convexCopyReservationPort.ts
@@ -24,13 +24,24 @@ export const convexCopyReservationPort = (
     if (!copy) return false;
     const ownedPuzzleId = copy._id as Id<"ownedPuzzles">;
 
-    // Scan exchanges that reference the copy as requested or offered, in an active status.
-    const exchanges = await ctx.db.query("exchanges").collect();
-    return exchanges.some(
-      (ex) =>
-        ACTIVE_STATUSES.has(ex.status) &&
-        (ex.requestedPuzzleId === ownedPuzzleId ||
-          ex.offeredPuzzleId === ownedPuzzleId),
+    // Indexed lookup of exchanges that reference the copy as requested or offered (union of the
+    // two indexes), then keep only those in an active status — no full-table scan.
+    const [asRequested, asOffered] = await Promise.all([
+      ctx.db
+        .query("exchanges")
+        .withIndex("by_requested_copy", (q) =>
+          q.eq("requestedPuzzleId", ownedPuzzleId),
+        )
+        .collect(),
+      ctx.db
+        .query("exchanges")
+        .withIndex("by_offered_copy", (q) =>
+          q.eq("offeredPuzzleId", ownedPuzzleId),
+        )
+        .collect(),
+    ]);
+    return [...asRequested, ...asOffered].some((ex) =>
+      ACTIVE_STATUSES.has(ex.status),
     );
   },
 });

--- a/packages/backend/convex/library/adapters/eventPublisher.ts
+++ b/packages/backend/convex/library/adapters/eventPublisher.ts
@@ -6,5 +6,5 @@ import { makeEventPublisher } from "../../events/makeEventPublisher";
 // CRITICAL in-transaction reaction (no sync handlers); it durably records + schedules its events
 // (CopyAcquired, CollectionCreated, ...) for the async subscribers. None map to a member-facing
 // notification yet, but recording keeps the log complete + the seam ready for Social/Insights.
-export const noopEventPublisher = (ctx: MutationCtx): DomainEventPublisher =>
+export const libraryEventPublisher = (ctx: MutationCtx): DomainEventPublisher =>
   makeEventPublisher(ctx, "library");

--- a/packages/backend/convex/library/addCopyImage.ts
+++ b/packages/backend/convex/library/addCopyImage.ts
@@ -9,7 +9,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -37,7 +37,7 @@ export const addCopyImage = mutation({
 
     const add = makeAddCopyImage({
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/addCopyToCollection.ts
+++ b/packages/backend/convex/library/addCopyToCollection.ts
@@ -9,7 +9,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCollectionRepository } from "./adapters/convexCollectionRepository";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -26,7 +26,7 @@ export const addCopyToCollection = mutation({
     const add = makeAddCopyToCollection({
       collections: convexCollectionRepository(ctx),
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/browseOwnedPuzzles.ts
+++ b/packages/backend/convex/library/browseOwnedPuzzles.ts
@@ -56,6 +56,9 @@ export const browseOwnedPuzzles = query({
     // Availability-sourced candidate set: every OPEN copy (rule 1). Convex can't `neq` on an
     // index, so we collect the availability-filtered set and exclude the viewer's own copies in
     // memory (unless includeOwnPuzzles). Browse shows OTHER members' available copies.
+    // Perf: bound the worst-case scan with `.take(500)` instead of an unbounded `.collect()`.
+    // CAVEAT: this is a read-cap, not a true index — at large catalogue scale this set should be
+    // sourced from a dedicated availability index + cursor paging rather than an in-memory filter.
     const availableNotOwn = (
       await ctx.db
         .query("ownedPuzzles")
@@ -66,7 +69,7 @@ export const browseOwnedPuzzles = query({
             f.eq(f.field("availability.forLend"), true),
           ),
         )
-        .collect()
+        .take(500)
     ).filter((c) => args.includeOwnPuzzles || c.ownerId !== memberId);
 
     // Circle-shared copies the viewer may see (cross-context). Rule 1 applies to these too: a

--- a/packages/backend/convex/library/canViewCopy.ts
+++ b/packages/backend/convex/library/canViewCopy.ts
@@ -1,0 +1,41 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import { profileVisibilityOf } from "../social/privacy";
+import { collectCircleSharedCopies } from "./circleSharedCopies";
+
+// A copy is "open" iff at least one exchange-availability flag is set (identical to
+// browseOwnedPuzzles/getPuzzleDefinitionView).
+const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
+  copy.availability.forTrade ||
+  copy.availability.forSale ||
+  copy.availability.forLend;
+
+// THE single copy-reachability gate, lifted out of browseOwnedPuzzles/getPuzzleDefinitionView so the
+// copy-detail reads (getCopyInstanceView, getCopyLoanHistory, getCopyCustodyTimeline) decide
+// visibility identically to Browse. A copy is viewable by `viewerId` iff:
+//   1. the viewer owns it; OR
+//   2. the owner's profile is PUBLIC and the copy is OPEN (at least one availability flag); OR
+//   3. the copy is shared into a circle the viewer belongs to.
+// Anything else (a private/unreachable copy of another member) is NOT viewable.
+export const canViewCopy = async (
+  ctx: QueryCtx,
+  viewerId: Id<"users">,
+  copy: Doc<"ownedPuzzles">,
+): Promise<boolean> => {
+  if (copy.ownerId === viewerId) return true;
+
+  if (
+    isOpen(copy) &&
+    (await profileVisibilityOf(ctx, copy.ownerId)) === "public"
+  ) {
+    return true;
+  }
+
+  // Circle-shared reachability: the copy must appear among the OPEN copies shared into one of the
+  // viewer's circles — browseOwnedPuzzles filters the circle-shared set by isOpen before matching,
+  // so a closed circle copy is never reachable there; mirror that exactly.
+  const circleShared = (await collectCircleSharedCopies(ctx, viewerId)).filter(
+    isOpen,
+  );
+  return circleShared.some((c) => c._id === copy._id);
+};

--- a/packages/backend/convex/library/changeCopyCondition.ts
+++ b/packages/backend/convex/library/changeCopyCondition.ts
@@ -8,7 +8,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -29,7 +29,7 @@ export const changeCopyCondition = mutation({
 
     const change = makeChangeCopyCondition({
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/createCollection.ts
+++ b/packages/backend/convex/library/createCollection.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCollectionRepository } from "./adapters/convexCollectionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { collectionIdGenerator } from "./adapters/idGenerators";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
@@ -30,7 +30,7 @@ export const createCollection = mutation({
     const create = makeCreateCollection({
       collections: convexCollectionRepository(ctx),
       ids: collectionIdGenerator,
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/createPersonalCategory.ts
+++ b/packages/backend/convex/library/createPersonalCategory.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexPersonalCategoryRepository } from "./adapters/convexPersonalCategoryRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { personalCategoryIdGenerator } from "./adapters/idGenerators";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
@@ -22,7 +22,7 @@ export const createPersonalCategory = mutation({
     const create = makeCreatePersonalCategory({
       categories: convexPersonalCategoryRepository(ctx),
       ids: personalCategoryIdGenerator,
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/deleteCollection.ts
+++ b/packages/backend/convex/library/deleteCollection.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCollectionRepository } from "./adapters/convexCollectionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -20,7 +20,7 @@ export const deleteCollection = mutation({
 
     const remove = makeDeleteCollection({
       collections: convexCollectionRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/deleteCopy.ts
+++ b/packages/backend/convex/library/deleteCopy.ts
@@ -4,7 +4,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
 import { convexCopyReservationPort } from "./adapters/convexCopyReservationPort";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -19,7 +19,7 @@ export const deleteCopy = mutation({
     const remove = makeDeleteCopy({
       copies: convexCopyRepository(ctx),
       reservations: convexCopyReservationPort(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/getCollectionById.ts
+++ b/packages/backend/convex/library/getCollectionById.ts
@@ -52,6 +52,7 @@ export const getCollectionById = query({
     return toCollectionDetailView(
       collection,
       puzzles.filter((p) => p !== null),
+      { includeOwnerOnly: isOwner },
     );
   },
 });

--- a/packages/backend/convex/library/getCollectionById.ts
+++ b/packages/backend/convex/library/getCollectionById.ts
@@ -24,6 +24,10 @@ export const getCollectionById = query({
       return null;
     }
 
+    // Owner-only copy fields (notes/acquisition provenance) only surface when the viewer owns the
+    // collection (a public collection is readable by anyone, so a non-owner must not see them).
+    const isOwner = collection.userId === actingMember;
+
     const members = await ctx.db
       .query("collectionMembers")
       .withIndex("by_collection", (q) =>
@@ -38,7 +42,10 @@ export const getCollectionById = query({
           : null;
         if (!copy) return null;
         const puzzle = await ctx.db.get(copy.puzzleId);
-        return toOwnedCopyView(copy, puzzle, { addedAt: member.addedAt });
+        return toOwnedCopyView(copy, puzzle, {
+          addedAt: member.addedAt,
+          includeOwnerOnly: isOwner,
+        });
       }),
     );
 

--- a/packages/backend/convex/library/getCollectionById.ts
+++ b/packages/backend/convex/library/getCollectionById.ts
@@ -1,6 +1,8 @@
 import type { CollectionDetailView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toCollectionDetailView, toOwnedCopyView } from "./mappers";
 
 // Library read: a collection with its member copies resolved (each carrying its addedAt and joined
@@ -9,8 +11,18 @@ import { toCollectionDetailView, toOwnedCopyView } from "./mappers";
 export const getCollectionById = query({
   args: { collectionId: v.id("collections") },
   handler: async (ctx, args): Promise<CollectionDetailView | null> => {
+    const actingMember = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const collection = await ctx.db.get(args.collectionId);
     if (!collection) return null;
+
+    // Visibility ACL: only the owner may read a non-public collection.
+    if (
+      collection.userId !== actingMember &&
+      collection.visibility !== "public"
+    ) {
+      return null;
+    }
 
     const members = await ctx.db
       .query("collectionMembers")

--- a/packages/backend/convex/library/getCollectionById.ts
+++ b/packages/backend/convex/library/getCollectionById.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { canViewCopy } from "./canViewCopy";
 import { toCollectionDetailView, toOwnedCopyView } from "./mappers";
 
 // Library read: a collection with its member copies resolved (each carrying its addedAt and joined
@@ -41,6 +42,14 @@ export const getCollectionById = query({
           ? await ctx.db.get(member.ownedPuzzleId)
           : null;
         if (!copy) return null;
+        // Per-copy reachability gate: a non-owner viewing a public collection must NOT see member
+        // copies that fail THE canonical copy-reachability gate (private/closed copies the owner
+        // added), exactly as every sibling copy-read (getOwnedPuzzlesByOwner, getCopyInstanceView,
+        // featuredShelf, listPuzzleComments, ...) does. The owner viewing their own collection sees
+        // everything (canViewCopy short-circuits on ownership).
+        if (!isOwner && !(await canViewCopy(ctx, actingMember, copy))) {
+          return null;
+        }
         const puzzle = await ctx.db.get(copy.puzzleId);
         return toOwnedCopyView(copy, puzzle, {
           addedAt: member.addedAt,

--- a/packages/backend/convex/library/getCollectionsForOwnedPuzzle.ts
+++ b/packages/backend/convex/library/getCollectionsForOwnedPuzzle.ts
@@ -32,8 +32,10 @@ export const getCollectionsForOwnedPuzzle = query({
       }),
     );
 
+    // Every collection here belongs to the acting member (filtered above), so the viewer is the
+    // owner — surface their own personalNotes.
     return collections
       .filter((c) => c !== null)
-      .map(toCollectionMembershipView);
+      .map((c) => toCollectionMembershipView(c, { includeOwnerOnly: true }));
   },
 });

--- a/packages/backend/convex/library/getCopyInstanceView.ts
+++ b/packages/backend/convex/library/getCopyInstanceView.ts
@@ -13,6 +13,7 @@ import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
 import { projectMemberIdentity } from "../social/privacy";
+import { canViewCopy } from "./canViewCopy";
 
 // Solve duration in whole MINUTES: prefer (endDate - startDate); else completionTimeMinutes; else
 // null. Returned raw (not rounded to days) so the UI can humanize it (e.g. "2 hours", "1 day",
@@ -51,6 +52,13 @@ export const getCopyInstanceView = query({
 
     const copy = await ctx.db.get(args.copyId);
     if (!copy) return null;
+
+    // Copy-reachability gate (identical to browseOwnedPuzzles): the viewer may only see this copy if
+    // they own it, the owner is public AND the copy is open, or the copy is circle-shared to them.
+    // A private/unreachable copy of another member returns null — no personal data leaks.
+    if (!(await canViewCopy(ctx, viewerId, copy))) return null;
+
+    const viewerIsOwner = copy.ownerId === viewerId;
 
     const puzzle = await ctx.db.get(copy.puzzleId);
     const salt = args.copyId as string;
@@ -135,8 +143,6 @@ export const getCopyInstanceView = query({
       ...completionEntries,
       ...loanEntries,
     ].sort((a, b) => a.occurredAt - b.occurredAt);
-
-    const viewerIsOwner = copy.ownerId === viewerId;
 
     // The acquisition boundary: the latest custody transfer that handed the copy TO the viewer,
     // else the copy's creation time. Only meaningful when the viewer owns the copy.
@@ -335,10 +341,12 @@ export const getCopyInstanceView = query({
         image: coverImage,
         coverImageId,
         condition: copy.condition,
-        notes: copy.notes,
+        // Owner-only personal fields (notes / acquisition provenance) are omitted for non-owners,
+        // alongside the sale/acquisition price the DTO already never carries for them.
+        notes: viewerIsOwner ? copy.notes : undefined,
         availability: copy.availability,
-        acquisitionDate: copy.acquisitionDate,
-        acquisitionSource: copy.acquisitionSource,
+        acquisitionDate: viewerIsOwner ? copy.acquisitionDate : undefined,
+        acquisitionSource: viewerIsOwner ? copy.acquisitionSource : undefined,
         difficulty: puzzle?.difficulty,
         tags: puzzle?.tags ?? [],
       },

--- a/packages/backend/convex/library/getCopyLoanHistory.ts
+++ b/packages/backend/convex/library/getCopyLoanHistory.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { canViewCopy } from "./canViewCopy";
 import { toProjectedLoanView } from "./loanReadViews";
 
 // A copy's full lending history (every loan, newest first), for the copy detail page. Auth-gated;
@@ -15,6 +16,9 @@ export const getCopyLoanHistory = query({
 
     const copy = await ctx.db.get(args.copyId);
     if (!copy?.aggregateId) return [];
+    // Copy-reachability gate (identical to browseOwnedPuzzles / getCopyInstanceView): a non-owner
+    // may not read the loan history of a private/unreachable copy.
+    if (!(await canViewCopy(ctx, viewerId, copy))) return [];
     const salt = args.copyId as string;
     const loans = await ctx.db
       .query("loans")

--- a/packages/backend/convex/library/getCopyLoanHistory.ts
+++ b/packages/backend/convex/library/getCopyLoanHistory.ts
@@ -1,19 +1,28 @@
-import type { LoanView } from "@jigswap/contracts";
+import type { ProjectedLoanView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
-import { toLoanView } from "./loanReadViews";
+import { requireMember } from "../identity/requireMember";
+import { toProjectedLoanView } from "./loanReadViews";
 
-// A copy's full lending history (every loan, newest first), for the copy detail page.
+// A copy's full lending history (every loan, newest first), for the copy detail page. Auth-gated;
+// both parties of every loan are privacy-projected (salt = copyId), so a hidden member's identity
+// never crosses the wire — consistent with getCopyInstanceView's loan projection.
 export const getCopyLoanHistory = query({
   args: { copyId: v.id("ownedPuzzles") },
-  handler: async (ctx, args): Promise<LoanView[]> => {
+  handler: async (ctx, args): Promise<ProjectedLoanView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const copy = await ctx.db.get(args.copyId);
     if (!copy?.aggregateId) return [];
+    const salt = args.copyId as string;
     const loans = await ctx.db
       .query("loans")
       .withIndex("by_copy", (q) => q.eq("copyId", copy.aggregateId as string))
       .order("desc")
       .collect();
-    return Promise.all(loans.map((loan) => toLoanView(ctx, loan)));
+    return Promise.all(
+      loans.map((loan) => toProjectedLoanView(ctx, loan, viewerId, salt)),
+    );
   },
 });

--- a/packages/backend/convex/library/getOwnedPuzzleWithCollectionStatus.ts
+++ b/packages/backend/convex/library/getOwnedPuzzleWithCollectionStatus.ts
@@ -35,10 +35,31 @@ export const getOwnedPuzzleWithCollectionStatus = query({
 
     const owner = await ctx.db.get(ownedPuzzle.ownerId);
 
-    const collection = await ctx.db
-      .query("collections")
-      .withIndex("by_user", (q) => q.eq("userId", user._id))
-      .unique();
+    // Collection status of THIS specific copy: find a collectionMembers row for the copy whose
+    // collection belongs to the acting member. `by_user` is non-unique, so the user's collection ids
+    // are collected into a set and the copy's membership rows are matched against it. (A bare
+    // `.unique()` on `by_user` would throw for any member with >=2 collections, and a non-null
+    // collection never proved the copy itself was a member.)
+    const userCollectionIds = new Set(
+      (
+        await ctx.db
+          .query("collections")
+          .withIndex("by_user", (q) => q.eq("userId", user._id))
+          .collect()
+      ).map((c) => c._id),
+    );
+    const memberships = await ctx.db
+      .query("collectionMembers")
+      .withIndex("by_owned_puzzle", (q) =>
+        q.eq("ownedPuzzleId", args.ownedPuzzleId),
+      )
+      .collect();
+    const membership = memberships.find((m) =>
+      userCollectionIds.has(m.collectionId),
+    );
+    const collection = membership
+      ? await ctx.db.get(membership.collectionId)
+      : null;
 
     const completions = await ctx.db
       .query("completions")

--- a/packages/backend/convex/library/getOwnedPuzzleWithCollectionStatus.ts
+++ b/packages/backend/convex/library/getOwnedPuzzleWithCollectionStatus.ts
@@ -30,6 +30,12 @@ export const getOwnedPuzzleWithCollectionStatus = query({
     const ownedPuzzle = await ctx.db.get(args.ownedPuzzleId);
     if (!ownedPuzzle) return null;
 
+    // Owner-only management view: collection status and completion history are computed for the
+    // ACTING member, and the result exposes financials (acquisition/sale price), private notes, and
+    // unmoderated photos. A non-owner gets null; the public copy-detail route uses the gated
+    // getCopyInstanceView instead.
+    if (ownedPuzzle.ownerId !== user._id) return null;
+
     const puzzle = await ctx.db.get(ownedPuzzle.puzzleId);
     if (!puzzle) return null;
 

--- a/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
+++ b/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { canViewCopy } from "./canViewCopy";
 import { toOwnedCopyView } from "./mappers";
 
 const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
@@ -31,10 +32,16 @@ export const getOwnedPuzzlesByOwner = query({
       .collect();
 
     if (!isOwner) {
-      // A non-owner only ever sees available, non-private copies — `includeUnavailable` is ignored.
-      ownedPuzzles = ownedPuzzles.filter(
-        (i) => i.visibility !== "private" && isOpen(i),
+      // A non-owner only sees copies that pass THE canonical copy-reachability gate (canViewCopy),
+      // exactly as Browse/getCopyInstanceView do — `includeUnavailable` is ignored. The previous
+      // ad-hoc filter checked only the per-copy `visibility` + isOpen axes, NOT the owner's PROFILE
+      // visibility, so available copies of a member with a PRIVATE profile were still enumerated to
+      // any authenticated viewer. canViewCopy folds in owner-public AND circle-shared reachability,
+      // closing that leak and keeping this read consistent with the rest of the library.
+      const visible = await Promise.all(
+        ownedPuzzles.map((copy) => canViewCopy(ctx, viewerId, copy)),
       );
+      ownedPuzzles = ownedPuzzles.filter((_, i) => visible[i]);
     } else if (!args.includeUnavailable) {
       ownedPuzzles = ownedPuzzles.filter(isOpen);
     }

--- a/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
+++ b/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
@@ -10,24 +10,12 @@ const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
   copy.availability.forSale ||
   copy.availability.forLend;
 
-// Owner-only fields that must never surface on a NON-owner's view of a copy (price, provenance and
-// private notes are personal to the owner). Strip them off the row before it reaches the mapper.
-const stripOwnerOnly = (copy: Doc<"ownedPuzzles">): Doc<"ownedPuzzles"> => {
-  const { salePrice, acquisitionPrice, acquisitionSource, notes, ...rest } =
-    copy;
-  void salePrice;
-  void acquisitionPrice;
-  void acquisitionSource;
-  void notes;
-  return rest as Doc<"ownedPuzzles">;
-};
-
 // Library read: a member's owned copies (optionally only the available ones), each joined to its
 // Catalog puzzle. Auth-gated. The OWNER sees everything (both available + private copies, with all
 // owner-only fields). A NON-owner only sees available, non-private copies, with owner-only fields
-// (salePrice/acquisitionPrice/acquisitionSource/notes) stripped — `includeUnavailable` is ignored
-// for non-owners. Filtering, the newest-first ordering, and the join are preserved from legacy
-// puzzles.getOwnedPuzzlesByOwner; rows map to typed copy DTOs.
+// (acquisitionPrice/acquisitionSource/notes) stripped by the mapper's `includeOwnerOnly` default —
+// `includeUnavailable` is ignored for non-owners. Filtering, the newest-first ordering, and the
+// join are preserved from legacy puzzles.getOwnedPuzzlesByOwner; rows map to typed copy DTOs.
 export const getOwnedPuzzlesByOwner = query({
   args: {
     ownerId: v.id("users"),
@@ -52,8 +40,7 @@ export const getOwnedPuzzlesByOwner = query({
     }
 
     const views = await Promise.all(
-      ownedPuzzles.map(async (rawCopy) => {
-        const copy = isOwner ? rawCopy : stripOwnerOnly(rawCopy);
+      ownedPuzzles.map(async (copy) => {
         const puzzle = await ctx.db.get(copy.puzzleId);
         // Resolve the card cover: the copy's chosen-and-APPROVED cover photo if set, otherwise the
         // puzzle's global box art, else null (the card falls back to its placeholder). Pending or
@@ -68,7 +55,10 @@ export const getOwnedPuzzlesByOwner = query({
         if (!coverUrl && puzzle?.image) {
           coverUrl = await ctx.storage.getUrl(puzzle.image);
         }
-        return toOwnedCopyView(copy, puzzle, { coverUrl });
+        return toOwnedCopyView(copy, puzzle, {
+          coverUrl,
+          includeOwnerOnly: isOwner,
+        });
       }),
     );
 

--- a/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
+++ b/packages/backend/convex/library/getOwnedPuzzlesByOwner.ts
@@ -1,33 +1,59 @@
 import type { OwnedCopyView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toOwnedCopyView } from "./mappers";
 
+const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
+  copy.availability.forTrade ||
+  copy.availability.forSale ||
+  copy.availability.forLend;
+
+// Owner-only fields that must never surface on a NON-owner's view of a copy (price, provenance and
+// private notes are personal to the owner). Strip them off the row before it reaches the mapper.
+const stripOwnerOnly = (copy: Doc<"ownedPuzzles">): Doc<"ownedPuzzles"> => {
+  const { salePrice, acquisitionPrice, acquisitionSource, notes, ...rest } =
+    copy;
+  void salePrice;
+  void acquisitionPrice;
+  void acquisitionSource;
+  void notes;
+  return rest as Doc<"ownedPuzzles">;
+};
+
 // Library read: a member's owned copies (optionally only the available ones), each joined to its
-// Catalog puzzle. Filtering (availability), the newest-first ordering, and the join are preserved
-// from legacy puzzles.getOwnedPuzzlesByOwner; rows map to typed copy DTOs.
+// Catalog puzzle. Auth-gated. The OWNER sees everything (both available + private copies, with all
+// owner-only fields). A NON-owner only sees available, non-private copies, with owner-only fields
+// (salePrice/acquisitionPrice/acquisitionSource/notes) stripped — `includeUnavailable` is ignored
+// for non-owners. Filtering, the newest-first ordering, and the join are preserved from legacy
+// puzzles.getOwnedPuzzlesByOwner; rows map to typed copy DTOs.
 export const getOwnedPuzzlesByOwner = query({
   args: {
     ownerId: v.id("users"),
     includeUnavailable: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<OwnedCopyView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+    const isOwner = viewerId === args.ownerId;
+
     let ownedPuzzles = await ctx.db
       .query("ownedPuzzles")
       .withIndex("by_owner", (q) => q.eq("ownerId", args.ownerId))
       .collect();
 
-    if (!args.includeUnavailable) {
+    if (!isOwner) {
+      // A non-owner only ever sees available, non-private copies — `includeUnavailable` is ignored.
       ownedPuzzles = ownedPuzzles.filter(
-        (i) =>
-          i.availability.forTrade ||
-          i.availability.forSale ||
-          i.availability.forLend,
+        (i) => i.visibility !== "private" && isOpen(i),
       );
+    } else if (!args.includeUnavailable) {
+      ownedPuzzles = ownedPuzzles.filter(isOpen);
     }
 
     const views = await Promise.all(
-      ownedPuzzles.map(async (copy) => {
+      ownedPuzzles.map(async (rawCopy) => {
+        const copy = isOwner ? rawCopy : stripOwnerOnly(rawCopy);
         const puzzle = await ctx.db.get(copy.puzzleId);
         // Resolve the card cover: the copy's chosen-and-APPROVED cover photo if set, otherwise the
         // puzzle's global box art, else null (the card falls back to its placeholder). Pending or

--- a/packages/backend/convex/library/getUserCollections.ts
+++ b/packages/backend/convex/library/getUserCollections.ts
@@ -23,13 +23,20 @@ export const getUserCollections = query({
     if (!currentUser) throw new ConvexError("User not found");
 
     const targetUserId = args.userId || currentUser._id;
+    const isOwner = targetUserId === currentUser._id;
 
     let collections = await ctx.db
       .query("collections")
       .withIndex("by_user", (q) => q.eq("userId", targetUserId))
       .collect();
 
-    if (args.includePublic && targetUserId !== currentUser._id) {
+    // Visibility ACL: another member's private collections (names, descriptions, personalNotes,
+    // wished definitions) must never leak — only the owner sees their own private collections.
+    if (!isOwner) {
+      collections = collections.filter((c) => c.visibility === "public");
+    }
+
+    if (args.includePublic && !isOwner) {
       const publicCollections = await ctx.db
         .query("collections")
         .withIndex("by_visibility", (q) => q.eq("visibility", "public"))

--- a/packages/backend/convex/library/getUserCollections.ts
+++ b/packages/backend/convex/library/getUserCollections.ts
@@ -41,7 +41,17 @@ export const getUserCollections = query({
         .query("collections")
         .withIndex("by_visibility", (q) => q.eq("visibility", "public"))
         .collect();
-      collections = [...collections, ...publicCollections];
+      // De-duplicate by `_id` (keep first occurrence): the target's public collections were already
+      // fetched above and ALSO appear in this platform-wide public set, so a plain concat would
+      // surface each of the target's public collections twice.
+      const merged = [...collections, ...publicCollections];
+      const seen = new Set<string>();
+      collections = merged.filter((c) => {
+        const id = c._id as unknown as string;
+        if (seen.has(id)) return false;
+        seen.add(id);
+        return true;
+      });
     }
 
     const views = await Promise.all(

--- a/packages/backend/convex/library/getUserCollections.ts
+++ b/packages/backend/convex/library/getUserCollections.ts
@@ -62,7 +62,11 @@ export const getUserCollections = query({
             q.eq("collectionId", collection._id),
           )
           .collect();
-        return toCollectionView(collection, members.length);
+        return toCollectionView(collection, members.length, {
+          // personalNotes is owner-only: surface it only on the acting member's OWN collections
+          // (the public-collection set may include OTHER members' collections under includePublic).
+          includeOwnerOnly: collection.userId === currentUser._id,
+        });
       }),
     );
 

--- a/packages/backend/convex/library/listPhotoComments.ts
+++ b/packages/backend/convex/library/listPhotoComments.ts
@@ -1,15 +1,30 @@
 import type { PhotoCommentView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
+import { canViewCopy } from "./canViewCopy";
 
 // Read side: the discussion comments on a single shared PHOTO, newest first. Keyed by the
 // `ownedPuzzleImages` _id the lightbox shows. Each comment joins its REAL author (photo comments are
 // voluntary public posts — never anonymised). The author join falls back to a synthetic "Member"
 // view if the user row vanished, so an orphaned comment never breaks the list.
+//
+// SECURITY: auth-gated, and the photo's parent copy is run through the SAME reachability gate as
+// getCopyInstanceView (canViewCopy) before any comment is returned — a missing photo, missing copy,
+// or a private/unreachable copy of another member yields [], so the photo discussion never leaks to
+// a viewer who cannot see the copy.
 export const listPhotoComments = query({
   args: { photoId: v.id("ownedPuzzleImages") },
   handler: async (ctx, args): Promise<PhotoCommentView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+
+    const photo = await ctx.db.get(args.photoId);
+    if (!photo) return [];
+    const copy = await ctx.db.get(photo.ownedPuzzleId);
+    if (!copy || !(await canViewCopy(ctx, viewerId, copy))) return [];
+
     const rows = await ctx.db
       .query("photoComments")
       .withIndex("by_photo", (q) => q.eq("photoId", args.photoId))

--- a/packages/backend/convex/library/listPhotoComments.ts
+++ b/packages/backend/convex/library/listPhotoComments.ts
@@ -26,8 +26,6 @@ export const listPhotoComments = query({
             : {
                 _id: row.authorId,
                 _creationTime: 0,
-                clerkId: "",
-                email: "",
                 name: "Member",
                 isActive: false,
                 createdAt: 0,

--- a/packages/backend/convex/library/loanReadViews.ts
+++ b/packages/backend/convex/library/loanReadViews.ts
@@ -1,7 +1,8 @@
-import type { LoanView } from "@jigswap/contracts";
-import type { Doc } from "../_generated/dataModel";
+import type { LoanView, ProjectedLoanView } from "@jigswap/contracts";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { toMemberView } from "../identity/toMemberView";
+import { projectMemberIdentity } from "../social/privacy";
 
 // Resolve a loan row into a typed LoanView: join the copy (title/pieces) and both members.
 export const toLoanView = async (
@@ -31,4 +32,21 @@ export const toLoanView = async (
     lender: lender ? toMemberView(lender) : null,
     borrower: borrower ? toMemberView(borrower) : null,
   };
+};
+
+// Resolve a loan into a ProjectedLoanView for a Copy's PUBLIC lending history: identical to
+// toLoanView but both parties are run through projectMemberIdentity (salt = the copy's _id, matching
+// getCopyInstanceView) so a hidden member's real identity never crosses the wire.
+export const toProjectedLoanView = async (
+  ctx: QueryCtx,
+  loan: Doc<"loans">,
+  viewerId: Id<"users">,
+  salt: string,
+): Promise<ProjectedLoanView> => {
+  const base = await toLoanView(ctx, loan);
+  const [lender, borrower] = await Promise.all([
+    projectMemberIdentity(ctx, viewerId, loan.lenderId, salt),
+    projectMemberIdentity(ctx, viewerId, loan.borrowerId, salt),
+  ]);
+  return { ...base, lender, borrower };
 };

--- a/packages/backend/convex/library/mappers.ts
+++ b/packages/backend/convex/library/mappers.ts
@@ -132,9 +132,18 @@ export const toOwnedCopyCompletionView = (
   updatedAt: row.updatedAt,
 });
 
-/** The bare collection row (no derived count) for the contains-copy read. */
+/**
+ * The bare collection row (no derived count) for the contains-copy read.
+ *
+ * SECURITY: `personalNotes` is the owner's private note on the collection and must never surface to
+ * a non-owner — a PUBLIC collection is readable by anyone, so the note is OMITTED unless
+ * `opts.includeOwnerOnly` is explicitly true (the caller established viewer === collection owner).
+ * `wishedDefinitions` is the substantive (public) content of a shared wishlist and is always
+ * carried.
+ */
 export const toCollectionMembershipView = (
   row: Doc<"collections">,
+  opts?: { includeOwnerOnly?: boolean },
 ): CollectionMembershipView => ({
   _id: row._id,
   _creationTime: row._creationTime,
@@ -148,7 +157,7 @@ export const toCollectionMembershipView = (
   isDefault: row.isDefault,
   isWishlist: row.isWishlist,
   wishedDefinitions: row.wishedDefinitions,
-  personalNotes: row.personalNotes,
+  personalNotes: opts?.includeOwnerOnly ? row.personalNotes : undefined,
   createdAt: row.createdAt,
   updatedAt: row.updatedAt,
 });
@@ -157,8 +166,9 @@ export const toCollectionMembershipView = (
 export const toCollectionView = (
   row: Doc<"collections">,
   puzzleCount: number,
+  opts?: { includeOwnerOnly?: boolean },
 ): CollectionView => ({
-  ...toCollectionMembershipView(row),
+  ...toCollectionMembershipView(row, opts),
   puzzleCount,
 });
 
@@ -166,7 +176,8 @@ export const toCollectionView = (
 export const toCollectionDetailView = (
   row: Doc<"collections">,
   puzzles: OwnedCopyView[],
+  opts?: { includeOwnerOnly?: boolean },
 ): CollectionDetailView => ({
-  ...toCollectionMembershipView(row),
+  ...toCollectionMembershipView(row, opts),
   puzzles,
 });

--- a/packages/backend/convex/library/mappers.ts
+++ b/packages/backend/convex/library/mappers.ts
@@ -44,8 +44,9 @@ export const toOwnedCopyOwnerView = (
 /**
  * An owned copy with its joined puzzle (and optional owner / collection-membership timestamp).
  *
- * SECURITY: the owner-only personal fields — `notes`, `acquisitionPrice`, `acquisitionSource` — are
- * OMITTED by default and only included when `opts.includeOwnerOnly` is explicitly true (i.e. the
+ * SECURITY: the owner-only personal fields — `notes`, `acquisitionPrice`, `acquisitionSource`,
+ * `acquisitionDate` — are OMITTED by default and only included when `opts.includeOwnerOnly` is
+ * explicitly true (i.e. the
  * caller has established viewer === owner). Stripping owner-only data is opt-OUT at the mapper, not
  * something each call site must remember to do. `salePrice` is NOT owner-only: it is the public
  * asking price for a copy listed `forSale`, so it is always carried (the row only holds it when the
@@ -76,7 +77,7 @@ export const toOwnedCopyView = (
   visibility: row.visibility,
   // Public asking price for a copy listed for sale — always carried.
   salePrice: row.salePrice,
-  acquisitionDate: row.acquisitionDate,
+  acquisitionDate: opts?.includeOwnerOnly ? row.acquisitionDate : undefined,
   acquisitionSource: opts?.includeOwnerOnly ? row.acquisitionSource : undefined,
   acquisitionPrice: opts?.includeOwnerOnly ? row.acquisitionPrice : undefined,
   snapshot: row.snapshot,

--- a/packages/backend/convex/library/mappers.ts
+++ b/packages/backend/convex/library/mappers.ts
@@ -41,7 +41,17 @@ export const toOwnedCopyOwnerView = (
   avatar: row.avatar,
 });
 
-/** An owned copy with its joined puzzle (and optional owner / collection-membership timestamp). */
+/**
+ * An owned copy with its joined puzzle (and optional owner / collection-membership timestamp).
+ *
+ * SECURITY: the owner-only personal fields — `notes`, `acquisitionPrice`, `acquisitionSource` — are
+ * OMITTED by default and only included when `opts.includeOwnerOnly` is explicitly true (i.e. the
+ * caller has established viewer === owner). Stripping owner-only data is opt-OUT at the mapper, not
+ * something each call site must remember to do. `salePrice` is NOT owner-only: it is the public
+ * asking price for a copy listed `forSale`, so it is always carried (the row only holds it when the
+ * owner set one). Callers that surface OTHER members' copies must leave `includeOwnerOnly` at its
+ * `false` default.
+ */
 export const toOwnedCopyView = (
   row: Doc<"ownedPuzzles">,
   puzzle: Doc<"puzzles"> | null,
@@ -49,6 +59,7 @@ export const toOwnedCopyView = (
     owner?: Doc<"users"> | null;
     addedAt?: number;
     coverUrl?: string | null;
+    includeOwnerOnly?: boolean;
   },
 ): OwnedCopyView => ({
   _id: row._id,
@@ -59,13 +70,15 @@ export const toOwnedCopyView = (
   ownerId: row.ownerId,
   condition: row.condition,
   missingPiecesCount: row.missingPiecesCount,
-  notes: row.notes,
+  // Owner-only personal fields: only surfaced when the viewer owns the copy.
+  notes: opts?.includeOwnerOnly ? row.notes : undefined,
   availability: row.availability,
   visibility: row.visibility,
+  // Public asking price for a copy listed for sale — always carried.
   salePrice: row.salePrice,
   acquisitionDate: row.acquisitionDate,
-  acquisitionSource: row.acquisitionSource,
-  acquisitionPrice: row.acquisitionPrice,
+  acquisitionSource: opts?.includeOwnerOnly ? row.acquisitionSource : undefined,
+  acquisitionPrice: opts?.includeOwnerOnly ? row.acquisitionPrice : undefined,
   snapshot: row.snapshot,
   createdAt: row.createdAt,
   updatedAt: row.updatedAt,

--- a/packages/backend/convex/library/moderatePhoto.ts
+++ b/packages/backend/convex/library/moderatePhoto.ts
@@ -135,6 +135,10 @@ export const moderatePhoto = internalAction({
 
       // Re-encode (strip EXIF/metadata). Best-effort: on decode failure, classify the original.
       let cleanBytes = bytes;
+      // Tracks the just-stored clean blob across the try/catch. If `setModerationFile` throws AFTER
+      // the store succeeded, the row still points at the original, so the clean blob is unreferenced.
+      // There is no storage GC, so we must delete it ourselves to avoid orphaning it permanently.
+      let storedFileId: string | null = null;
       try {
         const { bytes: encoded, mime } = await reencodeImage(bytes);
         cleanBytes = encoded;
@@ -144,11 +148,14 @@ export const moderatePhoto = internalAction({
         const newFileId = await ctx.storage.store(
           new Blob([toArrayBuffer(cleanBytes)], { type: mime }),
         );
+        storedFileId = newFileId;
         await ctx.runMutation(
           internal.library.moderationStore.setModerationFile,
           { imageId, fileId: newFileId },
         );
-        // The row now points at the clean blob; drop the original (best-effort).
+        // Swap succeeded: the row now points at the clean blob, so it is no longer the one to clean
+        // up on failure; drop the original instead (best-effort).
+        storedFileId = null;
         try {
           await ctx.storage.delete(row.fileId);
         } catch (error) {
@@ -158,6 +165,15 @@ export const moderatePhoto = internalAction({
         event.reencoded = false;
         event.reencode_error = errMsg(error);
         cleanBytes = bytes;
+        // If the clean blob was stored but the row swap failed, the blob is now orphaned (the row
+        // still references the original). Delete it best-effort before falling back to the original.
+        if (storedFileId !== null) {
+          try {
+            await ctx.storage.delete(storedFileId);
+          } catch (cleanupError) {
+            event.orphan_cleanup_error = errMsg(cleanupError);
+          }
+        }
       }
 
       // Classify. The port itself fails open; this try/catch is the last-resort guard.

--- a/packages/backend/convex/library/openLoanOnSettlement.ts
+++ b/packages/backend/convex/library/openLoanOnSettlement.ts
@@ -3,7 +3,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
 import { convexLoanRepository } from "./adapters/convexLoanRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { loanIdGenerator } from "./adapters/idGenerators";
 import { systemClock } from "./adapters/systemClock";
 
@@ -23,7 +23,7 @@ export const handleDomainEvent = async (
     copies: convexCopyRepository(ctx),
     loans: convexLoanRepository(ctx),
     ids: loanIdGenerator,
-    events: noopEventPublisher(ctx),
+    events: libraryEventPublisher(ctx),
     clock: systemClock,
   });
   await openLoan({

--- a/packages/backend/convex/library/postPhotoComment.ts
+++ b/packages/backend/convex/library/postPhotoComment.ts
@@ -6,6 +6,7 @@ import {
   toPhotoId,
 } from "@jigswap/domain";
 import { ConvexError, v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexPhotoCommentRepository } from "../social/adapters/convexPhotoCommentRepository";
@@ -13,11 +14,13 @@ import { photoCommentIdGenerator } from "../social/adapters/idGenerators";
 import { inProcessEventPublisher } from "../social/adapters/inProcessEventPublisher";
 import { systemClock } from "../social/adapters/systemClock";
 import { toConvexError } from "../social/errors";
+import { canViewCopy } from "./canViewCopy";
 
 // Composition root for posting a discussion comment on a single shared PHOTO. The comment is keyed
-// to the `ownedPuzzleImages` _id (the lightbox the UI shows). Anyone authenticated may comment —
-// these are public discussion on a shared photo — so the author is derived from auth and we only
-// require that the photo exists. The PhotoComment aggregate validates the text.
+// to the `ownedPuzzleImages` _id (the lightbox the UI shows). Anyone authenticated who can SEE the
+// photo's copy may comment — these are public discussion on a shared photo — so the author is
+// derived from auth and the photo's parent copy is run through the SAME reachability gate as the
+// read side (canViewCopy). The PhotoComment aggregate validates the text.
 export const postPhotoComment = mutation({
   args: {
     photoId: v.id("ownedPuzzleImages"),
@@ -28,6 +31,15 @@ export const postPhotoComment = mutation({
 
     const photo = await ctx.db.get(args.photoId);
     if (!photo) throw new ConvexError("Photo not found");
+
+    // Reachability gate: a member must not comment on a photo of a copy they cannot see.
+    const copy = await ctx.db.get(photo.ownedPuzzleId);
+    if (
+      !copy ||
+      !(await canViewCopy(ctx, authorId as unknown as Id<"users">, copy))
+    ) {
+      throw new ConvexError("Photo not found");
+    }
 
     const post = makePostPhotoComment({
       comments: convexPhotoCommentRepository(ctx),

--- a/packages/backend/convex/library/recallLoan.ts
+++ b/packages/backend/convex/library/recallLoan.ts
@@ -4,7 +4,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
 import { convexLoanRepository } from "./adapters/convexLoanRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -17,7 +17,7 @@ export const recallLoan = mutation({
     const result = await makeRecallLoan({
       loans: convexLoanRepository(ctx),
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     })({
       loanId: toLoanId(args.loanId),

--- a/packages/backend/convex/library/removeCopyFromCollection.ts
+++ b/packages/backend/convex/library/removeCopyFromCollection.ts
@@ -8,7 +8,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCollectionRepository } from "./adapters/convexCollectionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -23,7 +23,7 @@ export const removeCopyFromCollection = mutation({
 
     const remove = makeRemoveCopyFromCollection({
       collections: convexCollectionRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/returnLoan.ts
+++ b/packages/backend/convex/library/returnLoan.ts
@@ -4,7 +4,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
 import { convexLoanRepository } from "./adapters/convexLoanRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -17,7 +17,7 @@ export const returnLoan = mutation({
     const result = await makeReturnLoan({
       loans: convexLoanRepository(ctx),
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     })({
       loanId: toLoanId(args.loanId),

--- a/packages/backend/convex/library/setCopyCover.ts
+++ b/packages/backend/convex/library/setCopyCover.ts
@@ -4,7 +4,7 @@ import type { Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -40,7 +40,7 @@ export const setCopyCover = mutation({
 
     const setCover = makeSetCopyCover({
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/transferOnSettlement.ts
+++ b/packages/backend/convex/library/transferOnSettlement.ts
@@ -6,7 +6,7 @@ import {
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 
 // Library's reaction to a settled swap/sale (Exchange's OwnershipTransferred): the SAME copy changes
@@ -25,7 +25,7 @@ export const handleDomainEvent = async (
 
   const transfer = makeTransferCopyOwnership({
     copies: convexCopyRepository(ctx),
-    events: noopEventPublisher(ctx),
+    events: libraryEventPublisher(ctx),
     clock: systemClock,
   });
   // The new owner is the event's member id, which is the resolved users _id the copy row stores.

--- a/packages/backend/convex/library/updateCollection.ts
+++ b/packages/backend/convex/library/updateCollection.ts
@@ -8,7 +8,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCollectionRepository } from "./adapters/convexCollectionRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -30,7 +30,7 @@ export const updateCollection = mutation({
 
     const update = makeUpdateCollection({
       collections: convexCollectionRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/updateCopyDetails.ts
+++ b/packages/backend/convex/library/updateCopyDetails.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -20,7 +20,7 @@ export const updateCopyDetails = mutation({
 
     const update = makeUpdateCopyDetails({
       copies: convexCopyRepository(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/library/updateCopySharing.ts
+++ b/packages/backend/convex/library/updateCopySharing.ts
@@ -10,7 +10,7 @@ import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCopyRepository } from "./adapters/convexCopyRepository";
 import { convexCopyReservationPort } from "./adapters/convexCopyReservationPort";
-import { noopEventPublisher } from "./adapters/eventPublisher";
+import { libraryEventPublisher } from "./adapters/eventPublisher";
 import { systemClock } from "./adapters/systemClock";
 import { toConvexError } from "./errors";
 
@@ -44,7 +44,7 @@ export const updateCopySharing = mutation({
     const update = makeUpdateCopySharing({
       copies: convexCopyRepository(ctx),
       reservations: convexCopyReservationPort(ctx),
-      events: noopEventPublisher(ctx),
+      events: libraryEventPublisher(ctx),
       clock: systemClock,
     });
 

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -188,11 +188,12 @@ describe("library reads", () => {
     expect(view).toHaveLength(1);
     const copy = view[0];
     expect(copy.puzzle?.title).toBe("Mountain Vista");
-    // Owner-only fields are stripped.
+    // Owner-only fields (private notes + acquisition provenance) are stripped for a non-owner.
     expect(copy.notes).toBeUndefined();
-    expect(copy.salePrice).toBeUndefined();
     expect(copy.acquisitionPrice).toBeUndefined();
     expect(copy.acquisitionSource).toBeUndefined();
+    // salePrice is the public asking price for a copy listed for sale — it stays visible.
+    expect(copy.salePrice).toEqual({ amount: 1000, currency: "EUR" });
     // Adversarial: the secret notes value never appears anywhere in the payload.
     expect(JSON.stringify(view)).not.toContain("my secret notes");
 
@@ -405,6 +406,73 @@ describe("collection reads", () => {
     expect(view?.puzzles).toHaveLength(1);
     expect(view?.puzzles[0].puzzle?.title).toBe("Mountain Vista");
     expect(view?.puzzles[0].addedAt).toBeDefined();
+  });
+
+  test("getCollectionById strips owner-only copy fields for a non-owner viewing a public collection", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, available } = await seed(t);
+
+    // Make the available copy carry owner-only data, then put it in a PUBLIC collection a non-owner
+    // can read. The collection is readable, but the copy's owner-only fields must not leak.
+    const publicCollection = await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.patch(available, {
+        notes: "my secret notes",
+        acquisitionPrice: { amount: 500, currency: "EUR" },
+        acquisitionSource: "bought_new",
+        salePrice: { amount: 1000, currency: "EUR" },
+      });
+      const coll = await ctx.db.insert("collections", {
+        aggregateId: "coll-public",
+        userId: alice,
+        name: "Public Showcase",
+        visibility: "public",
+        isDefault: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("collectionMembers", {
+        collectionId: coll,
+        ownedPuzzleId: available,
+        addedAt: now,
+      });
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return coll;
+    });
+
+    const seenByBob = await t
+      .withIdentity({ subject: "clerk_bob" })
+      .query(api.library.getCollectionById.getCollectionById, {
+        collectionId: publicCollection,
+      });
+    expect(seenByBob).not.toBeNull();
+    const bobCopy = seenByBob?.puzzles[0];
+    expect(bobCopy?.notes).toBeUndefined();
+    expect(bobCopy?.acquisitionPrice).toBeUndefined();
+    expect(bobCopy?.acquisitionSource).toBeUndefined();
+    // salePrice (public asking price) is still visible.
+    expect(bobCopy?.salePrice).toEqual({ amount: 1000, currency: "EUR" });
+    expect(JSON.stringify(seenByBob)).not.toContain("my secret notes");
+
+    // The owner sees the owner-only fields.
+    const seenByAlice = await asAlice(t).query(
+      api.library.getCollectionById.getCollectionById,
+      { collectionId: publicCollection },
+    );
+    const aliceCopy = seenByAlice?.puzzles[0];
+    expect(aliceCopy?.notes).toBe("my secret notes");
+    expect(aliceCopy?.acquisitionPrice).toEqual({
+      amount: 500,
+      currency: "EUR",
+    });
   });
 
   test("getCollectionsForOwnedPuzzle returns the member's collections containing the copy", async () => {

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -394,6 +394,90 @@ describe("collection reads", () => {
     expect(seenByBob.filter((c) => c.name === "Wishlist")).toHaveLength(1);
   });
 
+  test("getUserCollections withholds personalNotes from a non-owner on a public collection", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    // Give Alice's PUBLIC "Wishlist" a private personalNotes; a non-owner must never receive it.
+    await t.run(async (ctx) => {
+      const wishlist = await ctx.db
+        .query("collections")
+        .withIndex("by_user", (q) => q.eq("userId", alice))
+        .collect();
+      const pub = wishlist.find((c) => c.name === "Wishlist");
+      if (pub) await ctx.db.patch(pub._id, { personalNotes: "secret note" });
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const seenByBob = await t
+      .withIdentity({ subject: "clerk_bob" })
+      .query(api.library.getUserCollections.getUserCollections, {
+        userId: alice,
+      });
+    const bobWishlist = seenByBob.find((c) => c.name === "Wishlist");
+    expect(bobWishlist).toBeDefined();
+    expect(bobWishlist?.personalNotes).toBeUndefined();
+    expect(JSON.stringify(seenByBob)).not.toContain("secret note");
+
+    // The owner still sees their own personalNotes.
+    const seenByAlice = await asAlice(t).query(
+      api.library.getUserCollections.getUserCollections,
+      { userId: alice },
+    );
+    expect(seenByAlice.find((c) => c.name === "Wishlist")?.personalNotes).toBe(
+      "secret note",
+    );
+  });
+
+  test("getCollectionById withholds personalNotes from a non-owner on a public collection", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    const wishlistId = await t.run(async (ctx) => {
+      const cols = await ctx.db
+        .query("collections")
+        .withIndex("by_user", (q) => q.eq("userId", alice))
+        .collect();
+      const pub = cols.find((c) => c.name === "Wishlist")!;
+      await ctx.db.patch(pub._id, { personalNotes: "secret note" });
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return pub._id;
+    });
+
+    const seenByBob = await t
+      .withIdentity({ subject: "clerk_bob" })
+      .query(api.library.getCollectionById.getCollectionById, {
+        collectionId: wishlistId,
+      });
+    expect(seenByBob).not.toBeNull();
+    expect(seenByBob?.personalNotes).toBeUndefined();
+    expect(JSON.stringify(seenByBob)).not.toContain("secret note");
+
+    const seenByAlice = await asAlice(t).query(
+      api.library.getCollectionById.getCollectionById,
+      { collectionId: wishlistId },
+    );
+    expect(seenByAlice?.personalNotes).toBe("secret note");
+  });
+
   test("getCollectionById resolves member copies with addedAt", async () => {
     const t = convexTest(schema, modules);
     const { collection } = await seed(t);

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -189,6 +189,36 @@ describe("library reads", () => {
     expect(view?.completionHistory).toHaveLength(1);
   });
 
+  test("getOwnedPuzzleWithCollectionStatus is gated to the copy owner", async () => {
+    const t = convexTest(schema, modules);
+    const { available } = await seed(t);
+
+    // Bob is authenticated but does NOT own the copy: the owner-only management view (financials,
+    // private notes, unmoderated photos) must not leak — he gets null.
+    const bobClerk = "clerk_bob";
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: bobClerk,
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const seenByBob = await t
+      .withIdentity({ subject: bobClerk })
+      .query(
+        api.library.getOwnedPuzzleWithCollectionStatus
+          .getOwnedPuzzleWithCollectionStatus,
+        { ownedPuzzleId: available },
+      );
+    expect(seenByBob).toBeNull();
+  });
+
   test("getOwnedPuzzleWithCollectionStatus reports not-in-collection for an uncollected copy", async () => {
     const t = convexTest(schema, modules);
     const { unavailable } = await seed(t);

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -359,6 +359,40 @@ describe("collection reads", () => {
     expect(seenByAlice.map((c) => c.name)).toEqual(["Favourites", "Wishlist"]);
   });
 
+  test("getUserCollections de-duplicates the target's public collections under includePublic", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    // A non-owner viewer querying Alice's collections WITH includePublic. Alice's public "Wishlist"
+    // is fetched once as the target's public collection AND again as part of the platform-wide
+    // public set — the result must contain each `_id` exactly once (no duplicate rows).
+    const bobClerk = "clerk_bob";
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: bobClerk,
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const seenByBob = await t
+      .withIdentity({ subject: bobClerk })
+      .query(api.library.getUserCollections.getUserCollections, {
+        userId: alice,
+        includePublic: true,
+      });
+
+    const ids = seenByBob.map((c) => c._id);
+    expect(ids.length).toBe(new Set(ids).size);
+    // Alice's public "Wishlist" appears exactly once.
+    expect(seenByBob.filter((c) => c.name === "Wishlist")).toHaveLength(1);
+  });
+
   test("getCollectionById resolves member copies with addedAt", async () => {
     const t = convexTest(schema, modules);
     const { collection } = await seed(t);

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -122,7 +122,7 @@ describe("library reads", () => {
     const t = convexTest(schema, modules);
     const { alice } = await seed(t);
 
-    const available = await t.query(
+    const available = await asAlice(t).query(
       api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
       { ownerId: alice, includeUnavailable: false },
     );
@@ -131,13 +131,80 @@ describe("library reads", () => {
     // Box-art is never joined onto the copy's puzzle snapshot (preserved behaviour).
     expect(available[0].puzzle?.images).toBeUndefined();
 
-    const all = await t.query(
+    const all = await asAlice(t).query(
       api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
       { ownerId: alice, includeUnavailable: true },
     );
     expect(all).toHaveLength(2);
     // Newest-first.
     expect(all[0].puzzle?.title).toBe("Mountain Vista");
+  });
+
+  test("getOwnedPuzzlesByOwner is auth-gated", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+    await expect(
+      t.query(api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner, {
+        ownerId: alice,
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
+  test("getOwnedPuzzlesByOwner gates a non-owner: only available, non-private copies and owner-only fields stripped", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, available, unavailable } = await seed(t);
+
+    // Give the AVAILABLE copy owner-only data + a public visibility, and make the UNAVAILABLE one
+    // private so a non-owner must never see it (even with includeUnavailable).
+    await t.run(async (ctx) => {
+      await ctx.db.patch(available, {
+        visibility: "visible",
+        notes: "my secret notes",
+        salePrice: { amount: 1000, currency: "EUR" },
+        acquisitionPrice: { amount: 500, currency: "EUR" },
+        acquisitionSource: "bought_new",
+      });
+      await ctx.db.patch(unavailable, { visibility: "private" });
+      // A fresh non-owner viewer.
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const asBob = t.withIdentity({ subject: "clerk_bob" });
+
+    // Even asking for everything, the non-owner only gets the one available, non-private copy.
+    const view = await asBob.query(
+      api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
+      { ownerId: alice, includeUnavailable: true },
+    );
+    expect(view).toHaveLength(1);
+    const copy = view[0];
+    expect(copy.puzzle?.title).toBe("Mountain Vista");
+    // Owner-only fields are stripped.
+    expect(copy.notes).toBeUndefined();
+    expect(copy.salePrice).toBeUndefined();
+    expect(copy.acquisitionPrice).toBeUndefined();
+    expect(copy.acquisitionSource).toBeUndefined();
+    // Adversarial: the secret notes value never appears anywhere in the payload.
+    expect(JSON.stringify(view)).not.toContain("my secret notes");
+
+    // The OWNER, by contrast, sees everything including the private copy and the owner-only fields.
+    const ownerView = await asAlice(t).query(
+      api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
+      { ownerId: alice, includeUnavailable: true },
+    );
+    expect(ownerView).toHaveLength(2);
+    const ownerCopy = ownerView.find((c) => c._id === (available as string));
+    expect(ownerCopy?.notes).toBe("my secret notes");
+    expect(ownerCopy?.salePrice).toEqual({ amount: 1000, currency: "EUR" });
   });
 
   test("browseOwnedPuzzles is auth-gated and returns a typed paginated view with owner", async () => {

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -198,7 +198,7 @@ describe("collection reads", () => {
     const t = convexTest(schema, modules);
     const { collection } = await seed(t);
 
-    const view = await t.query(
+    const view = await asAlice(t).query(
       api.library.getCollectionById.getCollectionById,
       { collectionId: collection },
     );

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -163,6 +163,7 @@ describe("library reads", () => {
         salePrice: { amount: 1000, currency: "EUR" },
         acquisitionPrice: { amount: 500, currency: "EUR" },
         acquisitionSource: "bought_new",
+        acquisitionDate: 1_700_000_000_000,
       });
       await ctx.db.patch(unavailable, { visibility: "private" });
       // A fresh non-owner viewer.
@@ -192,6 +193,8 @@ describe("library reads", () => {
     expect(copy.notes).toBeUndefined();
     expect(copy.acquisitionPrice).toBeUndefined();
     expect(copy.acquisitionSource).toBeUndefined();
+    // acquisitionDate is owner-only too — a non-owner must never learn when the copy was acquired.
+    expect(copy.acquisitionDate).toBeUndefined();
     // salePrice is the public asking price for a copy listed for sale — it stays visible.
     expect(copy.salePrice).toEqual({ amount: 1000, currency: "EUR" });
     // Adversarial: the secret notes value never appears anywhere in the payload.
@@ -206,6 +209,7 @@ describe("library reads", () => {
     const ownerCopy = ownerView.find((c) => c._id === (available as string));
     expect(ownerCopy?.notes).toBe("my secret notes");
     expect(ownerCopy?.salePrice).toEqual({ amount: 1000, currency: "EUR" });
+    expect(ownerCopy?.acquisitionDate).toBe(1_700_000_000_000);
   });
 
   test("getOwnedPuzzlesByOwner hides a PRIVATE-profile owner's available copies from a non-owner", async () => {

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -75,6 +75,17 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       createdAt: now,
       updatedAt: now,
     });
+    // A SECOND collection for Alice so the by_user lookup is genuinely non-unique — guards against a
+    // regression to `.unique()` on `by_user`, which would throw for any member with >=2 collections.
+    await ctx.db.insert("collections", {
+      aggregateId: "coll-a2",
+      userId: alice,
+      name: "Wishlist",
+      visibility: "public",
+      isDefault: false,
+      createdAt: now,
+      updatedAt: now,
+    });
     await ctx.db.insert("collectionMembers", {
       collectionId: collection,
       ownedPuzzleId: available,
@@ -170,8 +181,27 @@ describe("library reads", () => {
     // Consumers read images[0].fileId directly.
     expect(view?.images[0].fileId).toBeDefined();
     expect(view?.owner?.name).toBe("Alice");
+    // The copy IS a member of Alice's "Favourites" collection -> in-collection with its visibility.
     expect(view?.collectionStatus.isInCollection).toBe(true);
+    if (view?.collectionStatus.isInCollection) {
+      expect(view.collectionStatus.visibility).toBe("private");
+    }
     expect(view?.completionHistory).toHaveLength(1);
+  });
+
+  test("getOwnedPuzzleWithCollectionStatus reports not-in-collection for an uncollected copy", async () => {
+    const t = convexTest(schema, modules);
+    const { unavailable } = await seed(t);
+
+    // `unavailable` (copy-b) is in NONE of Alice's collections; despite Alice owning >=2 collections
+    // (which would break a `.unique()` on by_user), status must be exactly { isInCollection: false }.
+    const view = await asAlice(t).query(
+      api.library.getOwnedPuzzleWithCollectionStatus
+        .getOwnedPuzzleWithCollectionStatus,
+      { ownedPuzzleId: unavailable },
+    );
+    expect(view).not.toBeNull();
+    expect(view?.collectionStatus.isInCollection).toBe(false);
   });
 });
 
@@ -188,10 +218,13 @@ describe("collection reads", () => {
       api.library.getUserCollections.getUserCollections,
       { userId: alice },
     );
-    expect(collections).toHaveLength(1);
+    expect(collections).toHaveLength(2);
+    // Default ("Favourites") sorts first; the second collection ("Wishlist") follows.
     expect(collections[0].name).toBe("Favourites");
     expect(collections[0].puzzleCount).toBe(1);
     expect(collections[0].isDefault).toBe(true);
+    expect(collections[1].name).toBe("Wishlist");
+    expect(collections[1].isDefault).toBe(false);
   });
 
   test("getCollectionById resolves member copies with addedAt", async () => {

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -208,6 +208,49 @@ describe("library reads", () => {
     expect(ownerCopy?.salePrice).toEqual({ amount: 1000, currency: "EUR" });
   });
 
+  test("getOwnedPuzzlesByOwner hides a PRIVATE-profile owner's available copies from a non-owner", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, available } = await seed(t);
+
+    // Alice's copy is AVAILABLE and copy-level visible, but her PROFILE is private. The canViewCopy
+    // reachability gate must keep this off-limits to a non-owner, matching Browse/getCopyInstanceView
+    // (the previous ad-hoc filter only checked the per-copy axes and would have leaked it).
+    await t.run(async (ctx) => {
+      await ctx.db.patch(available, { visibility: "visible" });
+      await ctx.db.insert("profiles", {
+        memberId: alice,
+        displayName: "Alice",
+        visibility: "private",
+        updatedAt: Date.now(),
+      });
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    // Non-owner Bob sees NONE of Alice's copies — her private profile makes them unreachable.
+    const asBob = t.withIdentity({ subject: "clerk_bob" });
+    const bobView = await asBob.query(
+      api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
+      { ownerId: alice, includeUnavailable: true },
+    );
+    expect(bobView).toHaveLength(0);
+
+    // Alice herself still sees her own copies (owner short-circuit).
+    const ownerView = await asAlice(t).query(
+      api.library.getOwnedPuzzlesByOwner.getOwnedPuzzlesByOwner,
+      { ownerId: alice, includeUnavailable: true },
+    );
+    expect(ownerView.map((c) => c._id)).toContain(available as string);
+  });
+
   test("browseOwnedPuzzles is auth-gated and returns a typed paginated view with owner", async () => {
     const t = convexTest(schema, modules);
     await seed(t);

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -227,6 +227,41 @@ describe("collection reads", () => {
     expect(collections[1].isDefault).toBe(false);
   });
 
+  test("getUserCollections hides another member's private collections", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    // A second member who only follows Alice — querying Alice's collections must surface ONLY her
+    // public "Wishlist", never her private "Favourites" (names/notes must not leak).
+    const bobClerk = "clerk_bob";
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("users", {
+        clerkId: bobClerk,
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const asBob = t.withIdentity({ subject: bobClerk });
+    const seenByBob = await asBob.query(
+      api.library.getUserCollections.getUserCollections,
+      { userId: alice },
+    );
+    expect(seenByBob.map((c) => c.name)).toEqual(["Wishlist"]);
+
+    // The owner still sees ALL of their own collections, private included.
+    const seenByAlice = await asAlice(t).query(
+      api.library.getUserCollections.getUserCollections,
+      { userId: alice },
+    );
+    expect(seenByAlice.map((c) => c.name)).toEqual(["Favourites", "Wishlist"]);
+  });
+
   test("getCollectionById resolves member copies with addedAt", async () => {
     const t = convexTest(schema, modules);
     const { collection } = await seed(t);

--- a/packages/backend/convex/libraryReads.test.ts
+++ b/packages/backend/convex/libraryReads.test.ts
@@ -606,6 +606,70 @@ describe("collection reads", () => {
     });
   });
 
+  test("getCollectionById hides an unreachable member copy from a non-owner but shows it to the owner", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, available, unavailable } = await seed(t);
+
+    // A PUBLIC collection holding BOTH copies: `available` is OPEN (forTrade) and reachable; the
+    // `unavailable` copy is CLOSED (no availability flags), so a non-owner must not see it even
+    // though the collection itself is public — mirroring THE canonical copy-reachability gate.
+    const publicCollection = await t.run(async (ctx) => {
+      const now = Date.now();
+      const coll = await ctx.db.insert("collections", {
+        aggregateId: "coll-mixed",
+        userId: alice,
+        name: "Mixed Showcase",
+        visibility: "public",
+        isDefault: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("collectionMembers", {
+        collectionId: coll,
+        ownedPuzzleId: available,
+        addedAt: now,
+      });
+      await ctx.db.insert("collectionMembers", {
+        collectionId: coll,
+        ownedPuzzleId: unavailable,
+        addedAt: now,
+      });
+      await ctx.db.insert("users", {
+        clerkId: "clerk_bob",
+        email: "bob@example.com",
+        name: "Bob",
+        username: "bob",
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return coll;
+    });
+
+    // Non-owner: only the reachable (open) copy comes back; the closed copy is dropped entirely so
+    // its condition/availability/snapshot/ownerId never leak.
+    const seenByBob = await t
+      .withIdentity({ subject: "clerk_bob" })
+      .query(api.library.getCollectionById.getCollectionById, {
+        collectionId: publicCollection,
+      });
+    expect(seenByBob).not.toBeNull();
+    expect(seenByBob?.puzzles).toHaveLength(1);
+    expect(seenByBob?.puzzles[0].puzzle?.title).toBe("Mountain Vista");
+    expect(JSON.stringify(seenByBob)).not.toContain("Ocean Calm");
+
+    // Owner: sees BOTH copies, including the closed one.
+    const seenByAlice = await asAlice(t).query(
+      api.library.getCollectionById.getCollectionById,
+      { collectionId: publicCollection },
+    );
+    expect(seenByAlice?.puzzles).toHaveLength(2);
+    expect(seenByAlice?.puzzles.map((p) => p.puzzle?.title).sort()).toEqual([
+      "Mountain Vista",
+      "Ocean Calm",
+    ]);
+  });
+
   test("getCollectionsForOwnedPuzzle returns the member's collections containing the copy", async () => {
     const t = convexTest(schema, modules);
     const { available, collection } = await seed(t);

--- a/packages/backend/convex/loanFlow.test.ts
+++ b/packages/backend/convex/loanFlow.test.ts
@@ -1,4 +1,5 @@
 import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
@@ -122,12 +123,28 @@ describe("loan lifecycle", () => {
         {},
       ),
     ).toHaveLength(0);
+    // The history read is auth-gated.
+    await expect(
+      t.query(api.library.getCopyLoanHistory.getCopyLoanHistory, {
+        copyId: copy,
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+
     const history = await asOwner(t).query(
       api.library.getCopyLoanHistory.getCopyLoanHistory,
       { copyId: copy },
     );
     expect(history).toHaveLength(1);
     expect(history[0].status).toBe("returned");
+    // Both parties are privacy-projected; here both have public (default) profiles so they reveal.
+    expect(history[0].lender.anonymous).toBe(false);
+    if (!history[0].lender.anonymous) {
+      expect(history[0].lender.member.name).toBe("clerk_owner");
+    }
+    expect(history[0].borrower.anonymous).toBe(false);
+    if (!history[0].borrower.anonymous) {
+      expect(history[0].borrower.member.name).toBe("clerk_alice");
+    }
   });
 
   test("the owner recalls the loan -> possession back to the owner", async () => {

--- a/packages/backend/convex/loanFlow.test.ts
+++ b/packages/backend/convex/loanFlow.test.ts
@@ -147,6 +147,48 @@ describe("loan lifecycle", () => {
     }
   });
 
+  test("getCopyLoanHistory returns [] for a non-owner when the copy is unreachable", async () => {
+    const t = convexTest(schema, modules);
+    const { copy, owner } = await seed(t);
+    await settleLend(t, copy, owner);
+    await flush(t);
+
+    // Make the owner private and the copy closed -> a non-owner stranger cannot reach it.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        clerkId: "clerk_stranger",
+        email: "stranger@example.com",
+        name: "clerk_stranger",
+        isActive: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("profiles", {
+        memberId: owner,
+        displayName: "clerk_owner",
+        visibility: "private",
+        updatedAt: Date.now(),
+      });
+      await ctx.db.patch(copy, {
+        availability: { forTrade: false, forSale: false, forLend: false },
+      });
+    });
+
+    const history = await t
+      .withIdentity({ subject: "clerk_stranger" })
+      .query(api.library.getCopyLoanHistory.getCopyLoanHistory, {
+        copyId: copy,
+      });
+    expect(history).toEqual([]);
+
+    // The owner still sees the full history.
+    const ownerHistory = await asOwner(t).query(
+      api.library.getCopyLoanHistory.getCopyLoanHistory,
+      { copyId: copy },
+    );
+    expect(ownerHistory).toHaveLength(1);
+  });
+
   test("the owner recalls the loan -> possession back to the owner", async () => {
     const t = convexTest(schema, modules);
     const { copy, owner } = await seed(t);

--- a/packages/backend/convex/ogieStorePageFetcher.test.ts
+++ b/packages/backend/convex/ogieStorePageFetcher.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { ogieStorePageFetcher } from "./catalog/adapters/ogieStorePageFetcher";
+
+// SSRF regression: the ogie primary tier pins allowPrivateUrls:false, so ogie's own per-hop
+// validation rejects a LITERAL private/loopback/link-local URL up front — including a redirect
+// target — WITHOUT performing any network egress (the lexical check throws before fetch). These
+// cover the entry-URL leg directly; the same validateUrl runs on every redirect hop inside ogie
+// (getRedirectUrl -> validateUrl), which is the redirect-hop SSRF this fix closes for this tier.
+//
+// We cannot exercise an actual redirect without a network/mocked HTTP server, so we assert the
+// load-bearing behaviour: a private-IP target is rejected (mapped to a StorePageFetchError), never
+// fetched. The DNS-validating browserStorePageFetcher remains the fallback for the DNS-rebinding
+// case (a public hostname that resolves to a private IP), which ogie's lexical check does not cover.
+describe("ogieStorePageFetcher SSRF guard", () => {
+  const blockedTargets = [
+    "http://169.254.169.254/latest/meta-data/", // cloud metadata
+    "http://127.0.0.1/", // loopback
+    "http://[::1]/", // IPv6 loopback
+    "http://10.0.0.1/", // RFC1918 private
+    "http://192.168.1.1/", // RFC1918 private
+  ];
+
+  for (const url of blockedTargets) {
+    test(`rejects a private/internal target without fetching: ${url}`, async () => {
+      const result = await ogieStorePageFetcher.fetch(url);
+      expect(result.isOk).toBe(false);
+      expect(result.isErr).toBe(true);
+      if (result.isErr) {
+        // It must be the SSRF rejection (mapped from ogie's INVALID_URL "private/internal network
+        // address"), NOT a network timeout/failure — proving the address was never dialled. This
+        // assertion fails if allowPrivateUrls is ever flipped to true.
+        expect(result.error.code).toBe("InvalidUrl");
+        expect(result.error.detail ?? "").toContain("private/internal network");
+      }
+    });
+  }
+});

--- a/packages/backend/convex/ogieStorePageFetcher.test.ts
+++ b/packages/backend/convex/ogieStorePageFetcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { ogieStorePageFetcher } from "./catalog/adapters/ogieStorePageFetcher";
 
 // SSRF regression: the ogie primary tier pins allowPrivateUrls:false, so ogie's own per-hop
@@ -34,4 +34,49 @@ describe("ogieStorePageFetcher SSRF guard", () => {
       }
     });
   }
+});
+
+// SSRF: the ogie primary tier must NOT follow redirects (maxRedirects:1). A redirecting store URL
+// has to surface as a (retryable) failure so the import falls through to the DNS-validating
+// browserStorePageFetcher, which is the only tier allowed to follow — and re-validate — redirect
+// hops. We stub global fetch with a 301 from a PUBLIC-looking host (so ogie's lexical entry-URL
+// check passes and it actually performs the fetch) and assert ogie reports a failure rather than
+// chasing the Location header.
+describe("ogieStorePageFetcher does not follow redirects", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("a 3xx response surfaces as a retryable failure, not a followed hop", async () => {
+    const redirected = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const target = typeof input === "string" ? input : input.toString();
+        // The entry URL is answered with a redirect; anything else means ogie followed the hop.
+        if (target === "https://store.example.com/product/123") {
+          return new Response(null, {
+            status: 301,
+            headers: { location: "https://store.example.com/moved" },
+          });
+        }
+        redirected();
+        return new Response("<html><head><title>Moved</title></head></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      },
+    );
+
+    const result = await ogieStorePageFetcher.fetch(
+      "https://store.example.com/product/123",
+    );
+
+    // ogie must not have dialled the redirect target.
+    expect(redirected).not.toHaveBeenCalled();
+    expect(result.isErr).toBe(true);
+    if (result.isErr) {
+      // REDIRECT_LIMIT maps to a retryable FetchFailed, which triggers the fallback chain.
+      expect(result.error.code).toBe("FetchFailed");
+    }
+  });
 });

--- a/packages/backend/convex/photoComments.test.ts
+++ b/packages/backend/convex/photoComments.test.ts
@@ -35,11 +35,13 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       updatedAt: now,
     });
 
+    // Alice's copy is OPEN (forTrade) and her profile is PUBLIC, so the copy is reachable by any
+    // member via canViewCopy — the reachability gate on photo comments lets Bob comment/read.
     const copy = await ctx.db.insert("ownedPuzzles", {
       puzzleId,
       ownerId: alice,
       condition: "good",
-      availability: { forTrade: false, forSale: false, forLend: false },
+      availability: { forTrade: true, forSale: false, forLend: false },
       createdAt: now,
       updatedAt: now,
     });
@@ -56,7 +58,7 @@ const seed = async (t: ReturnType<typeof convexTest>) =>
       updatedAt: now,
     });
 
-    return { alice, bob, photoId };
+    return { alice, bob, copy, photoId };
   });
 
 const asAlice = (t: ReturnType<typeof convexTest>) =>
@@ -201,5 +203,107 @@ describe("postPhotoComment / listPhotoComments", () => {
         text: "anon",
       }),
     ).rejects.toThrow(ConvexError);
+  });
+
+  test("listPhotoComments requires auth even with a photoId", async () => {
+    const t = convexTest(schema, modules);
+    const { photoId } = await seed(t);
+
+    await expect(
+      t.query(api.library.listPhotoComments.listPhotoComments, { photoId }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("photo comment reachability gating", () => {
+  // Seed a CLOSED copy (no availability flags) on a PUBLIC owner: unreachable by a non-owner because
+  // canViewCopy requires the copy to be open for a public-profile reveal.
+  const seedClosed = (t: ReturnType<typeof convexTest>) =>
+    t.run(async (ctx) => {
+      const now = Date.now();
+      const mkUser = (clerkId: string, email: string, name: string) =>
+        ctx.db.insert("users", {
+          clerkId,
+          email,
+          name,
+          isActive: true,
+          createdAt: now,
+          updatedAt: now,
+        });
+      const alice = await mkUser("clerk_alice", "alice@example.com", "Alice");
+      const bob = await mkUser("clerk_bob", "bob@example.com", "Bob");
+
+      const puzzleId = await ctx.db.insert("puzzles", {
+        aggregateId: crypto.randomUUID(),
+        title: "Closed Vista",
+        pieceCount: 500,
+        status: "approved",
+        submittedBy: alice,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const copy = await ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: alice,
+        condition: "good",
+        availability: { forTrade: false, forSale: false, forLend: false },
+        createdAt: now,
+        updatedAt: now,
+      });
+      const blob = new Blob(["fake-image-bytes"], { type: "image/png" });
+      const fileId = await ctx.storage.store(blob);
+      const photoId = await ctx.db.insert("ownedPuzzleImages", {
+        ownedPuzzleId: copy,
+        uploaderId: alice,
+        fileId,
+        title: "Box front",
+        tag: "box_front",
+        createdAt: now,
+        updatedAt: now,
+      });
+      return { alice, bob, photoId };
+    });
+
+  test("a viewer who cannot see the copy gets [] from listPhotoComments", async () => {
+    const t = convexTest(schema, modules);
+    const { photoId } = await seedClosed(t);
+
+    // The owner posts a comment on her own (closed) copy's photo.
+    await asAlice(t).mutation(api.library.postPhotoComment.postPhotoComment, {
+      photoId,
+      text: "owner note",
+    });
+
+    // The owner still sees it...
+    expect(
+      await asAlice(t).query(api.library.listPhotoComments.listPhotoComments, {
+        photoId,
+      }),
+    ).toHaveLength(1);
+
+    // ...but Bob cannot reach the closed copy, so the discussion is hidden.
+    expect(
+      await asBob(t).query(api.library.listPhotoComments.listPhotoComments, {
+        photoId,
+      }),
+    ).toEqual([]);
+  });
+
+  test("posting on a photo of an unreachable copy is rejected", async () => {
+    const t = convexTest(schema, modules);
+    const { photoId } = await seedClosed(t);
+
+    await expect(
+      asBob(t).mutation(api.library.postPhotoComment.postPhotoComment, {
+        photoId,
+        text: "from bob",
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    // Nothing persisted.
+    const stored = await t.run((ctx) =>
+      ctx.db.query("photoComments").collect(),
+    );
+    expect(stored).toHaveLength(0);
   });
 });

--- a/packages/backend/convex/postPuzzleComment.test.ts
+++ b/packages/backend/convex/postPuzzleComment.test.ts
@@ -238,4 +238,64 @@ describe("postPuzzleComment / listPuzzleComments", () => {
       }),
     ).rejects.toThrow(ConvexError);
   });
+
+  test("listPuzzleComments is auth-gated", async () => {
+    const t = convexTest(schema, modules);
+    const { aliceCopy } = await seed(t);
+
+    await expect(
+      t.query(api.social.listPuzzleComments.listPuzzleComments, {
+        copyId: aliceCopy,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("listPuzzleComments hides comments on an unreachable copy from a non-owner", async () => {
+    const t = convexTest(schema, modules);
+    const { aliceCopy } = await seed(t);
+
+    // Alice's copy is CLOSED (not open) and her profile defaults to public — so it is unreachable
+    // for Bob, who would otherwise see her private per-copy notes/rating.
+    await asAlice(t).mutation(api.social.postPuzzleComment.postPuzzleComment, {
+      copyId: aliceCopy,
+      text: "my private take",
+      rating: 5,
+    });
+
+    const seenByBob = await asBob(t).query(
+      api.social.listPuzzleComments.listPuzzleComments,
+      { copyId: aliceCopy },
+    );
+    expect(seenByBob).toEqual([]);
+
+    // The owner still sees their own comments.
+    const seenByAlice = await asAlice(t).query(
+      api.social.listPuzzleComments.listPuzzleComments,
+      { copyId: aliceCopy },
+    );
+    expect(seenByAlice.map((c) => c.text)).toEqual(["my private take"]);
+  });
+
+  test("listPuzzleComments returns comments on a reachable copy to a non-owner", async () => {
+    const t = convexTest(schema, modules);
+    const { aliceCopy } = await seed(t);
+
+    // Make Alice's copy OPEN; her profile defaults to public, so it is reachable for Bob.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(aliceCopy, {
+        availability: { forTrade: true, forSale: false, forLend: false },
+      });
+    });
+    await asAlice(t).mutation(api.social.postPuzzleComment.postPuzzleComment, {
+      copyId: aliceCopy,
+      text: "publicly reachable",
+      rating: 4,
+    });
+
+    const seenByBob = await asBob(t).query(
+      api.social.listPuzzleComments.listPuzzleComments,
+      { copyId: aliceCopy },
+    );
+    expect(seenByBob.map((c) => c.text)).toEqual(["publicly reachable"]);
+  });
 });

--- a/packages/backend/convex/postPuzzleComment.test.ts
+++ b/packages/backend/convex/postPuzzleComment.test.ts
@@ -208,6 +208,25 @@ describe("postPuzzleComment / listPuzzleComments", () => {
     ).rejects.toThrow(ConvexError);
   });
 
+  test("a non-owner posting on someone else's copy is rejected", async () => {
+    const t = convexTest(schema, modules);
+    const { aliceCopy } = await seed(t);
+
+    // Bob is authenticated but does NOT own aliceCopy.
+    await expect(
+      asBob(t).mutation(api.social.postPuzzleComment.postPuzzleComment, {
+        copyId: aliceCopy,
+        text: "not my copy",
+        rating: 5,
+      }),
+    ).rejects.toThrow(ConvexError);
+
+    const stored = await t.run((ctx) =>
+      ctx.db.query("puzzleComments").collect(),
+    );
+    expect(stored).toHaveLength(0);
+  });
+
   test("auth is required to post a comment", async () => {
     const t = convexTest(schema, modules);
     const { aliceCopy } = await seed(t);

--- a/packages/backend/convex/postPuzzleReview.test.ts
+++ b/packages/backend/convex/postPuzzleReview.test.ts
@@ -146,4 +146,22 @@ describe("postPuzzleReview / listPuzzleReviews", () => {
       }),
     ).rejects.toThrow(ConvexError);
   });
+
+  // SECURITY: listPuzzleReviews projects each author through `toMemberView`, exposing member
+  // identity (name/username/bio/location) meant only for OTHER AUTHENTICATED MEMBERS. An
+  // unauthenticated caller must be rejected so that PII never leaks to anonymous clients.
+  test("auth is required to list reviews (no anonymous PII exposure)", async () => {
+    const t = convexTest(schema, modules);
+    const { puzzleId } = await seed(t);
+
+    await asAlice(t).mutation(api.social.postPuzzleReview.postPuzzleReview, {
+      puzzleId,
+      text: "Stunning artwork",
+      rating: 5,
+    });
+
+    await expect(
+      t.query(api.social.listPuzzleReviews.listPuzzleReviews, { puzzleId }),
+    ).rejects.toThrow(ConvexError);
+  });
 });

--- a/packages/backend/convex/puzzles.ts
+++ b/packages/backend/convex/puzzles.ts
@@ -1,10 +1,15 @@
 import { mutation } from "./_generated/server";
+import { requireMember } from "./identity/requireMember";
 
 // Storage infrastructure, not a domain read/write. Kept here (out of scope of the read-model
 // cutover) so the upload flow that backs copy/box-art photos is unchanged.
 export const generateUploadUrl = mutation({
   args: {},
   handler: async (ctx) => {
+    // Gate behind authentication: an ungated public mutation lets anyone with the deployment URL
+    // mint presigned upload URLs and write arbitrary blobs (cost/quota abuse), like every other
+    // write and the sibling catalog/importPuzzleImage guard.
+    await requireMember(ctx);
     const url = await ctx.storage.generateUploadUrl();
     return url;
   },

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -15,12 +15,19 @@ export default defineSchema({
     // Absent or false means the user's avatar image must never appear on public
     // marketing surfaces — initials only. Opt-in; defaults to NOT consented.
     shareAvatarPublicly: v.optional(v.boolean()),
+    // Lowercased "<name> <username>" maintained on every user write, backing the
+    // people search index so member search is a real index lookup rather than a
+    // full-table scan + in-memory filter. Optional so legacy rows still validate.
+    searchableName: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
     .index("by_clerk_id", ["clerkId"])
     .index("by_email", ["email"])
-    .index("by_username", ["username"]),
+    .index("by_username", ["username"])
+    .searchIndex("by_searchable_name", {
+      searchField: "searchableName",
+    }),
 
   // Puzzles  - the actual puzzle designs that exist in the world
   puzzles: defineTable({
@@ -680,6 +687,7 @@ export default defineSchema({
   })
     .index("by_follower", ["followerId"])
     .index("by_followee", ["followeeId"])
+    .index("by_follower_followee", ["followerId", "followeeId"])
     .index("by_aggregate_id", ["aggregateId"]),
 
   // The durable domain-event log: every context's events are appended here, then an async

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -442,7 +442,11 @@ export default defineSchema({
   })
     .index("by_initiator", ["initiatorId", "offeredPuzzleId"])
     .index("by_recipient", ["recipientId", "offeredPuzzleId"])
-    .index("by_aggregate_id", ["aggregateId"]),
+    .index("by_aggregate_id", ["aggregateId"])
+    // Back the copy-reservation check: find exchanges referencing a copy as requested/offered
+    // without scanning the whole table.
+    .index("by_requested_copy", ["requestedPuzzleId"])
+    .index("by_offered_copy", ["offeredPuzzleId"]),
 
   messages: defineTable({
     exchangeId: v.id("exchanges"),
@@ -688,7 +692,11 @@ export default defineSchema({
     occurredAt: v.number(),
     context: v.string(),
     processedAt: v.optional(v.number()),
-  }).index("by_processed", ["processedAt"]),
+  })
+    .index("by_processed", ["processedAt"])
+    // Backs the activity feed: pull recent events of a given name in a bounded time window without
+    // a full-table scan-and-filter.
+    .index("by_name", ["name", "occurredAt"]),
 
   // Chain-of-Custody projection: one row per OwnershipTransferred event, folded by the custody
   // subscriber off the durable event log. WHY a dedicated table: domainEvents.payload is v.any()

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -695,7 +695,7 @@ export default defineSchema({
   // with no per-copy index, so transfer history is not queryable by copyId; this read-model makes
   // a Copy's provenance a single indexed scan. Pure projection — keyed by copyId, no aggregateId.
   copyCustodyEntries: defineTable({
-    copyId: v.string(), // the transferred Copy (an ownedPuzzles _id, the domain CopyId)
+    copyId: v.string(), // the transferred Copy's `ownedPuzzles._id` (NOT the aggregateId) — the timeline query indexes by this
     exchangeId: v.string(), // the settling Exchange aggregateId
     previousOwner: v.string(), // the member the Copy moved FROM (a users _id)
     newOwner: v.string(), // the member the Copy moved to (a users _id)

--- a/packages/backend/convex/search/globalSearch.ts
+++ b/packages/backend/convex/search/globalSearch.ts
@@ -2,23 +2,26 @@ import type { GlobalSearchResults } from "@jigswap/contracts";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { areMutualFollowers, profileVisibilityOf } from "../social/privacy";
 
 // Global search: the single read behind the ⌘K command palette. Given a term it returns a small
 // grouped result set across Puzzles, People, Circles and the signed-in member's Collections.
 //
 // Indexing strategy (documented intentionally):
 //   - Puzzles      -> the existing `by_searchable_text` search index (approved-only). REAL index.
-//   - People       -> NO name search index exists; we scan a BOUNDED set of active users
-//                     (PEOPLE_SCAN_LIMIT) and filter in-memory by lowercased substring. This is a
-//                     best-effort match, not exhaustive — see TODO in the report.
+//   - People       -> the `by_searchable_name` search index over users.searchableName. REAL index.
+//                     Results are then routed through the profile-visibility chokepoint so a member
+//                     with a private profile is never surfaced by name/username/avatar to a searcher
+//                     who is neither them nor a mutual follower (consistent with getProfile and the
+//                     custody-timeline projectMemberIdentity chokepoint).
 //   - Circles      -> the signed-in member's circles only (small set), in-memory name filter.
 //   - Collections  -> the signed-in member's collections only (small set), in-memory name filter.
 //
 // Short/empty terms short-circuit to empty groups. Unauthenticated callers get empty groups too.
 
-// How many active users to scan for the in-memory name match. Kept small on purpose; a proper
-// `users` name search index would remove this bound (TODO).
-const PEOPLE_SCAN_LIMIT = 50;
+// We over-fetch people candidates from the search index (since some get dropped by the visibility
+// gate) and stop once `limit` visible matches are collected.
+const PEOPLE_CANDIDATE_LIMIT = 50;
 
 const EMPTY: GlobalSearchResults = {
   puzzles: [],
@@ -62,25 +65,32 @@ export const global = query({
       })),
     );
 
-    // --- People: bounded scan + in-memory substring filter (no name index). ---
-    const scanned = await ctx.db
+    // --- People: real search index + profile-visibility gate. ---
+    const candidates = await ctx.db
       .query("users")
-      .withIndex("by_clerk_id")
-      .take(PEOPLE_SCAN_LIMIT);
-    const people = scanned
-      .filter(
-        (u) =>
-          u._id !== memberId &&
-          (u.name.toLowerCase().includes(term) ||
-            (u.username?.toLowerCase().includes(term) ?? false)),
+      .withSearchIndex("by_searchable_name", (q) =>
+        q.search("searchableName", term),
       )
-      .slice(0, limit)
-      .map((u) => ({
+      .take(PEOPLE_CANDIDATE_LIMIT);
+    const people: GlobalSearchResults["people"] = [];
+    for (const u of candidates) {
+      if (people.length >= limit) break;
+      if (u._id === memberId) continue;
+      // Privacy chokepoint: only surface a member if their profile is public, or
+      // they are a mutual follower of the searcher. Mirrors getProfile and the
+      // custody-timeline projectMemberIdentity rules so a private member is not
+      // identifiable by name/username/avatar via ⌘K.
+      const visible =
+        (await profileVisibilityOf(ctx, u._id)) === "public" ||
+        (await areMutualFollowers(ctx, memberId, u._id));
+      if (!visible) continue;
+      people.push({
         id: u._id,
         name: u.name,
         image: u.avatar ?? null,
         href: "/people",
-      }));
+      });
+    }
 
     // --- Circles: the member's own circles, in-memory name filter. ---
     const circleLinks = await ctx.db

--- a/packages/backend/convex/sendExchangeMessage.test.ts
+++ b/packages/backend/convex/sendExchangeMessage.test.ts
@@ -1,0 +1,102 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    const mkUser = (clerkId: string) =>
+      ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name: clerkId,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    const alice = await mkUser("clerk_alice");
+    const bob = await mkUser("clerk_bob");
+    const puzzleId = await ctx.db.insert("puzzles", {
+      title: "Test Puzzle",
+      pieceCount: 1000,
+      status: "approved",
+      submittedBy: bob,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const copyId = await ctx.db.insert("ownedPuzzles", {
+      puzzleId,
+      ownerId: bob,
+      condition: "good",
+      availability: { forTrade: true, forSale: false, forLend: false },
+      createdAt: now,
+      updatedAt: now,
+    });
+    const exchangeId = await ctx.db.insert("exchanges", {
+      initiatorId: alice,
+      recipientId: bob,
+      type: "trade",
+      requestedPuzzleId: copyId,
+      status: "proposed",
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { alice, bob, exchangeId };
+  });
+
+const asAlice = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+
+describe("exchanges.sendExchangeMessage messageType", () => {
+  test("defaults to text and accepts an explicit text/image type", async () => {
+    const t = convexTest(schema, modules);
+    const { exchangeId } = await seed(t);
+
+    await asAlice(t).mutation(api.exchanges.sendExchangeMessage, {
+      exchangeId,
+      content: "hello",
+    });
+    await asAlice(t).mutation(api.exchanges.sendExchangeMessage, {
+      exchangeId,
+      content: "pic",
+      messageType: "image",
+    });
+
+    const messages = await t.run(async (ctx) =>
+      ctx.db
+        .query("messages")
+        .withIndex("by_exchange", (q) => q.eq("exchangeId", exchangeId))
+        .collect(),
+    );
+    expect(messages.map((m) => m.messageType).sort()).toEqual([
+      "image",
+      "text",
+    ]);
+  });
+
+  test("rejects a client-supplied 'system' messageType (validator)", async () => {
+    const t = convexTest(schema, modules);
+    const { exchangeId } = await seed(t);
+
+    await expect(
+      asAlice(t).mutation(api.exchanges.sendExchangeMessage, {
+        exchangeId,
+        content: "System: payment received, please ship",
+        // 'system' is no longer part of the accepted union; the arg validator rejects it.
+        messageType: "system" as unknown as "text",
+      }),
+    ).rejects.toThrow();
+
+    const systemMessages = await t.run(async (ctx) =>
+      ctx.db
+        .query("messages")
+        .withIndex("by_exchange", (q) => q.eq("exchangeId", exchangeId))
+        .filter((q) => q.eq(q.field("messageType"), "system"))
+        .collect(),
+    );
+    expect(systemMessages).toHaveLength(0);
+  });
+});

--- a/packages/backend/convex/setProfileVisibility.test.ts
+++ b/packages/backend/convex/setProfileVisibility.test.ts
@@ -10,19 +10,24 @@ const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
 const seed = (t: ReturnType<typeof convexTest>) =>
   t.run(async (ctx) => {
     const now = Date.now();
-    const alice = await ctx.db.insert("users", {
-      clerkId: "clerk_alice",
-      email: "alice@example.com",
-      name: "Alice",
-      isActive: true,
-      createdAt: now,
-      updatedAt: now,
-    });
-    return { alice };
+    const mkUser = (clerkId: string, email: string, name: string) =>
+      ctx.db.insert("users", {
+        clerkId,
+        email,
+        name,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    const alice = await mkUser("clerk_alice", "alice@example.com", "Alice");
+    const bob = await mkUser("clerk_bob", "bob@example.com", "Bob");
+    return { alice, bob };
   });
 
 const asAlice = (t: ReturnType<typeof convexTest>) =>
   t.withIdentity({ subject: "clerk_alice" });
+const asBob = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_bob" });
 
 describe("setProfileVisibility", () => {
   test("a freshly created profile defaults to public", async () => {
@@ -104,5 +109,89 @@ describe("setProfileVisibility", () => {
         visibility: "private",
       }),
     ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("getProfile visibility", () => {
+  test("getProfile requires authentication even when a memberId is supplied", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice A.",
+    });
+
+    // Passing memberId must NOT bypass requireMember: an unauthenticated caller is rejected.
+    await expect(
+      t.query(api.social.getProfile.getProfile, { memberId: alice }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("a public profile is visible to a non-connected viewer", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice A.",
+    });
+
+    const seenByBob = await asBob(t).query(api.social.getProfile.getProfile, {
+      memberId: alice,
+    });
+    expect(seenByBob?.displayName).toBe("Alice A.");
+    expect(seenByBob?.visibility).toBe("public");
+  });
+
+  test("a private profile is hidden from a non-connected viewer but visible to its owner", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice A.",
+    });
+    await asAlice(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    // Non-connected Bob gets null for Alice's private profile.
+    const seenByBob = await asBob(t).query(api.social.getProfile.getProfile, {
+      memberId: alice,
+    });
+    expect(seenByBob).toBeNull();
+
+    // The owner still sees their own private profile.
+    const seenBySelf = await asAlice(t).query(
+      api.social.getProfile.getProfile,
+      { memberId: alice },
+    );
+    expect(seenBySelf?.visibility).toBe("private");
+  });
+
+  test("mutual followers can see each other's private profiles", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    await asAlice(t).mutation(api.social.editProfile.editProfile, {
+      displayName: "Alice A.",
+    });
+    await asAlice(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    // Establish the mutual follow edge (both directions).
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+    await asBob(t).mutation(api.social.followMember.followMember, {
+      followeeId: alice,
+    });
+
+    const seenByBob = await asBob(t).query(api.social.getProfile.getProfile, {
+      memberId: alice,
+    });
+    expect(seenByBob?.displayName).toBe("Alice A.");
+    expect(seenByBob?.visibility).toBe("private");
   });
 });

--- a/packages/backend/convex/sharing/shareCopyToCircle.ts
+++ b/packages/backend/convex/sharing/shareCopyToCircle.ts
@@ -4,7 +4,7 @@ import {
   toCircleId,
   toCopyId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCircleRepository } from "./adapters/convexCircleRepository";
@@ -22,6 +22,18 @@ export const shareCopyToCircle = mutation({
   },
   handler: async (ctx, args) => {
     const actorId = await requireMember(ctx);
+
+    // Sharing's aggregate only gates on circle Admin — it never loads the Copy, so a circle Admin
+    // could otherwise share a copy they do NOT own. Verify ownership here: resolve the copy by its
+    // aggregateId (the Library CopyId) and require the actor to be its owner.
+    const copy = await ctx.db
+      .query("ownedPuzzles")
+      .withIndex("by_aggregate_id", (q) => q.eq("aggregateId", args.copyId))
+      .unique();
+    if (!copy) throw new ConvexError("Copy not found");
+    if (copy.ownerId !== (actorId as unknown as string)) {
+      throw new ConvexError("Only the owner can share this copy");
+    }
 
     const shareCopyToCircle = makeShareCopyToCircle({
       circles: convexCircleRepository(ctx),

--- a/packages/backend/convex/sharingMutations.test.ts
+++ b/packages/backend/convex/sharingMutations.test.ts
@@ -329,6 +329,31 @@ describe("library.browseOwnedPuzzles circle-aware visibility", () => {
     expect(view.ownedPuzzles.some((c) => c.aggregateId === copyId)).toBe(true);
   });
 
+  test("a circle Admin cannot share a copy they do not own", async () => {
+    const t = convexTest(schema, modules);
+    const { puzzleAggregateId } = await seed(t);
+    // Bob owns the copy.
+    const bobsCopyId = (await asBob(t).mutation(
+      api.library.acquireCopy.acquireCopy,
+      { puzzleDefinitionId: puzzleAggregateId, condition: "good" },
+    )) as string;
+
+    // Alice (the circle Admin) tries to share BOB's copy into her circle -> rejected.
+    const circleId = await createCircleForAlice(t);
+    await expect(
+      asAlice(t).mutation(api.sharing.shareCopyToCircle.shareCopyToCircle, {
+        circleId,
+        copyId: bobsCopyId,
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+
+    // And no share row was materialised.
+    const shares = await t.run(async (ctx) =>
+      ctx.db.query("circleCopyShares").collect(),
+    );
+    expect(shares).toHaveLength(0);
+  });
+
   test("a private copy shared into a circle stays hidden from a non-member (public path preserved)", async () => {
     const t = convexTest(schema, modules);
     const { puzzleAggregateId } = await seed(t);

--- a/packages/backend/convex/social/featuredShelf.ts
+++ b/packages/backend/convex/social/featuredShelf.ts
@@ -2,15 +2,25 @@ import type { OwnedCopyView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
+import { canViewCopy } from "../library/canViewCopy";
 import { toOwnedCopyView } from "../library/mappers";
 
 // Social read: the curated, ordered set of owned copies a member has featured on their profile
-// shelf. Returns them in the stored order and skips any entry that no longer exists or is no longer
-// owned by `userId` (defensive; ownership could have changed since curation). Returns [] when
-// the member has no profile or has not curated their shelf (caller falls back to recent-6).
+// shelf. Auth-gated. Returns them in the stored order and skips any entry that no longer exists or
+// is no longer owned by `userId` (defensive; ownership could have changed since curation).
+//
+// SECURITY: this is a public profile shelf, so a NON-owner viewer only sees copies they may
+// actually reach (canViewCopy: owner public + open, or circle-shared) and never the owner-only
+// fields (notes / acquisition provenance) — those are gated by the mapper's includeOwnerOnly
+// default. The OWNER sees their full curated shelf with all owner-only fields. Returns [] when the
+// member has no profile or has not curated their shelf (caller falls back to recent-6).
 export const featuredShelf = query({
   args: { userId: v.id("users") },
   handler: async (ctx, args): Promise<OwnedCopyView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+    const isOwner = viewerId === args.userId;
+
     const profile = await ctx.db
       .query("profiles")
       .withIndex("by_member", (q) =>
@@ -28,6 +38,9 @@ export const featuredShelf = query({
       const copy = await ctx.db.get(copyId);
       // Skip entries that no longer exist or are no longer owned by the profile member.
       if (!copy || copy.ownerId !== args.userId) continue;
+      // Reachability gate (identical to Browse / copy-detail): a non-owner only sees copies they
+      // may actually view. The owner always passes this via canViewCopy's owner short-circuit.
+      if (!(await canViewCopy(ctx, viewerId, copy))) continue;
 
       const puzzle = await ctx.db.get(copy.puzzleId);
 
@@ -43,7 +56,9 @@ export const featuredShelf = query({
         coverUrl = await ctx.storage.getUrl(puzzle.image);
       }
 
-      results.push(toOwnedCopyView(copy, puzzle, { coverUrl }));
+      results.push(
+        toOwnedCopyView(copy, puzzle, { coverUrl, includeOwnerOnly: isOwner }),
+      );
     }
 
     return results;

--- a/packages/backend/convex/social/getActivityFeed.ts
+++ b/packages/backend/convex/social/getActivityFeed.ts
@@ -29,6 +29,11 @@ const FEED_EVENT_NAMES = [
 
 const DEFAULT_LIMIT = 50;
 
+// Time window + per-name cap so the feed reads a bounded slice of `domainEvents` (via the
+// `by_name` index) instead of scanning the whole log. 90 days comfortably covers a feed page.
+const FEED_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+const PER_NAME_CAP = 500;
+
 export const getActivityFeed = query({
   args: { limit: v.optional(v.number()) },
   handler: async (ctx, args): Promise<ActivityEntryView[]> => {
@@ -43,13 +48,18 @@ export const getActivityFeed = query({
     const audience = new Set<string>([meId as string]);
     for (const f of followRows) audience.add(f.followeeId as string);
 
-    // Pull the activity-bearing events. Convex has no OR over `name`, so collect per-name.
+    // Pull the activity-bearing events. Convex has no OR over `name`, so query per-name via the
+    // `by_name` index, bounded to a recent window and capped (newest-first) to avoid a full scan.
+    const since = Date.now() - FEED_WINDOW_MS;
     const eventBatches = await Promise.all(
       FEED_EVENT_NAMES.map((name) =>
         ctx.db
           .query("domainEvents")
-          .filter((q) => q.eq(q.field("name"), name))
-          .collect(),
+          .withIndex("by_name", (q) =>
+            q.eq("name", name).gte("occurredAt", since),
+          )
+          .order("desc")
+          .take(PER_NAME_CAP),
       ),
     );
 

--- a/packages/backend/convex/social/getActivityFeed.ts
+++ b/packages/backend/convex/social/getActivityFeed.ts
@@ -34,6 +34,22 @@ const DEFAULT_LIMIT = 50;
 const FEED_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 const PER_NAME_CAP = 500;
 
+// KNOWN SCALE LIMITATION (finding #7, tracked as a follow-up):
+//   This query pulls a GLOBAL newest-`PER_NAME_CAP`-per-event-name window (keyed on event name +
+//   time, NOT on member) and only THEN filters down to the viewer's audience in memory. On a busy
+//   platform the newest 500 events of a given name can all belong to members the viewer does not
+//   follow, so a viewer following only a few people could see a stale/empty feed even when their
+//   followees have recent activity that fell outside the global window. The 90-day window does not
+//   help — the cap, not the window, is the binding constraint under load.
+//
+//   The correct fix is a per-actor read path, NOT a bigger cap (which only defers the problem and
+//   inflates every read): either (a) add an `actorId` column to `domainEvents` populated at record
+//   time with a `by_actor_and_time` index and query per audience member, or (b) maintain a
+//   denormalized per-member activity table written by the event dispatcher. Both require changes
+//   across the emitting domains (and a backfill), and ExchangeCompleted carries no member today
+//   (parties are resolved from the exchange row), so this is deliberately left as a follow-up
+//   rather than a risky partial. Raising PER_NAME_CAP is an accepted stopgap if needed.
+
 export const getActivityFeed = query({
   args: { limit: v.optional(v.number()) },
   handler: async (ctx, args): Promise<ActivityEntryView[]> => {

--- a/packages/backend/convex/social/getActivityFeed.ts
+++ b/packages/backend/convex/social/getActivityFeed.ts
@@ -87,7 +87,14 @@ export const getActivityFeed = query({
       }
     }
 
-    const feed = buildActivityFeed(entries, {
+    // One activity per (kind, ref): an ExchangeCompleted is attributed to BOTH parties, so a viewer
+    // who is a party AND follows the counterparty would otherwise see the same exchange twice.
+    // buildActivityFeed only sorts/slices, so dedupe here, keeping the first occurrence.
+    const deduped = [
+      ...new Map(entries.map((e) => [`${e.kind}:${e.ref}`, e])).values(),
+    ];
+
+    const feed = buildActivityFeed(deduped, {
       limit: args.limit ?? DEFAULT_LIMIT,
     });
     return feed.map(toActivityEntryView);

--- a/packages/backend/convex/social/getProfile.ts
+++ b/packages/backend/convex/social/getProfile.ts
@@ -3,19 +3,35 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { areMutualFollowers } from "./privacy";
 import { toProfileView } from "./readViews";
 
-// Read side: a member's public profile, or null if they have none yet. When `memberId` is omitted
-// the acting member's own profile is returned (auth-gated). Returns a typed ProfileView DTO.
+// Read side: a member's profile, or null if they have none yet. When `memberId` is omitted the
+// acting member's own profile is returned. Always auth-gated: the acting member is resolved
+// UNCONDITIONALLY (passing a memberId must not bypass authentication). A profile whose visibility is
+// "private" is hidden from everyone except the owner and the member's mutual followers. Returns a
+// typed ProfileView DTO.
 export const getProfile = query({
   args: { memberId: v.optional(v.id("users")) },
   handler: async (ctx, args): Promise<ProfileView | null> => {
-    const memberId =
-      args.memberId ?? ((await requireMember(ctx)) as unknown as Id<"users">);
+    const viewer = (await requireMember(ctx)) as unknown as Id<"users">;
+    const target = args.memberId ?? viewer;
+
     const row = await ctx.db
       .query("profiles")
-      .withIndex("by_member", (q) => q.eq("memberId", memberId))
+      .withIndex("by_member", (q) => q.eq("memberId", target))
       .unique();
-    return row ? toProfileView(row) : null;
+    if (!row) return null;
+
+    // Visibility ACL: a private profile is visible only to its owner and to mutual followers.
+    if (
+      row.visibility === "private" &&
+      target !== viewer &&
+      !(await areMutualFollowers(ctx, viewer, target))
+    ) {
+      return null;
+    }
+
+    return toProfileView(row);
   },
 });

--- a/packages/backend/convex/social/isFollowing.ts
+++ b/packages/backend/convex/social/isFollowing.ts
@@ -9,11 +9,16 @@ export const isFollowing = query({
   args: { followeeId: v.id("users") },
   handler: async (ctx, args): Promise<boolean> => {
     const followerId = (await requireMember(ctx)) as unknown as Id<"users">;
+    // Use the compound (followerId, followeeId) index rather than scanning all of
+    // the follower's edges and filtering. `.first()` is duplicate-tolerant
+    // (matches areMutualFollowers in privacy.ts) so a stray duplicate edge never
+    // 500s the follow/unfollow button state.
     const row = await ctx.db
       .query("follows")
-      .withIndex("by_follower", (q) => q.eq("followerId", followerId))
-      .filter((q) => q.eq(q.field("followeeId"), args.followeeId))
-      .unique();
+      .withIndex("by_follower_followee", (q) =>
+        q.eq("followerId", followerId).eq("followeeId", args.followeeId),
+      )
+      .first();
     return row !== null;
   },
 });

--- a/packages/backend/convex/social/listFollowees.ts
+++ b/packages/backend/convex/social/listFollowees.ts
@@ -3,15 +3,30 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { areMutualFollowers, profileVisibilityOf } from "./privacy";
 import { toFollowEdgeView } from "./readViews";
 
 // Read side: the members the target follows (defaults to the acting member). Each entry resolves
 // the FOLLOWEE's display name. Returns typed FollowEdgeView DTOs.
+//
+// SECURITY: always auth-gated — the acting member is resolved UNCONDITIONALLY (passing a `memberId`
+// must not bypass authentication via `??` short-circuit). The follow graph follows the SAME
+// visibility model as getProfile: a member whose profile is "private" exposes their following list
+// only to themselves and to mutual followers; everyone else gets [].
 export const listFollowees = query({
   args: { memberId: v.optional(v.id("users")) },
   handler: async (ctx, args): Promise<FollowEdgeView[]> => {
-    const target =
-      args.memberId ?? ((await requireMember(ctx)) as unknown as Id<"users">);
+    const viewer = (await requireMember(ctx)) as unknown as Id<"users">;
+    const target = args.memberId ?? viewer;
+
+    if (
+      target !== viewer &&
+      (await profileVisibilityOf(ctx, target)) === "private" &&
+      !(await areMutualFollowers(ctx, viewer, target))
+    ) {
+      return [];
+    }
+
     const rows = await ctx.db
       .query("follows")
       .withIndex("by_follower", (q) => q.eq("followerId", target))

--- a/packages/backend/convex/social/listFollowers.ts
+++ b/packages/backend/convex/social/listFollowers.ts
@@ -3,15 +3,30 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { areMutualFollowers, profileVisibilityOf } from "./privacy";
 import { toFollowEdgeView } from "./readViews";
 
 // Read side: the members who follow the target (defaults to the acting member). Each entry resolves
 // the FOLLOWER's display name. Returns typed FollowEdgeView DTOs.
+//
+// SECURITY: always auth-gated — the acting member is resolved UNCONDITIONALLY (passing a `memberId`
+// must not bypass authentication via `??` short-circuit). The follow graph follows the SAME
+// visibility model as getProfile: a member whose profile is "private" exposes their follower list
+// only to themselves and to mutual followers; everyone else gets [].
 export const listFollowers = query({
   args: { memberId: v.optional(v.id("users")) },
   handler: async (ctx, args): Promise<FollowEdgeView[]> => {
-    const target =
-      args.memberId ?? ((await requireMember(ctx)) as unknown as Id<"users">);
+    const viewer = (await requireMember(ctx)) as unknown as Id<"users">;
+    const target = args.memberId ?? viewer;
+
+    if (
+      target !== viewer &&
+      (await profileVisibilityOf(ctx, target)) === "private" &&
+      !(await areMutualFollowers(ctx, viewer, target))
+    ) {
+      return [];
+    }
+
     const rows = await ctx.db
       .query("follows")
       .withIndex("by_followee", (q) => q.eq("followeeId", target))

--- a/packages/backend/convex/social/listPuzzleComments.ts
+++ b/packages/backend/convex/social/listPuzzleComments.ts
@@ -30,8 +30,6 @@ export const listPuzzleComments = query({
             : {
                 _id: row.authorId,
                 _creationTime: 0,
-                clerkId: "",
-                email: "",
                 name: "Member",
                 isActive: false,
                 createdAt: 0,

--- a/packages/backend/convex/social/listPuzzleComments.ts
+++ b/packages/backend/convex/social/listPuzzleComments.ts
@@ -1,18 +1,28 @@
 import type { PuzzleCommentView } from "@jigswap/contracts";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
+import { canViewCopy } from "../library/canViewCopy";
 
 // Read side: the COPY-scoped comments on the given owned copy (the owner's own notes/rating),
 // newest first — NOT the shared community reviews (those live on the catalog page via
 // listPuzzleReviews). Each comment joins its REAL author (comments are voluntary public posts —
 // never anonymised). A missing copy returns []. The author join falls back to a synthetic "Member"
 // view if the user row vanished, so an orphaned comment never breaks the list.
+//
+// SECURITY: auth-gated, and the copy is run through the SAME reachability gate as getCopyInstanceView
+// (canViewCopy) before any comment is returned — a private/unreachable copy of another member yields
+// [], so the owner's per-copy notes/ratings never leak to a viewer who cannot see the copy.
 export const listPuzzleComments = query({
   args: { copyId: v.id("ownedPuzzles") },
   handler: async (ctx, args): Promise<PuzzleCommentView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+
     const copy = await ctx.db.get(args.copyId);
     if (!copy) return [];
+    if (!(await canViewCopy(ctx, viewerId, copy))) return [];
 
     const rows = await ctx.db
       .query("puzzleComments")

--- a/packages/backend/convex/social/listPuzzleReviews.ts
+++ b/packages/backend/convex/social/listPuzzleReviews.ts
@@ -29,8 +29,6 @@ export const listPuzzleReviews = query({
             : {
                 _id: row.authorId,
                 _creationTime: 0,
-                clerkId: "",
-                email: "",
                 name: "Member",
                 isActive: false,
                 createdAt: 0,

--- a/packages/backend/convex/social/listPuzzleReviews.ts
+++ b/packages/backend/convex/social/listPuzzleReviews.ts
@@ -1,6 +1,7 @@
 import type { PuzzleCommentView } from "@jigswap/contracts";
 import { v } from "convex/values";
 import { query } from "../_generated/server";
+import { requireMember } from "../identity/requireMember";
 import { toMemberView } from "../identity/toMemberView";
 
 // Read side: the community reviews on a catalog puzzle DEFINITION, keyed by puzzleId directly (the
@@ -8,9 +9,17 @@ import { toMemberView } from "../identity/toMemberView";
 // voluntary public posts — never anonymised); the author join falls back to a synthetic "Member"
 // view if the user row vanished, so an orphaned review never breaks the list. Mirrors
 // listPuzzleComments, which keys by copyId.
+//
+// SECURITY: auth-gated. Each review is projected through `toMemberView`, which exposes member
+// identity (name/username/bio/location) intended only for OTHER AUTHENTICATED MEMBERS — so the
+// handler requires a signed-in member before returning any author view. There is no copy here (these
+// are catalog-definition reviews with copyId == null), so the `canViewCopy` reachability gate that
+// listPuzzleComments uses does NOT apply; auth is the correct gate for definition-level reviews.
 export const listPuzzleReviews = query({
   args: { puzzleId: v.id("puzzles") },
   handler: async (ctx, args): Promise<PuzzleCommentView[]> => {
+    await requireMember(ctx);
+
     const rows = (
       await ctx.db
         .query("puzzleComments")

--- a/packages/backend/convex/social/postPuzzleComment.ts
+++ b/packages/backend/convex/social/postPuzzleComment.ts
@@ -32,6 +32,11 @@ export const postPuzzleComment = mutation({
 
     const copy = await ctx.db.get(args.copyId);
     if (!copy) throw new ConvexError("Copy not found");
+    // Copy-scoped comments ARE the owner's own notes/rating on their copy, so only the owner may
+    // post one — mirroring the addCopyPhoto ownership guard.
+    if (copy.ownerId !== (authorId as unknown as string)) {
+      throw new ConvexError("Only the owner can comment on this copy");
+    }
 
     const post = makePostComment({
       comments: convexCommentRepository(ctx),

--- a/packages/backend/convex/social/privacy.ts
+++ b/packages/backend/convex/social/privacy.ts
@@ -31,14 +31,16 @@ export const areMutualFollowers = async (
   if (a === b) return false;
   const aFollowsB = await ctx.db
     .query("follows")
-    .withIndex("by_follower", (q) => q.eq("followerId", a))
-    .filter((q) => q.eq(q.field("followeeId"), b))
+    .withIndex("by_follower_followee", (q) =>
+      q.eq("followerId", a).eq("followeeId", b),
+    )
     .first();
   if (!aFollowsB) return false;
   const bFollowsA = await ctx.db
     .query("follows")
-    .withIndex("by_follower", (q) => q.eq("followerId", b))
-    .filter((q) => q.eq(q.field("followeeId"), a))
+    .withIndex("by_follower_followee", (q) =>
+      q.eq("followerId", b).eq("followeeId", a),
+    )
     .first();
   return bFollowsA !== null;
 };

--- a/packages/backend/convex/socialMutations.test.ts
+++ b/packages/backend/convex/socialMutations.test.ts
@@ -108,6 +108,82 @@ describe("follow / unfollow", () => {
   });
 });
 
+describe("listFollowers / listFollowees auth + visibility gating", () => {
+  test("passing a memberId while unauthenticated is rejected (no ?? auth bypass)", async () => {
+    const t = convexTest(schema, modules);
+    const { bob } = await seed(t);
+
+    // Supplying a memberId must NOT short-circuit requireMember.
+    await expect(
+      t.query(api.social.listFollowers.listFollowers, { memberId: bob }),
+    ).rejects.toThrow(ConvexError);
+    await expect(
+      t.query(api.social.listFollowees.listFollowees, { memberId: bob }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("a private member's follow graph is hidden from non-mutual viewers", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    // Alice follows Bob (one-directional), and Bob marks his profile private.
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+    await asBob(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    // Alice is not a mutual follower of Bob, so Bob's graph is hidden.
+    expect(
+      await asAlice(t).query(api.social.listFollowers.listFollowers, {
+        memberId: bob,
+      }),
+    ).toEqual([]);
+    expect(
+      await asAlice(t).query(api.social.listFollowees.listFollowees, {
+        memberId: bob,
+      }),
+    ).toEqual([]);
+
+    // Bob himself always sees his own graph.
+    const ownFollowers = await asBob(t).query(
+      api.social.listFollowers.listFollowers,
+      { memberId: bob },
+    );
+    expect(ownFollowers.map((f) => f.memberId)).toContain(alice as string);
+  });
+
+  test("mutual followers may see a private member's follow graph", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    // Mutual follow, then Bob goes private.
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+    await asBob(t).mutation(api.social.followMember.followMember, {
+      followeeId: alice,
+    });
+    await asBob(t).mutation(
+      api.social.setProfileVisibility.setProfileVisibility,
+      { visibility: "private" },
+    );
+
+    const followers = await asAlice(t).query(
+      api.social.listFollowers.listFollowers,
+      { memberId: bob },
+    );
+    expect(followers.map((f) => f.memberId)).toContain(alice as string);
+    const followees = await asAlice(t).query(
+      api.social.listFollowees.listFollowees,
+      { memberId: bob },
+    );
+    expect(followees.map((f) => f.memberId)).toContain(alice as string);
+  });
+});
+
 describe("editProfile", () => {
   test("first edit creates the profile; a later edit updates it", async () => {
     const t = convexTest(schema, modules);

--- a/packages/backend/convex/socialMutations.test.ts
+++ b/packages/backend/convex/socialMutations.test.ts
@@ -343,4 +343,59 @@ describe("activity feed projection", () => {
     expect(feed[0].ref).toBe(exchangeAggregateId);
     expect(feed[0].memberId).toBe(alice as string);
   });
+
+  test("a completed exchange appears once when the viewer is a party AND follows the counterparty", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    // Alice is a party (initiator) AND follows Bob (the recipient/counterparty) — both parties land
+    // in her audience, which previously emitted the same exchange twice.
+    await asAlice(t).mutation(api.social.followMember.followMember, {
+      followeeId: bob,
+    });
+
+    const exchangeAggregateId = "exch-dup";
+    await t.run(async (ctx) => {
+      const puzzleId = await ctx.db.insert("puzzles", {
+        title: "P",
+        pieceCount: 100,
+        status: "approved",
+        submittedBy: bob,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      const copyId = await ctx.db.insert("ownedPuzzles", {
+        puzzleId,
+        ownerId: bob,
+        condition: "good",
+        availability: { forTrade: true, forSale: false, forLend: false },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("exchanges", {
+        aggregateId: exchangeAggregateId,
+        initiatorId: alice,
+        recipientId: bob,
+        type: "trade",
+        requestedPuzzleId: copyId,
+        status: "completed",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+    await insertEvent(
+      t,
+      "ExchangeCompleted",
+      { exchangeId: exchangeAggregateId },
+      Date.now(),
+      "exchange",
+    );
+
+    const feed = await asAlice(t).query(
+      api.social.getActivityFeed.getActivityFeed,
+      {},
+    );
+    // De-duplicated by (kind, ref): the exchange shows exactly once, not twice.
+    expect(feed.filter((e) => e.ref === exchangeAggregateId)).toHaveLength(1);
+  });
 });

--- a/packages/backend/convex/socialMutations.test.ts
+++ b/packages/backend/convex/socialMutations.test.ts
@@ -84,6 +84,32 @@ describe("follow / unfollow", () => {
     ).rejects.toThrow(ConvexError);
   });
 
+  test("isFollowing is duplicate-tolerant (compound index + .first, no 500)", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob } = await seed(t);
+
+    // Two identical (alice -> bob) edges. With the old by_follower scan + .unique()
+    // this would throw; the compound index + .first() must return true cleanly.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("follows", {
+        followerId: alice,
+        followeeId: bob,
+        createdAt: 1,
+      });
+      await ctx.db.insert("follows", {
+        followerId: alice,
+        followeeId: bob,
+        createdAt: 2,
+      });
+    });
+
+    expect(
+      await asAlice(t).query(api.social.isFollowing.isFollowing, {
+        followeeId: bob,
+      }),
+    ).toBe(true);
+  });
+
   test("unfollow removes the edge; unfollowing a non-followee is rejected", async () => {
     const t = convexTest(schema, modules);
     const { bob } = await seed(t);

--- a/packages/backend/convex/solving/recordCompletion.ts
+++ b/packages/backend/convex/solving/recordCompletion.ts
@@ -6,7 +6,7 @@ import {
   toFileId,
   toPuzzleDefinitionId,
 } from "@jigswap/domain";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { convexCompletionRepository } from "./adapters/convexCompletionRepository";
@@ -32,6 +32,22 @@ export const recordCompletion = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await requireMember(ctx);
+
+    // Logging a solve is an OWNER-ONLY action on one's OWN copy. The domain use cases never load
+    // the Copy, so without this gate any authenticated user could inject fabricated completions
+    // (with ratings/notes) onto another member's copy — getCopyInstanceView surfaces ALL of a
+    // copy's completions. Mirror shareCopyToCircle/setCopyCover: resolve the copy by its
+    // aggregateId (the Library CopyId) and require the actor to be its owner.
+    if (args.copyId !== undefined) {
+      const copy = await ctx.db
+        .query("ownedPuzzles")
+        .withIndex("by_aggregate_id", (q) => q.eq("aggregateId", args.copyId))
+        .unique();
+      if (!copy) throw new ConvexError("Copy not found");
+      if (copy.ownerId !== (userId as unknown as string)) {
+        throw new ConvexError("Only the owner can log a solve for this copy");
+      }
+    }
 
     const puzzleDefinitionId = args.puzzleDefinitionId
       ? toPuzzleDefinitionId(args.puzzleDefinitionId)

--- a/packages/backend/convex/solvingMutations.test.ts
+++ b/packages/backend/convex/solvingMutations.test.ts
@@ -141,6 +141,57 @@ describe("solving.recordCompletion", () => {
     expect(row?.completionTimeMinutes).toBe(60);
   });
 
+  test("a non-owner cannot record a completion against someone else's copy, and nothing is written", async () => {
+    const t = convexTest(schema, modules);
+    const { copyAggregateId, ownedPuzzleId } = await seed(t);
+
+    await expect(
+      asBob(t).mutation(api.solving.recordCompletion.recordCompletion, {
+        copyId: copyAggregateId,
+        startDate: Date.now() - 2 * HOUR,
+        endDate: Date.now() - HOUR,
+        notes: "fabricated",
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+
+    // No completion row was inserted against the copy.
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("completions")
+        .withIndex("by_owned_puzzle", (q) =>
+          q.eq("ownedPuzzleId", ownedPuzzleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a non-owner cannot start a completion against someone else's copy, and nothing is written", async () => {
+    const t = convexTest(schema, modules);
+    const { copyAggregateId, ownedPuzzleId } = await seed(t);
+
+    await expect(
+      asBob(t).mutation(api.solving.recordCompletion.recordCompletion, {
+        copyId: copyAggregateId,
+        startDate: Date.now() - HOUR,
+      }),
+    ).rejects.toBeInstanceOf(ConvexError);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("completions")
+        .withIndex("by_owned_puzzle", (q) =>
+          q.eq("ownedPuzzleId", ownedPuzzleId),
+        )
+        .collect(),
+    );
+    expect(rows).toHaveLength(0);
+
+    // The owner can still log a solve for their own copy.
+    const completionId = await recordForAlice(t, copyAggregateId);
+    expect(typeof completionId).toBe("string");
+  });
+
   test("records against a puzzle definition, resolving the puzzles._id FK", async () => {
     const t = convexTest(schema, modules);
     const { puzzleAggregateId, puzzleId } = await seed(t);

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -1,15 +1,18 @@
 import { UserJSON } from "@clerk/backend";
 import { v } from "convex/values";
-import { Doc } from "./_generated/dataModel";
+import { Doc, Id } from "./_generated/dataModel";
 import {
   internalMutation,
   internalQuery,
   mutation,
   QueryCtx,
 } from "./_generated/server";
+import { requireMember } from "./identity/requireMember";
 
-// Create or update user from Clerk
-export const createOrUpdateUser = mutation({
+// Create or update user from Clerk. Internal only: the canonical user sync happens via the Clerk
+// webhook (updateOrCreateUser). Exposing this publicly would let any client upsert a `users` row
+// keyed by a client-supplied clerkId (account takeover).
+export const createOrUpdateUser = internalMutation({
   args: {
     clerkId: v.string(),
     email: v.string(),
@@ -65,15 +68,15 @@ export const createOrUpdateUser = mutation({
 // webhook (see updateOrCreateUser).
 export const updateUserProfile = mutation({
   args: {
-    userId: v.id("users"),
     bio: v.optional(v.string()),
     location: v.optional(v.string()),
     preferredLanguage: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { userId, ...updates } = args;
-    await ctx.db.patch(userId, {
-      ...updates,
+    // Ownership: the patched row is the authenticated member, never a client-supplied id (IDOR).
+    const memberId = await requireMember(ctx);
+    await ctx.db.patch(memberId as unknown as Id<"users">, {
+      ...args,
       updatedAt: Date.now(),
     });
   },

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -9,6 +9,11 @@ import {
 } from "./_generated/server";
 import { requireMember } from "./identity/requireMember";
 
+// The lowercased text backing the `by_searchable_name` people-search index. Kept in sync on every
+// user write so member search is an index lookup, not a full-table scan + in-memory filter.
+const toSearchableName = (name: string, username?: string): string =>
+  [name, username].filter(Boolean).join(" ").toLowerCase();
+
 // Create or update user from Clerk. Internal only: the canonical user sync happens via the Clerk
 // webhook (updateOrCreateUser). Exposing this publicly would let any client upsert a `users` row
 // keyed by a client-supplied clerkId (account takeover).
@@ -35,6 +40,7 @@ export const createOrUpdateUser = internalMutation({
         name: args.name,
         username: args.username,
         avatar: args.avatar,
+        searchableName: toSearchableName(args.name, args.username),
         updatedAt: now,
       });
       return existingUser._id;
@@ -46,6 +52,7 @@ export const createOrUpdateUser = internalMutation({
         name: args.name,
         username: args.username,
         avatar: args.avatar,
+        searchableName: toSearchableName(args.name, args.username),
         bio: undefined,
         location: undefined,
         preferredLanguage: "en",
@@ -96,13 +103,16 @@ export const updateOrCreateUser = internalMutation({
   async handler(ctx, { clerkUser }: { clerkUser: UserJSON }) {
     const userRecord = await userQuery(ctx, clerkUser.id);
 
+    const name = `${clerkUser.first_name} ${clerkUser.last_name}`;
+    const username = clerkUser.username ?? undefined;
     if (userRecord === null) {
       await ctx.db.insert("users", {
         clerkId: clerkUser.id,
         email: clerkUser.email_addresses[0].email_address,
-        name: `${clerkUser.first_name} ${clerkUser.last_name}`,
-        username: clerkUser.username ?? undefined,
+        name,
+        username,
         avatar: clerkUser.image_url,
+        searchableName: toSearchableName(name, username),
         bio: undefined,
         isActive: true,
         createdAt: clerkUser.created_at,
@@ -112,12 +122,43 @@ export const updateOrCreateUser = internalMutation({
       await ctx.db.patch(userRecord._id, {
         clerkId: clerkUser.id,
         email: clerkUser.email_addresses[0].email_address,
-        name: `${clerkUser.first_name} ${clerkUser.last_name}`,
-        username: clerkUser.username ?? undefined,
+        name,
+        username,
         avatar: clerkUser.image_url,
+        searchableName: toSearchableName(name, username),
         updatedAt: clerkUser.updated_at,
       });
     }
+  },
+});
+
+// One-shot backfill for the `searchableName` people-search field on rows created before the index
+// existed. Pages the `users` table and patches any row whose `searchableName` is missing or stale.
+// Internal-only (never wired to a public endpoint); run once from the Convex dashboard/CLI after
+// deploy. Without it, legacy rows only become searchable on their next write (Clerk webhook sync).
+export const backfillSearchableName = internalMutation({
+  args: { batchSize: v.optional(v.number()), cursor: v.optional(v.string()) },
+  async handler(ctx, { batchSize, cursor }) {
+    const page = await ctx.db
+      .query("users")
+      .paginate({ cursor: cursor ?? null, numItems: batchSize ?? 200 });
+
+    let patched = 0;
+    for (const user of page.page) {
+      const expected = toSearchableName(user.name, user.username);
+      if (user.searchableName !== expected) {
+        await ctx.db.patch(user._id, { searchableName: expected });
+        patched += 1;
+      }
+    }
+
+    return {
+      patched,
+      scanned: page.page.length,
+      isDone: page.isDone,
+      // Pass this back in as `cursor` to continue paging until `isDone` is true.
+      continueCursor: page.isDone ? null : page.continueCursor,
+    };
   },
 });
 

--- a/packages/contracts/src/custody/views.ts
+++ b/packages/contracts/src/custody/views.ts
@@ -3,14 +3,17 @@
 // settling exchange + when), and the current owner — derived from the OwnershipTransferred events
 // projected per copy. Ids are surfaced as opaque strings (the web app re-casts at the edge).
 
-import type { MemberView } from "../identity/member";
+import type { ProjectedMember } from "../social/social";
 
 /** A single ownership transfer in a Copy's provenance: who it went to, via which exchange, when. */
 export interface CustodyTransferView {
   /** The settling Exchange aggregateId (domain ExchangeId). */
   exchangeId: string;
-  /** The member the Copy was transferred to. Null if the user row no longer resolves. */
-  newOwner: MemberView | null;
+  /**
+   * The member the Copy was transferred to, privacy-projected for the viewer: a hidden member is
+   * anonymised server-side (only an opaque anonRef crosses the wire).
+   */
+  newOwner: ProjectedMember;
   /** Epoch millis the transfer occurred (settlement time). */
   occurredAt: number;
 }
@@ -18,14 +21,16 @@ export interface CustodyTransferView {
 /**
  * A Copy's full chain of custody, chronological: the original owner, every transfer in order, and
  * the current owner. `transfers` is ascending by `occurredAt`. Returned by `custody.timeline`.
+ * Every surfaced member is a {@link ProjectedMember}, anonymised server-side per the viewer's
+ * connection so a hidden member's real identity never crosses the wire.
  */
 export interface CopyCustodyTimelineView {
   /** The Copy this provenance belongs to (the `ownedPuzzles` _id). */
   copyId: string;
-  /** The member who first held the Copy (its creator/owner). Null if unresolved. */
-  originalOwner: MemberView | null;
+  /** The member who first held the Copy (its creator/owner), privacy-projected. */
+  originalOwner: ProjectedMember;
   /** Ordered transfers (ascending by time). Empty when the Copy was never transferred. */
   transfers: CustodyTransferView[];
-  /** The member who currently holds the Copy. Null if unresolved. */
-  currentOwner: MemberView | null;
+  /** The member who currently holds the Copy, privacy-projected. */
+  currentOwner: ProjectedMember;
 }

--- a/packages/contracts/src/identity/member.ts
+++ b/packages/contracts/src/identity/member.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 import type { ConvexSystemFields } from "../shared/convex";
 
 /**
- * A member (the wrapper over a Clerk user). Faithful superset of the `users` document the legacy
- * `getCurrentUser` / `getUserByClerkId` / `getUserById` / `searchUsers` reads returned raw, so
- * consumers that read `_id`, `name`, `avatar`, `bio`, `location`, etc. keep working unchanged.
+ * A member (the wrapper over a Clerk user) as projected to OTHER authenticated members.
+ * Deliberately excludes PII (`email`) and the Clerk subject (`clerkId`): those must never be
+ * exposed across members (GDPR + identity-provider subject leakage). The self-only `me` query
+ * returns {@link CurrentMemberView}, which adds those fields back for the signed-in member.
  */
 export interface MemberView extends ConvexSystemFields {
-  clerkId: string;
-  email: string;
   name: string;
   username?: string;
   avatar?: string;
@@ -18,6 +17,16 @@ export interface MemberView extends ConvexSystemFields {
   isActive: boolean;
   createdAt: number;
   updatedAt: number;
+}
+
+/**
+ * The signed-in member's own view (the `getCurrentUser` query only). Superset of {@link MemberView}
+ * that re-adds the member's own `email` and `clerkId` — safe because it is only ever returned for
+ * the caller's own account, never for another member.
+ */
+export interface CurrentMemberView extends MemberView {
+  clerkId: string;
+  email: string;
 }
 
 /**

--- a/packages/contracts/src/lending/views.ts
+++ b/packages/contracts/src/lending/views.ts
@@ -3,6 +3,7 @@
 // `lending.*` reads return these. Ids are opaque strings (the web app re-casts at the edge).
 
 import type { MemberView } from "../identity/member";
+import type { ProjectedMember } from "../social/social";
 
 /**
  * One loan — used for a member's currently-borrowed list, their currently-lent-out list, and a
@@ -29,4 +30,17 @@ export interface LoanView {
   lender: MemberView | null;
   /** The borrower holding the copy. Null if unresolved. */
   borrower: MemberView | null;
+}
+
+/**
+ * A loan as surfaced on a Copy's public lending history (`lending.copyHistory`). Identical to
+ * {@link LoanView} except both parties are privacy-projected ({@link ProjectedMember}) so a hidden
+ * member's real identity never crosses the wire — mirroring getCopyInstanceView's loan projection.
+ */
+export interface ProjectedLoanView extends Omit<
+  LoanView,
+  "lender" | "borrower"
+> {
+  lender: ProjectedMember;
+  borrower: ProjectedMember;
 }

--- a/packages/domain/src/catalog/domain/is-private-ip.spec.ts
+++ b/packages/domain/src/catalog/domain/is-private-ip.spec.ts
@@ -23,6 +23,23 @@ describe("isPrivateIp", () => {
     }
   });
 
+  // --- 100.64.0.0/10 carrier-grade NAT (RFC 6598) ---
+  it("flags the 100.64/10 CGNAT range and allows its neighbors", () => {
+    expect(isPrivateIp("100.64.0.0")).toBe(true); // lower bound
+    expect(isPrivateIp("100.100.0.1")).toBe(true); // inside
+    expect(isPrivateIp("100.127.255.255")).toBe(true); // upper bound
+    expect(isPrivateIp("100.63.0.1")).toBe(false); // one below the block
+    expect(isPrivateIp("100.128.0.1")).toBe(false); // one above the block
+  });
+
+  // --- 192.0.0.0/24 IETF protocol assignments ---
+  it("flags the 192.0.0.0/24 block and allows the public 192.0.2-derived space", () => {
+    expect(isPrivateIp("192.0.0.0")).toBe(true);
+    expect(isPrivateIp("192.0.0.171")).toBe(true); // NAT64 well-known
+    expect(isPrivateIp("192.0.1.1")).toBe(false); // outside the /24
+    expect(isPrivateIp("192.1.0.1")).toBe(false);
+  });
+
   it("flags IPv6 loopback, ULA, and link-local", () => {
     for (const ip of ["::1", "fc00::1", "fd12::34", "fe80::1", "::"]) {
       expect(isPrivateIp(ip), ip).toBe(true);

--- a/packages/domain/src/catalog/domain/is-private-ip.ts
+++ b/packages/domain/src/catalog/domain/is-private-ip.ts
@@ -15,7 +15,9 @@ const ipv4Private = (ip: string): boolean => {
   if (a === 10) return true; // 10/8
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
   if (a === 192 && b === 168) return true; // 192.168/16
+  if (a === 192 && b === 0 && parts[2] === 0) return true; // 192.0.0.0/24 IETF protocol assignments
   if (a === 169 && b === 254) return true; // link-local
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 carrier-grade NAT (RFC 6598)
   return false;
 };
 

--- a/packages/domain/src/exchange/application/errors.ts
+++ b/packages/domain/src/exchange/application/errors.ts
@@ -9,6 +9,7 @@ export type ApplicationErrorCode =
   | "CopyNotFound"
   | "CopyNotAvailable"
   | "OfferedCopyNotOwned"
+  | "RecipientNotOwner"
   | "DuplicateProposal"
   | "ExchangeNotFound";
 
@@ -46,6 +47,14 @@ export class ApplicationError extends DomainError {
     return new ApplicationError(
       "OfferedCopyNotOwned",
       `Offered copy ${copyId} is not owned by the initiator`,
+    );
+  }
+
+  // The requested copy is not owned by the named recipient — the proposal targets the wrong member.
+  static recipientNotOwner(copyId: CopyId): ApplicationError {
+    return new ApplicationError(
+      "RecipientNotOwner",
+      `Copy ${copyId} is not owned by the named recipient`,
     );
   }
 

--- a/packages/domain/src/exchange/application/use-cases/propose-exchange.spec.ts
+++ b/packages/domain/src/exchange/application/use-cases/propose-exchange.spec.ts
@@ -234,6 +234,31 @@ describe("makeProposeExchange", () => {
     if (result.isErr) expect(result.error.code).toBe("CopyNotFound");
   });
 
+  it("rejects when the requested copy is not owned by the named recipient", async () => {
+    // carol owns the requested copy, but the proposal names bob as the recipient.
+    const carol = toMemberId("carol");
+    copies
+      .seed(
+        copy({
+          id: requestedId,
+          ownerId: carol,
+          availability: { forTrade: false, forSale: true, forLend: false },
+        }),
+      )
+      .seed(copy({ id: offeredId, ownerId: alice }));
+
+    const result = await propose({
+      initiatorId: alice,
+      recipientId: bob,
+      kind: "sale",
+      requestedCopyId: requestedId,
+      terms: saleTerms(),
+    });
+    expect(result.isErr).toBe(true);
+    if (result.isErr) expect(result.error.code).toBe("RecipientNotOwner");
+    expect(events.published).toHaveLength(0);
+  });
+
   it("delegates self-exchange rejection to the aggregate", async () => {
     copies.seed(
       copy({

--- a/packages/domain/src/exchange/application/use-cases/propose-exchange.ts
+++ b/packages/domain/src/exchange/application/use-cases/propose-exchange.ts
@@ -64,6 +64,11 @@ export const makeProposeExchange =
         ApplicationError.copyNotAvailable(cmd.requestedCopyId, cmd.kind),
       );
     }
+    // The recipient must actually own the requested copy, else the proposal targets an arbitrary
+    // member (spam) and could never settle.
+    if (requested.ownerId !== cmd.recipientId) {
+      return err(ApplicationError.recipientNotOwner(cmd.requestedCopyId));
+    }
 
     if (cmd.kind === "swap") {
       const offered = await loadOfferedCopy(deps.copies, cmd);

--- a/packages/domain/src/library/application/use-cases/loan-use-cases.spec.ts
+++ b/packages/domain/src/library/application/use-cases/loan-use-cases.spec.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  err,
   toCopyId,
   toLoanId,
   toOwnerId,
   toPuzzleDefinitionId,
 } from "../../../shared-kernel";
-import { CatalogSnapshot, Copy, CopyId, LoanId } from "../../domain";
+import {
+  CatalogSnapshot,
+  Copy,
+  CopyId,
+  LibraryError,
+  LoanId,
+} from "../../domain";
 import {
   FixedClock,
   InMemoryCopyRepository,
@@ -199,6 +206,42 @@ describe("loan use cases", () => {
       })({ loanId: toLoanId("ghost"), actingMemberId: owner });
       expect(result.isErr).toBe(true);
       if (result.isErr) expect(result.error.code).toBe("LoanNotFound");
+    });
+
+    // returnToOwner returns a Result; both close use cases must propagate a failure rather than
+    // silently swallow it and still report ok. Wrap the repo so the loaded copy fails to return.
+    const failingReturnCopies = (): InMemoryCopyRepository => {
+      const wrapped = copies;
+      return {
+        ...wrapped,
+        findById: async (id: CopyId) => {
+          const copy = await wrapped.findById(id);
+          if (copy) {
+            copy.returnToOwner = () => err(LibraryError.notOwner("return"));
+          }
+          return copy;
+        },
+      } as InMemoryCopyRepository;
+    };
+
+    it("propagates a returnToOwner failure on return (does not report ok)", async () => {
+      const result = await makeReturnLoan({
+        loans,
+        copies: failingReturnCopies(),
+        events,
+        clock: new FixedClock(LATER),
+      })({ loanId, actingMemberId: borrower });
+      expect(result.isErr).toBe(true);
+    });
+
+    it("propagates a returnToOwner failure on recall (does not report ok)", async () => {
+      const result = await makeRecallLoan({
+        loans,
+        copies: failingReturnCopies(),
+        events,
+        clock: new FixedClock(LATER),
+      })({ loanId, actingMemberId: owner });
+      expect(result.isErr).toBe(true);
     });
   });
 });

--- a/packages/domain/src/library/application/use-cases/recall-loan.ts
+++ b/packages/domain/src/library/application/use-cases/recall-loan.ts
@@ -23,7 +23,10 @@ export const makeRecallLoan =
     if (closed.isErr) return err(closed.error);
 
     const copy = await deps.copies.findById(loan.copyId);
-    if (copy) copy.returnToOwner(now);
+    if (copy) {
+      const returned = copy.returnToOwner(now);
+      if (returned.isErr) return err(returned.error);
+    }
     await deps.loans.save(loan);
     if (copy) await deps.copies.save(copy);
     await deps.events.publish([

--- a/packages/domain/src/library/application/use-cases/return-loan.ts
+++ b/packages/domain/src/library/application/use-cases/return-loan.ts
@@ -23,7 +23,10 @@ export const makeReturnLoan =
     if (closed.isErr) return err(closed.error);
 
     const copy = await deps.copies.findById(loan.copyId);
-    if (copy) copy.returnToOwner(now);
+    if (copy) {
+      const returned = copy.returnToOwner(now);
+      if (returned.isErr) return err(returned.error);
+    }
     await deps.loans.save(loan);
     if (copy) await deps.copies.save(copy);
     await deps.events.publish([


### PR DESCRIPTION
## Summary

Output of a multi-agent codebase analysis of JigSwap. It delivers **two new docs** and **resolves the security/quality findings** the review surfaced — all on one branch.

The analysis used `code-explorer` (functionality map across web / domain / contracts+gateway / Convex backend), then `feature-dev:code-reviewer` + `Code Reviewer` + `Security Architect` + `Application Security Engineer` for findings, `Document Generator` for the guides, and `Senior Developer` for the fixes.

## 📚 Documentation
- `docs/user-guide.md` — end-user guide: account, library, add/import, completions & goals, collections, insights, visibility, the lend/swap/trade exchange flow, discovery, and friend circles.
- `docs/developer-guide.md` — contributor guide: monorepo + hexagonal/DDD architecture, local setup, end-to-end data flow, conventions (testing/prettier/commits), and how-to recipes (new feature, bounded context, contract+gateway op, Convex function/table + codegen, web route, new language).

## 🔒 Fixes (one atomic commit each)

The dominant theme: **authorization existed only in the web route guards while the Convex functions were directly callable** via the gateway/client. Each fix mirrors the existing `requireMember` / `isAdmin` patterns and ships with updated tests.

**Access control / IDOR (critical→high)**
- `fix(catalog)`: enforce `isAdmin` server-side on moderation (approve/reject) + category taxonomy mutations and the pending-list query — previously any member could self-approve catalog submissions or edit the global taxonomy.
- `fix(catalog)`: restrict puzzle-definition edits to the original submitter or an admin.
- `fix(identity)`: `createOrUpdateUser` → `internalMutation` (was a public, unauthenticated account-takeover primitive); `updateUserProfile` now patches the authenticated member and no longer trusts a client-supplied `userId` (IDOR).
- `fix(exchange)`: `sendExchangeMessage` derives the sender from auth + party-checks (was sender-spoofable); `getUserExchanges` / `getExchangeById` / `getExchangeMessages` now require an authenticated party (were leaking trade history, prices, and private threads + partner emails).
- `fix(library)`: `getCollectionById` enforces owner-or-public visibility (private collections were readable by id).
- `fix(identity)`: remove `email` & `clerkId` from the shared `MemberView` (GDPR/PII leak across search, comments, social graph, exchanges); add a self-only `CurrentMemberView`; add `requireMember` to `getUserById` / `getUserByClerkId` / `searchUsers`.

**Correctness**
- `fix(exchange)`: `propose` verifies the recipient owns the requested copy (prevents spam proposals / unsettleable exchanges).
- `fix(custody)`: persist the copy id from the resolved row, removing ambiguous `_id` vs aggregateId semantics.

**Performance**
- `perf(backend)`: `.take(500)` cap on `browseOwnedPuzzles`; new `domainEvents.by_name` index + windowed query for the activity feed; new `exchanges.by_requested_copy` / `by_offered_copy` indexes for reservation checks (replacing full table scans).

**SSRF (puzzle import)**
- `fix(catalog)`: centralize `http(s)` + DNS public-host validation (`assertPublicUrl`) at the top of `extractFromUrl` so every fetcher tier sees a pre-validated host (the `ogie` primary previously did lexical-only checks).

## ⚠️ Deploy & follow-up notes
- The new Convex indexes require `convex deploy` to build them before they take effect at runtime (type-check is green; `convex codegen` can't run offline here).
- SSRF residual: `ogie`/`firecrawl` tiers don't re-validate redirect *hops* (only `browserStorePageFetcher` does). Noted in code as a recommended deeper follow-up.

## ✅ Verification
- `pnpm type-check`: **pass** (5/5 projects)
- `pnpm test`: **pass** — domain 1005, backend 325, web 36 (all green)
- New/updated tests cover the admin gate, party-access reads, PII-free views, and recipient-ownership rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
