### PR TITLE
feat(web): four landing-page redesign variants behind a live switcher

### DIFF
--- a/apps/web/src/components/marketing/variants/_briefs/architecture.md
+++ b/apps/web/src/components/marketing/variants/_briefs/architecture.md
@@ -1,0 +1,235 @@
+# Landing Variant System — Technical Theming & Layout Architecture
+
+**Audience:** frontend devs building the four landing variants (`playful`, `editorial`, `cozy`, `retro`) plus `original`.
+**Status:** authoritative. These rules are non-negotiable; the orchestrator owns the switcher/data foundation, you own the variant components inside the contract below.
+
+---
+
+## 0. Ground truth (what already exists — do not change)
+
+- Marketing tokens live in `apps/web/src/styles/marketing.css`, all `--mk-*` prefixed, derived from three seeds (`--mk-seed-primary #6048e8`, `--mk-seed-secondary #19c316`, `--mk-seed-accent #ec4899`).
+- Ramps `--mk-violet-50..900`, `--mk-green-50..700`, `--mk-pink-300..500`; surfaces `--mk-bg / --mk-card / --mk-muted`; text `--mk-text-strong / -body / -muted`; lines `--mk-border / --mk-input-border / --mk-ring`; shadows `--shadow-mk-xs..lg` + `--shadow-mk-brand`; easings `--ease-mk-out`, `--ease-mk-spring`; heading font `--font-mk-heading` ("Baloo 2"), body `--font-mk-sans`.
+- Dark mode rides the **`.dark` class** (next-themes). The ramps flip automatically because the engine re-points `--mk-soft`/`--mk-deep`/`--mk-ground`/`--mk-card-base` under `.dark` and everything is `color-mix()`-derived from the seeds.
+- Tailwind v4, **no config file**. Utilities like `bg-mk-card`, `text-mk-text-strong`, `font-mk-heading`, `shadow-mk-brand` exist because `marketing.css` exposes the tokens via `@theme inline`. The `inline` keyword is what lets the `.dark` cascade flip them at runtime — preserve that mechanism, never hardcode hex in components.
+- Containers: `1200px` (default) / `760px` (`narrow`) max-width, `px-6` gutters (`Container`). Section rhythm: `py-[clamp(56px,8vw,104px)]` (`Section`). Mobile breakpoint convention across the marketing tree is **`max-[860px]` / `min-[861px]`** (one hard breakpoint, not Tailwind's `md`).
+- Fonts are loaded once in `apps/web/src/routes/__root.tsx` as Google Fonts `<link>` stylesheets (Baloo 2 + Poppins), with `preconnect` to `fonts.googleapis.com` / `fonts.gstatic.com`.
+
+The whole point of this system: **components stay written against `--mk-*`. A variant re-skins the page by redeclaring `--mk-*` (and adding `--v-*`) inside its `.v-<id>` scope — never by editing the global token file.**
+
+---
+
+## 1. Per-variant token scoping (THE core rule)
+
+### 1.1 The pattern
+
+Each variant root carries `class="v-<id>"` (orchestrator contract) and imports its own `<id>.css`. Inside that CSS you **redeclare the `--mk-*` tokens you want to change** on the `.v-<id>` selector. Because every shared component (`Button`, `Section`, `Reveal`, headers, cards) reads `--mk-*` through `var()`, those components instantly re-skin with zero component edits — same cascade trick the `.dark` class uses, one scope deeper.
+
+Two layers of tokens:
+
+- **Re-point `--mk-*`** to change what existing shared components render (palette, surfaces, border, ring, shadows, heading font).
+- **Add new `--v-*`** for variant-only concepts that have no `--mk-*` equivalent (display font, paper grain opacity, hero blob colors, custom radii scales, texture seeds). Variant-private styling reads `--v-*`.
+
+**Rules:**
+1. Never edit `marketing.css` or `globals.css` to theme a variant. All overrides live under `.v-<id>` in `<id>.css`.
+2. Re-point tokens by re-deriving from seeds where possible (`color-mix(... var(--mk-seed-*) ...)`) so the warm/cool relationships stay coherent; only drop to literal hex for a deliberately off-brand palette (retro, cozy).
+3. Dark mode for a variant is handled with **`.dark .v-<id> { ... }`** — you must provide it for every token you changed whose light value won't survive on a dark ground. If you only shift hues (not lightness grounds) you may inherit the global `.dark` flip; if you set literal surface hex you MUST supply the `.dark .v-<id>` counterpart.
+4. Keep `--mk-ring` meaningful (focus visibility) and keep `--mk-text-*` at AA contrast against your new `--mk-bg`/`--mk-card` (see §5).
+
+### 1.2 Concrete example — `cozy` (`cozy.css`)
+
+```css
+/* apps/web/src/components/marketing/variants/cozy/cozy.css
+   Cozy / Hygge: warm amber-terracotta palette, soft cream surfaces,
+   humanist display type, generous radii. Re-points --mk-* so shared
+   Button/Section/cards turn warm with no component changes. */
+
+.v-cozy {
+  /* --- Re-seed the engine toward warm (keeps ramp relationships) --- */
+  --mk-seed-primary: #c2683d;   /* terracotta — replaces violet as "brand" */
+  --mk-seed-secondary: #7d8b5a; /* sage/olive — replaces go-green */
+  --mk-seed-accent: #d9a441;    /* honey — replaces pink */
+
+  /* --- Warm grounds (literal: a cream page, not a tinted white) --- */
+  --mk-ground: #f6ede0;
+  --mk-card-base: #fffaf2;
+  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 5%, var(--mk-ground));
+  --mk-card: color-mix(in oklab, var(--mk-seed-primary) 3%, var(--mk-card-base));
+  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 8%, #efe2d0);
+
+  /* --- Warm-neutral ink (still AA on cream) --- */
+  --mk-text-strong: #2e2117;
+  --mk-text-body: #4a3a2c;
+  --mk-text-muted: #8a7560;
+
+  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 16%, #e6d6c2);
+  --mk-ring: var(--mk-seed-primary);
+
+  /* --- Softer, warmer shadows than the cool-neutral --shadow-mk-* --- */
+  --shadow-mk-md: 0 6px 18px -4px rgb(120 70 30 / 0.16);
+  --shadow-mk-lg: 0 16px 36px -8px rgb(120 70 30 / 0.20);
+  --shadow-mk-brand: 0 10px 30px -8px rgb(194 104 61 / 0.34);
+
+  /* --- Re-point heading font + variant-only display/texture tokens --- */
+  --mk-radius-card: 22px;                       /* used by variant CSS */
+  --v-font-display: "Fraunces", Georgia, serif; /* humanist display */
+  --v-paper-warmth: 0.06;                       /* gradient/texture intensity */
+
+  /* Make shared components read the variant display where headings appear: */
+  --font-mk-heading: var(--v-font-display);
+}
+
+/* Dark cozy: candle-lit, not black. Re-derive grounds; ink goes warm-light. */
+.dark .v-cozy {
+  --mk-ground: #221913;
+  --mk-card-base: #2c211a;
+  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 10%, var(--mk-ground));
+  --mk-card: color-mix(in oklab, var(--mk-seed-primary) 8%, var(--mk-card-base));
+  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 12%, #2e231b);
+  --mk-text-strong: #f4e9da;
+  --mk-text-body: #e4d4c2;
+  --mk-text-muted: #b39e88;
+  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 18%, #3a2c22);
+}
+```
+
+Same skeleton for the other three. Brief palette intent per variant:
+
+- **`playful`** — keep close to the real seeds (it IS the premium brand mood), but boost saturation, add `--v-font-display` rounded display, larger `--mk-radius-*`, springier motion via `--ease-mk-spring`. Mostly additive; minimal `.dark .v-playful` needed (inherit global flip).
+- **`editorial`** — near-monochrome ink-on-paper: `--mk-bg`/`--mk-card` to bright off-white/near-black, ONE high-chroma accent (re-point `--mk-seed-accent` to a single editorial red/violet), giant high-contrast display via `--v-font-display`. Must supply `.dark .v-editorial`.
+- **`cozy`** — warm example above.
+- **`retro`** — nostalgic muted board-game palette (mustard/teal/brick/cream), literal hex grounds, slab/vintage `--v-font-display`, paper grain tokens. Must supply `.dark .v-retro` (dim the paper, keep the grain).
+
+---
+
+## 2. Typography architecture
+
+### 2.1 Loading mechanism (matches the existing pattern)
+
+Each variant introduces ONE display typeface, exposed as `--v-font-display` and wired into headings by re-pointing `--font-mk-heading` (see §1.2). Two allowed loading strategies — **prefer self-host for the variant displays**:
+
+- **Preferred — self-host via `@font-face` in `<id>.css`** with `font-display: swap` and a local woff2 placed under `apps/web/src/components/marketing/variants/<id>/fonts/`. (NOTE: the brief forbids binary assets in THIS spec's deliverables, but production self-hosting is the recommended path; if you cannot add binaries yet, fall back to Google Fonts.)
+- **Fallback — Google Fonts `@import`** at the top of `<id>.css`: `@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..700&display=swap");`. Acceptable, but the `@import` blocks until fetched and adds a request chain — only one weight axis range per variant.
+
+Do **not** add variant fonts to `__root.tsx` — that would load all four variants' faces on every page. Variant fonts load only when the variant CSS is imported by the variant component.
+
+### 2.2 CLS / perf guardrails (mandatory)
+
+- Always `font-display: swap` (self-host) or `&display=swap` (Google). Never `block`.
+- Always declare a metric-compatible fallback in `--v-font-display` (e.g. `"Fraunces", Georgia, serif`) so the swap reflow is minimal.
+- Add `size-adjust` / `ascent-override` on self-hosted `@font-face` where the display face differs a lot from its fallback (editorial's huge type makes CLS most visible there).
+- One display family per variant, narrowest weight range that covers the design. Editorial may load two weights (e.g. 400 + 800) max.
+- Headings use `--v-font-display`; **body text stays on `--font-mk-sans`** in every variant (readability + no second web font). Exception: retro may set body to a system slab stack with no extra download.
+
+### 2.3 Suggested typefaces
+
+| Variant | Display intent | Suggested `--v-font-display` |
+|---|---|---|
+| `playful` | rounded, friendly, premium | `"Baloo 2"` (already loaded) or `"Quicksand"` |
+| `editorial` | high-contrast expressive display | `"Fraunces"` (opsz) or a grotesque like `"Space Grotesk"` |
+| `cozy` | humanist, warm, soft serif | `"Fraunces"` soft / `"Newsreader"` |
+| `retro` | slab / vintage / board-game | `"Bitter"`, `"Rokkitt"`, or a chunky slab |
+
+Reusing **Baloo 2 for `playful`** costs zero extra bytes (already in `__root.tsx`).
+
+---
+
+## 3. Layout & responsive contract (all variants honor)
+
+Distinct layouts are encouraged; the shared skeleton that keeps them coherent is not optional.
+
+- **Container widths:** content max-width ≤ `1200px`, reading columns `760px`. You may go full-bleed for hero/texture bands, but text blocks must respect these maxes. Reuse `Container` (`max-w-[1200px] mx-auto px-6`) or replicate its gutters exactly (`px-6`, never less than 16px on mobile).
+- **Section rhythm:** vertical padding `clamp(56px, 8vw, 104px)` (reuse `Section`, or match it). Editorial may use asymmetric/looser rhythm but stay within `clamp(40px, …, 140px)`.
+- **Fluid type & spacing:** size headings/spacing with `clamp()`, never fixed px that can't shrink. Reference: existing display is `clamp(28px,4vw,40px)`; editorial may push the hero to `clamp(40px, 9vw, 112px)`. Always set a sane min so mobile never overflows.
+- **One breakpoint:** honor `max-[860px]` / `min-[861px]` as the primary desktop↔mobile switch (consistent with header/footer). Use `max-[540px]` only for a further single-column collapse (footer already does this). Don't introduce a parallel `md:`/`lg:` ladder.
+- **Overflow safety:** the page root uses `overflow-x-clip`; any rotated/oversized decorative element (editorial bleeds, retro stickers) must not create horizontal scroll. Test at 320px.
+- **Header/footer coherence:** whatever the body layout, the page must open with a header landmark and close with a footer landmark at the standard container width so the chrome reads as the same product (see §4 for swapping).
+
+---
+
+## 4. Reuse vs rebuild
+
+Default to **reuse**. Rebuild only when the variant's identity demands it, and keep the same data + landmarks.
+
+| Piece | Default | Notes |
+|---|---|---|
+| `useLandingData()` (`{ stats, communityAvatars, plankPuzzles }`) | **Reuse always** | Single source of truth. Never re-fetch Convex directly in a variant. |
+| `useStartHref()` | **Reuse always** | Primary CTA href. |
+| `Container` | Reuse (or match its widths/gutters) | |
+| `Section` / `Eyebrow` / `SectionHead` | Reuse for standard bands; rebuild for editorial/retro custom rhythm | If you rebuild, match the `clamp()` rhythm in §3. |
+| `Reveal` | **Reuse always** | It's SSR-safe, base-visible, and already respects reduced-motion. Don't hand-roll scroll reveals. |
+| `MarketingHeader` / `MarketingFooter` | Reuse by default | They read `--mk-*`, so they re-skin automatically under `.v-<id>`. |
+| `JigPlank3D` (Three.js plank) | Reuse for `playful` hero (its signature interactive moment); optional elsewhere | Heavy + interactive — see §5 reduced-motion + lazy-load. `editorial`/`cozy`/`retro` should prefer their own hero (flat illustration / photo-gradient / paper diorama). |
+| `Wordmark`, `PieceMotif` | Reuse freely | Inherit `--mk-*`. |
+| `Button` (shadcn, `brand` variant) | Reuse | `brand` variant uses `--shadow-mk-brand` etc., re-skins automatically. |
+
+**Swapping header/footer:** if a variant needs different chrome (e.g. editorial wants a hairline serif header), build `variants/<id>/header.tsx` / `footer.tsx` and render those inside the variant root **instead of** importing the shared ones. Requirements when you do:
+- Keep semantic `<header>` / `<footer>` landmarks and the same nav destinations (the shared `NAV` list and auth `Button`s).
+- Keep the light/dark `ModeToggle` and the `LangToggle` (do not drop i18n/theme controls).
+- Style via `--mk-*` / `--v-*` only.
+- The floating variant switcher is injected by the orchestrator at the app shell level — variants must not render or block it, and must not use `position: fixed` elements that cover its corner.
+
+---
+
+## 5. Accessibility & motion guardrails
+
+- **Contrast (AA, 4.5:1 body / 3:1 large text):** the warm-on-warm (cozy, retro) and huge-type (editorial) variants are the risk zones. After re-pointing `--mk-bg`/`--mk-card`, verify `--mk-text-body` and `--mk-text-muted` against them; `-muted` is the usual failure. Editorial's accent-on-paper must clear 4.5:1 for any accent-colored body text (accent is fine for large display only).
+- **Focus states:** keep `--mk-ring` set to a hue with ≥3:1 against the variant surface; never remove focus outlines. Shared `Button`/links already use it — don't override `outline: none` without a replacement ring.
+- **prefers-reduced-motion:** any "delightful interactive hero moment" (playful's plank, editorial parallax, retro tilt/sticker physics) MUST degrade to a static, fully-legible state under `@media (prefers-reduced-motion: reduce)`. `Reveal` already handles this for scroll-ins; you handle it for bespoke hero motion. The 3D plank: gate auto-spin/drag-idle animation on the media query, and lazy-load it (`React.lazy` / dynamic import) so reduced-motion + slow devices aren't forced to download Three.js eagerly.
+- **Semantic landmarks:** exactly one `<header>`, one `<main>`, one `<footer>` per variant; section headings in order (`h1` once in the hero, `h2` per section). Asymmetric editorial layout must keep DOM order = reading order (don't reorder headings purely with CSS grid placement).
+- **Interactive targets:** ≥44px hit area for CTAs/toggles, even when the visual chip is smaller.
+- **Motion budget:** decorative loops (floating motifs, grain shimmer) must pause/stop under reduced-motion and must not run off-screen.
+
+---
+
+## 6. Texture & asset strategy (pure CSS/SVG — no binary assets)
+
+No real photography or raster textures are required or permitted as binaries here. Achieve atmosphere with CSS gradients + inline SVG (data-URI) filters.
+
+### 6.1 Cozy — photo-warmth fallback
+
+Simulate a photographed warm scene with layered radial/linear gradients reading off `--v-paper-warmth` and the warm seeds:
+
+```css
+.v-cozy .hero-photo-fallback {
+  background:
+    radial-gradient(60% 70% at 20% 15%,
+      color-mix(in oklab, var(--mk-seed-accent) 40%, transparent), transparent 70%),
+    radial-gradient(55% 65% at 85% 10%,
+      color-mix(in oklab, var(--mk-seed-primary) 28%, transparent), transparent 72%),
+    linear-gradient(160deg,
+      color-mix(in oklab, var(--mk-seed-accent) 14%, var(--mk-card)),
+      var(--mk-bg));
+}
+```
+
+Add a subtle "film grain" via an inline SVG `feTurbulence` mask at low opacity (`var(--v-paper-warmth)`), so the gradient reads less flat. If a real photo is later supplied, it drops in over this same box as a progressive enhancement — keep the gradient as the SSR/no-image baseline.
+
+### 6.2 Retro — paper grain / board-game box
+
+Generate paper fibre + a faint print misregistration with inline SVG `feTurbulence` + `feColorMatrix`, tiled as a `background-image: url("data:image/svg+xml,...")`, multiplied over the muted retro surface:
+
+```css
+.v-retro .paper {
+  background-color: var(--mk-card);
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.05'/></svg>");
+  background-blend-mode: multiply;
+}
+```
+
+- Keep grain opacity ≤ ~0.06 light / ≤ ~0.09 dark; it must never drop text contrast below AA.
+- Board-game "box edge" = CSS `border` + layered `box-shadow` + a slight `border-radius`, not an image.
+- Stickers/stamps = inline SVG shapes or text in `--v-font-display`, rotated with `transform`, kept inside the overflow-clip (§3).
+- Honor reduced-motion: any grain shimmer/animation stops; the static grain stays.
+
+---
+
+## Non-negotiable summary (read this if nothing else)
+
+1. **Theme by scope, not by edit.** Re-skin only by redeclaring `--mk-*` / adding `--v-*` inside `.v-<id>` in `<id>.css`; never touch `marketing.css` or `globals.css`. Components stay written against `--mk-*`.
+2. **Dark mode is `.dark .v-<id>`.** If you set literal surface colors, you MUST supply the dark counterpart; keep `--mk-text-*` at AA on your new grounds.
+3. **One display font per variant**, exposed as `--v-font-display`, wired via `--font-mk-heading`, loaded only in the variant CSS (never `__root.tsx`), `font-display: swap` + metric fallback; body stays on `--font-mk-sans`.
+4. **Honor the layout contract:** ≤1200/760px content, `clamp(56px,8vw,104px)` rhythm, `clamp()` type, the single `max-[860px]/min-[861px]` breakpoint, and no horizontal overflow at 320px.
+5. **Reuse `useLandingData()`, `useStartHref()`, and `Reveal` always**; reuse header/footer unless you rebuild them with the same landmarks, nav, theme + lang toggles, and `--mk-*` styling.
+6. **Accessibility is a gate:** AA contrast (watch warm-on-warm + editorial accent text), visible `--mk-ring` focus, one h1, ordered landmarks, ≥44px targets; every bespoke hero animation degrades fully under `prefers-reduced-motion` and the 3D plank lazy-loads.
+7. **Textures are pure CSS/SVG** (gradients + inline `feTurbulence`), no binary assets; grain opacity must never break text contrast.

--- a/apps/web/src/components/marketing/variants/_briefs/research.md
+++ b/apps/web/src/components/marketing/variants/_briefs/research.md
@@ -1,0 +1,226 @@
+# JigSwap Landing-Page Redesign — Content & UX Strategy Briefs
+
+**For:** UI designers + frontend developers building three landing-page variants.
+**Author:** UX Researcher
+**Date:** 2026-06-17
+
+---
+
+## 0. Shared context (read first)
+
+These facts are grounded in the real product and codebase, not assumptions. Copy below is meant to be pasted near-verbatim; where it differs from current strings, it is an intentional rewrite.
+
+**Product in one breath:** A personal puzzle library + community exchange for jigsaw enthusiasts. You shelve your puzzles, then lend / swap / share them, and always see who currently holds your lent-out boxes (custody tracking). Sustainability angle: give a finished puzzle a second, third, fourth life instead of leaving it in the attic. A warm Dutch family side-project, born 2025, now open to the wider community.
+
+**Real assets that exist today (use these, don't invent):**
+
+- **Live Convex metrics** — three real numbers, surfaced via `gateway.insights.globalStats`: puzzlers signed up (`totalUsers`), puzzles in catalog, puzzles on shelves. These are the single strongest credibility lever and they are REAL. Never fabricate counts (e.g. the old prototype's "4.200+" was removed for this reason).
+- **Live community avatars** — `gateway.insights.communityAvatars` returns real member initials/photos; decorative fallbacks exist for empty/loading states.
+- **Live plank puzzles** — `gateway.insights.plankPuzzles` feeds the 3D shelf with real catalog covers (falls back to themed Dutch placeholder boxes: "Boslicht", "Amsterdam", "De Nachtwacht", etc.).
+- **Founders' quote** — honest family note, already written: *"We built JigSwap because our finished puzzles deserved better than the attic — and because puzzling is more fun when you share it."* — *The family behind JigSwap, puzzling at the kitchen table since 2025.*
+- **One real cover photo** — `assets/cover-sand.webp` ("Zandsculpturen"). **There are NO real lifestyle photos** (no rainy-day, coffee, family-table photography). The Cozy variant MUST treat this as a constraint, not assume a photo library exists.
+
+**Design tokens already in the system** (`marketing.css`, all `--mk-*`):
+
+- Three brand seeds: violet `#6048e8` ("Jig" / signature), green `#19c316` ("Swap" / go), pink `#ec4899` (playful highlight). Full 50–900 ramps derived from these.
+- Surfaces are faintly violet-tinted cool neutrals (`--mk-bg`, `--mk-card`, `--mk-muted`). Light + dark via `.dark` class.
+- Type: **Baloo 2** rounded for headings (warm, friendly), system-sans for body.
+- Motion easings: `--ease-mk-out` (quick), `--ease-mk-spring` (bouncy). Brand glow helper `.mk-hero-glow`. Brand CTA shadow `--shadow-mk-brand` (violet glow).
+
+**Baseline section list we're moving away from (generic SaaS):** sticky header → 3D puzzle-plank hero w/ frosted callout + CTAs + trust row → stats strip → 3-step "how it works" teaser → three alternating feature rows (Library / Lend & Track / Discover) → sustainability band → founders' quote → final gradient CTA → footer. Primary CTA "Start trading", secondary "See the features".
+
+**The non-negotiable:** the three variants must end up DRASTICALLY different — different emotional target, different section lists (not the same sections reskinned), different copy voice, different visual logic. A reviewer should never confuse a screenshot of one for another.
+
+**Accessibility baseline (applies to all three — default requirement):**
+
+- Brand violet `#6048e8` on white passes AA for large text but is borderline for body; never set body copy in raw violet on light surfaces — use `--mk-text-body` / `--mk-text-strong`.
+- Every "one delightful moment" / animation must respect `prefers-reduced-motion` and degrade to a static, fully legible state.
+- The 3D plank and all motif art are decorative (`aria-hidden`), so headline + CTA + stats must carry the full meaning for screen-reader and no-JS users.
+- Live stats need an accessible loading state (don't announce empty/zero); avatars are decorative and already `aria-hidden`.
+- Target AA contrast minimum on all text over imagery/gradients via scrims, exactly as the current hero does.
+
+---
+
+# VARIANT 1 — Playful-Premium
+
+> Reference energy: Duolingo, Notion, Headspace. Friendly puzzle-piece personality on a clean, confident, whitespace-rich structure, with ONE delightful interactive moment in the hero.
+
+## Emotional target & positioning
+**Feel in 3 seconds:** "Oh, this is friendly *and* trustworthy — and that was fun." Warmth of community + safety of lending something you value + one memorable hook.
+**One-line positioning:** *The friendly home for your puzzles — shelve them, share them, and always know where they are.*
+
+## Messaging hierarchy
+Value-prop order: **(1) delight/personality hook → (2) the core loop (shelve → share → track) → (3) trust (custody + live community) → (4) sustainability as the warm "why".**
+
+Headline options (pick one, real copy):
+1. **"Your puzzles, but make them social."** / Subhead: *Shelve every box, lend to fellow puzzlers, and always see who's got it. Free to start.*
+2. **"Give every puzzle a second life — and a few new friends."** / Subhead: *Build your shelf, swap with the community, track every box you lend out.*
+3. **"Puzzles are better passed around."** / Subhead: *A friendly library for your jigsaws: lend, swap, and never lose track of a box.*
+
+(Recommended: #1 for the playful-but-clear hook; #3 if the team wants maximum warmth.)
+
+## The ONE delightful interactive moment (hero)
+A single **draggable puzzle piece** that snaps into a piece-shaped notch in the headline lockup (the missing piece in "puzzles"). On drop it snaps with `--ease-mk-spring`, emits a tiny confetti of 3–4 brand-colored mini-pieces, and the live stat counter ticks up once. One moment only — do not gamify the whole page.
+- **Reduced-motion / no-JS fallback:** the piece is already snapped in place; no drag affordance shown.
+- Reuse `PieceMotif` + spring easing already in the codebase. Keep the rest of the hero calm and whitespace-rich so this moment stands out.
+
+## Section list & order
+1. Sticky header (keep — minimal, add a subtle piece-dot logo flourish)
+2. **Hero** — clean, generous whitespace, the draggable-piece moment, headline + subhead + CTAs + live trust row (KEEP 3D plank but dial it back to a softer, smaller supporting element so the hero feels calmer than baseline)
+3. **Live stats strip** — KEEP, but restyle as three friendly "stat pills" with a gentle count-up on scroll
+4. **"How it works" — 3 steps** KEEP (Fill your shelf → Discover & request → Lend & track), as playful illustrated cards
+5. **Custody/peace-of-mind spotlight** ADD — a small, focused module: "Always know who has your box." This is the trust differentiator and deserves its own beat in this variant.
+6. Sustainability band KEEP — warm, light
+7. Founders' quote KEEP — the human anchor
+8. Final CTA KEEP — friendly, confident
+9. Footer
+
+**CUT from baseline:** the three heavy alternating feature rows (Library / Lend & Track / Discover) — they read as generic SaaS and fight the whitespace goal. Fold their essence into the 3-step "how it works" + the custody spotlight instead.
+**Why:** Duolingo/Notion energy = one clear loop, lots of air, one delight — not a feature wall.
+
+## CTAs
+- Primary: **"Start your shelf"** (warmer + more concrete than "Start trading"; implies zero-friction ownership)
+- Secondary: **"See how it works"**
+
+## Trust & credibility signals
+Lead on **live community avatars + the live count** ("{count} puzzlers are already swapping") right under the CTAs — real people, real numbers, friendly framing. Reinforce with the **custody spotlight** (you'll always know who has your box = safe to lend). Founders' story as the warm closer. Keep sustainability as the feel-good "why", not the lead.
+
+## Microcopy voice notes
+- Drag hint caption: *"Pop the last piece in →"*
+- Stat pill label: *"puzzles on shelves right now"*
+- Empty-shelf-style delight (for a future product hook, sets tone): *"Your shelf's a little quiet. Add your first box and let the swapping begin."*
+- Button on hover / success microcopy: *"Nice — that's the spirit 🧩"*
+
+## Differentiation risk to avoid
+**Don't let "playful" tip into childish or gimmicky.** The audience lends valuables; the page must still feel premium and safe. One delight moment, restrained color, lots of whitespace. If the confetti or the piece-snapping shows up more than once on the page, you've broken the brief.
+
+---
+
+# VARIANT 2 — Bold / Editorial
+
+> A design-magazine cover for a puzzle community. Big expressive typography, asymmetric magazine layouts, high visual personality.
+
+## Emotional target & positioning
+**Feel in 3 seconds:** "Whoa — this puzzle thing has *taste* and a point of view." Confident, characterful, culturally aware. Puzzling as a craft and a community worth belonging to.
+**One-line positioning:** *Puzzling, redrawn — a bold home for the people who love finishing them and passing them on.*
+
+## Messaging hierarchy
+Value-prop order: **(1) a strong editorial statement / manifesto line → (2) the live numbers as the "issue stats" → (3) the loop told as a narrative → (4) sustainability as the conviction → (5) community as the masthead.**
+
+Headline options (real copy, set HUGE):
+1. **"LEND. SWAP. SHARE."** as three stacked oversized words, each a different brand seed color, with subhead: *A library for jigsaw people. Build your shelf, pass your puzzles on, never lose a box.*
+2. **"The attic was a terrible place to keep a masterpiece."** / Subhead: *JigSwap is where finished puzzles get a second life — and a community to share them with.*
+3. **"1,000 pieces. One shelf. A whole community."** / Subhead: *Catalogue your jigsaws, lend them out, swap for new ones, and track every box.*
+
+(Recommended: #1 for pure editorial impact — it weaponizes the existing "Lend • Swap • Share" tagline as typographic art; #2 if the team wants a sharper, opinionated voice.)
+
+## Section list & order (asymmetric, magazine grid)
+1. **Editorial masthead header** — wordmark left, a thin "Issue No. / est. 2025 / Netherlands" rule, nav right. Sets the magazine frame immediately.
+2. **Hero / cover** — oversized stacked type, asymmetric: type hard-left, the 3D plank bleeding off the right edge as the "cover image". KEEP the 3D plank but crop/bleed it editorially rather than centering it.
+3. **Big-number band** ADD/REFRAME — the three live stats rendered as enormous editorial figures ("4 ⁄ 312 ⁄ 89" treatment), each with a one-word caption. This replaces the polite baseline stats strip.
+4. **Manifesto block** ADD — a single large pull-quote stating the conviction: puzzles deserve a second life, sharing beats hoarding. Sets JigSwap apart from a generic tool.
+5. **The loop, as numbered editorial spreads** — Fill your shelf / Discover & request / Lend & track, but as three asymmetric full-bleed-ish "articles" with big numerals 01 / 02 / 03, alternating left/right.
+6. **Custody feature, editorial** — "Who has your box?" as a confident standalone spread with a typographic diagram (box → person → back to you).
+7. Founders' quote KEEP — reframed as an editorial "letter from the founders".
+8. **Closing cover / CTA** — big-type sign-off.
+9. Editorial footer (colophon style).
+
+**CUT from baseline:** the soft frosted-glass hero callout (too gentle for editorial — let raw type carry it) and the three polite alternating feature rows (replaced by the numbered editorial spreads). The sustainability band becomes the manifesto block rather than a quiet side section.
+**ADD:** big-number band, manifesto pull-quote, colophon footer.
+**Why each variant differs:** this one is structurally type-led and asymmetric where Playful-Premium is centered and calm.
+
+## CTAs
+- Primary: **"Get on the shelf"** (confident, a little cheeky, on-brand for editorial voice)
+- Secondary: **"Read how it works"** (the "read" verb reinforces the magazine frame)
+
+## Trust & credibility signals
+Lead on the **live numbers rendered as bold editorial figures** — credibility through scale and confidence, not badges. The **founders' "letter"** carries authenticity (real family, est. 2025, Netherlands — lean into the place and the date as editorial detail). Community avatars become a small "contributors" row in the colophon. Sustainability = stated conviction, not a soft band.
+
+## Microcopy voice notes
+- Eyebrow / kicker: *"Est. 2025 · Made at a Dutch kitchen table"*
+- Big-number caption: *"puzzles in circulation"*
+- Section kicker: *"No. 03 — Lend & Track"*
+- Sign-off line above CTA: *"Stop hoarding masterpieces. Start a shelf."*
+
+## Differentiation risk to avoid
+**Don't let editorial become unreadable or cold.** Huge type + asymmetry can wreck mobile legibility and hierarchy. Enforce a real reading order on small screens (stack, don't shrink), keep body copy on `--mk-text-body` at readable sizes, and keep the *warmth* — the family/kitchen-table soul must survive the bold treatment, or it reads as a cold agency template, not a puzzle community.
+
+---
+
+# VARIANT 3 — Cozy / Hygge (lifestyle)
+
+> Photography-led, warm tones, the FEELING of puzzling: rainy day, coffee, family table. Emotionally resonant, easy to trust.
+
+## Emotional target & positioning
+**Feel in 3 seconds:** "This feels like home — a calm, warm corner where puzzling and people live." Belonging, comfort, gentle trust.
+**One-line positioning:** *A warm little corner for your puzzles and the people you share them with.*
+
+## CRITICAL constraint — no real lifestyle photos exist
+There is exactly one cover photo (`cover-sand.webp`) and NO rainy-day/coffee/family-table photography. The variant must look intentional **without** real photos:
+
+- **Mark every photographic slot explicitly** as `[PHOTO PLACEHOLDER: warm rainy-window puzzling scene]` so devs and a future photographer know exactly what goes where.
+- **CSS-driven warm fallbacks** so it ships looking deliberate today:
+  - Warm gradient grounds — shift the cool violet `--mk-bg` toward amber/terracotta for this variant only (e.g. `color-mix` of `--mk-warning` / a warm sand tone into the ground), so surfaces read like lamplight, not screen-blue.
+  - **Grain / paper texture overlay** (subtle CSS noise or an SVG `feTurbulence` layer at low opacity) to kill the flat-digital feel.
+  - **Soft duotone treatment spec** for whenever a real photo lands: warm-shadow / cream-highlight duotone so future photography auto-matches the mood.
+  - Generous rounded corners (`rounded-3xl`+), soft long shadows, layered translucency = the "blanket" feeling.
+  - The existing `cover-sand.webp` can anchor one hero corner as the single real photographic touch.
+
+## Messaging hierarchy
+Value-prop order: **(1) the feeling / belonging → (2) the gentle promise (shelve + share + always know where it is) → (3) trust through warmth + real community → (4) sustainability as the cozy, values-led close.**
+
+Headline options (real copy, warm + soft):
+1. **"Slow afternoons, shared puzzles."** / Subhead: *Keep your jigsaws in one cozy place, lend them to fellow puzzlers, and always know where each box is.*
+2. **"Every puzzle deserves another rainy afternoon."** / Subhead: *Shelve your boxes, share them with the community, and give finished puzzles a second life.*
+3. **"Pull up a chair. Bring your puzzles."** / Subhead: *A warm home for your jigsaw collection — lend, swap, and share with people who love them as much as you do.*
+
+(Recommended: #2 — it fuses the cozy feeling with the real sustainability angle in one line; #1 for the softest, most lifestyle read.)
+
+## Section list & order
+1. Header — soft, warm, low-contrast, no sticky urgency
+2. **Hero** — `[PHOTO PLACEHOLDER: hands placing a puzzle piece, warm window light, coffee mug]` with the warm gradient + grain fallback; soft headline lockup overlaid bottom-left. CUT the 3D plank here — it's cool and techy and fights the hygge feeling; replace with photo/treatment. (This is a deliberate, visible divergence from the other two variants, which both keep the plank.)
+3. **A warm "moment" strip** ADD — a single soft line + small live count: *"{count} puzzlers gathered round the table."* Stats stay, but de-emphasized and humanized (no big SaaS numbers).
+4. **"How sharing feels" — the loop as gentle vignettes** — Fill your shelf / Share & borrow / Always know where it is, each a small `[PHOTO PLACEHOLDER]` + warm caption, soft and unhurried.
+5. **Sustainability — promoted to a hero-weight emotional section** ADD emphasis — "second life" is the heart of cozy/values storytelling here, not a side band. `[PHOTO PLACEHOLDER: a puzzle being handed from one person to another]`.
+6. Founders' quote KEEP — perfect fit; render as a handwritten-feeling note on a card with grain.
+7. **Gentle final CTA** — warm, no pressure.
+8. Soft footer.
+
+**CUT from baseline:** the 3D plank hero (replaced by photo/treatment), the polite stats strip as a numbers-forward block (humanized into the "moment" strip), and the three alternating feature rows (replaced by warm vignettes).
+**ADD:** photo-placeholder system + CSS warm/grain treatment, promoted sustainability section, humanized count line.
+**Why:** this is the only photography-led, plank-free, warm-toned variant — structurally and tonally it cannot be confused with the other two.
+
+## CTAs
+- Primary: **"Find your puzzle people"** (belonging-led; warmer than transactional "trade")
+- Secondary: **"Take a look around"** (gentle, low-commitment)
+
+(Alt primary if a more direct ask is wanted: **"Start your cozy shelf"**.)
+
+## Trust & credibility signals
+Lead on **warmth + the real founders' story** (a real family, kitchen table, 2025 — this IS the trust in a cozy frame). Soften the live stats into a human sentence rather than big figures. Real community avatars shown small and warm ("the people round the table"). Custody/"always know where your box is" framed as *reassurance and care*, not security/tracking — comfort, not surveillance. Sustainability framed as shared values you belong to.
+
+## Microcopy voice notes
+- Hero caption / kicker: *"Rainy-day approved · since 2025"*
+- Count line: *"{count} puzzlers gathered round the table"*
+- Custody reassurance: *"Lent it out? You'll always know whose table it's on."*
+- Cozy empty-state-style delight (tone-setter): *"Kettle's on. Add your first puzzle whenever you're ready."*
+
+## Differentiation risk to avoid
+**Don't let cozy feel stocky, fake, or saccharine** — and specifically don't let the missing photos make it look unfinished. Because there are no real lifestyle photos, sloppy stock-style placeholders or flat gray boxes will instantly read as "broken/unstyled". The grain + warm-gradient + duotone fallback system is what keeps it intentional. Also avoid over-sweet copy that undercuts the lending-valuables trust — keep one or two concrete, grounded lines (piece counts, "always know where your box is") so it stays believable, not greeting-card.
+
+---
+
+## Cross-variant differentiation summary (at a glance)
+
+| | Playful-Premium | Bold/Editorial | Cozy/Hygge |
+|---|---|---|---|
+| Feeling | friendly + premium + a hook | confident, characterful, taste | belonging, warmth, calm |
+| Layout logic | centered, whitespace-rich | asymmetric magazine grid | photo-led, layered, soft |
+| 3D plank | kept, dialed back | kept, cropped/bleeding | CUT (photo/treatment instead) |
+| Type | rounded Baloo, calm | oversized, expressive | soft, warm, handwritten accents |
+| Color | brand violet/green/pink, airy | high-contrast brand seeds as art | warm amber/terracotta shift + grain |
+| Hero hook | ONE draggable piece moment | huge stacked "LEND. SWAP. SHARE." | warm photo placeholder + light |
+| Stats | friendly count-up pills | enormous editorial figures | humanized one-line sentence |
+| Primary CTA | "Start your shelf" | "Get on the shelf" | "Find your puzzle people" |
+| Trust lead | avatars + live count + custody | big numbers + founders' letter | founders' story + warmth |
+| Top risk | childish/gimmicky | unreadable/cold | stocky/fake/unfinished |

--- a/apps/web/src/components/marketing/variants/cozy/cozy.css
+++ b/apps/web/src/components/marketing/variants/cozy/cozy.css
@@ -1,6 +1,280 @@
 /* Cozy/Hygge variant — scoped styles under `.v-cozy`.
- * Warm palette, soft shadows, lifestyle treatment. Redeclare `--mk-*` / add
- * `--v-*` custom properties here. Replaced/expanded by the Frontend Developer. */
+ * Warm amber/terracotta re-seed, soft cream surfaces, humanist soft serif
+ * (Fraunces) display, generous radii, gentle grain + warm photo-fallback.
+ * Everything below lives ONLY under `.v-cozy` / `.dark .v-cozy` — no global
+ * token file is touched, so shared Button/Section/cards re-skin warm for free.
+ */
+
+/* Display font — Fraunces (humanist soft serif). swap + metric serif fallback.
+ * Italic axis loaded for the founders' note. Body stays on --font-mk-sans. */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..600;1,9..144,400..500&display=swap");
+
 .v-cozy {
-  /* scope marker — variant styles go here */
+  /* ---- Re-seed toward warm (keeps the ramp relationships coherent) ---- */
+  --mk-seed-primary: #c2683d; /* terracotta — replaces violet "brand" */
+  --mk-seed-secondary: #7d8b5a; /* sage/olive — replaces go-green */
+  --mk-seed-accent: #d9a441; /* honey — replaces pink highlight */
+
+  /* ---- Warm cream grounds (lamplight, not screen-blue) ---- */
+  --mk-ground: #f6ede0;
+  --mk-card-base: #fffaf2;
+  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 5%, var(--mk-ground));
+  --mk-card: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 3%,
+    var(--mk-card-base)
+  );
+  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 8%, #efe2d0);
+
+  /* ---- Warm-neutral ink (AA on cream — -muted darkened to clear 4.5:1) ---- */
+  --mk-text-strong: #2e2117;
+  --mk-text-body: #4a3a2c;
+  --mk-text-muted: #7a6450;
+
+  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 16%, #e6d6c2);
+  --mk-input-border: var(--mk-border);
+  --mk-ring: var(--mk-seed-primary);
+
+  /* ---- Re-point the violet/green ramps so component utilities that bypass
+          var(--mk-*) via Tailwind classes (Wordmark, Eyebrow, header/footer
+          links: text-mk-violet-600 / text-mk-green-600 / bg-mk-violet-400)
+          turn warm instead of staying violet/green on cream. ---- */
+  --mk-violet-200: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 26%,
+    var(--mk-card)
+  );
+  --mk-violet-300: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 40%,
+    var(--mk-card)
+  );
+  --mk-violet-400: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 55%,
+    var(--mk-card)
+  );
+  --mk-violet-500: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 80%,
+    var(--mk-card)
+  );
+  --mk-violet-600: var(--mk-seed-primary); /* "Jig" + eyebrow → terracotta */
+  --mk-violet-700: color-mix(in oklab, var(--mk-seed-primary) 80%, #2e2117);
+  --mk-green-300: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 40%,
+    var(--mk-card)
+  );
+  --mk-green-400: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 60%,
+    var(--mk-card)
+  );
+  --mk-green-500: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 80%,
+    var(--mk-card)
+  );
+  --mk-green-600: var(--mk-seed-secondary); /* "Swap" → sage */
+  --mk-pink-300: color-mix(in oklab, var(--mk-seed-accent) 40%, var(--mk-card));
+  --mk-pink-400: color-mix(in oklab, var(--mk-seed-accent) 60%, var(--mk-card));
+  --mk-pink-500: var(--mk-seed-accent);
+
+  /* ---- Softer, warmer shadows than the cool-neutral defaults ---- */
+  --shadow-mk-md: 0 6px 18px -4px rgb(120 70 30 / 0.16);
+  --shadow-mk-lg: 0 16px 36px -8px rgb(120 70 30 / 0.2);
+  --shadow-mk-brand: 0 10px 30px -8px rgb(194 104 61 / 0.34);
+
+  /* ---- Radii ---- */
+  --mk-radius-card: 22px;
+  --v-radius-note: 26px;
+  --v-radius-pill: 999px;
+
+  /* ---- Display font + variant-only texture/motion tokens ---- */
+  --v-font-display: "Fraunces", Georgia, "Times New Roman", serif;
+  --font-mk-heading: var(
+    --v-font-display
+  ); /* wires shared headings warm-serif */
+  --v-paper-warmth: 0.06; /* gradient/texture intensity */
+  --v-grain-light: 0.045; /* grain overlay opacity (light) */
+  --v-drift-dur: 14s; /* floating-piece drift period */
+
+  /* ---- Duotone (for cover-sand now, real photos later) ---- */
+  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #2e2117);
+  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 35%, #fffaf2);
+}
+
+/* Dark cozy: candle-lit, not black. Re-derive grounds + ramps. */
+.dark .v-cozy {
+  --mk-ground: #221913;
+  --mk-card-base: #2c211a;
+  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 10%, var(--mk-ground));
+  --mk-card: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 8%,
+    var(--mk-card-base)
+  );
+  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 12%, #2e231b);
+
+  --mk-text-strong: #f4e9da;
+  --mk-text-body: #e4d4c2;
+  --mk-text-muted: #b39e88;
+  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 18%, #3a2c22);
+
+  --mk-violet-200: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 30%,
+    var(--mk-card)
+  );
+  --mk-violet-300: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 45%,
+    var(--mk-card)
+  );
+  --mk-violet-400: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 60%,
+    var(--mk-card)
+  );
+  --mk-violet-600: color-mix(in oklab, var(--mk-seed-primary) 78%, #f4e9da);
+  --mk-violet-700: color-mix(in oklab, var(--mk-seed-primary) 90%, #f4e9da);
+  --mk-green-400: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 55%,
+    var(--mk-card)
+  );
+  --mk-green-600: color-mix(in oklab, var(--mk-seed-secondary) 72%, #f4e9da);
+  --mk-pink-400: color-mix(in oklab, var(--mk-seed-accent) 55%, var(--mk-card));
+  --mk-pink-500: color-mix(in oklab, var(--mk-seed-accent) 72%, #f4e9da);
+
+  --v-grain-light: 0.07; /* slightly more grain survives on dark */
+  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #160f0a);
+  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 30%, #2c211a);
+}
+
+/* ----------------------------------------------------------------------- */
+/* Warm photo-fallback: layered radial + linear gradients off the warm
+ * seeds. Every [PHOTO PLACEHOLDER] uses this. A real photo later drops in
+ * over the same box as a background-image — the gradient is the SSR/no-image
+ * baseline. */
+.v-cozy .cozy-photo-fallback {
+  background:
+    radial-gradient(
+      60% 70% at 20% 15%,
+      color-mix(in oklab, var(--mk-seed-accent) 40%, transparent),
+      transparent 70%
+    ),
+    radial-gradient(
+      55% 65% at 85% 10%,
+      color-mix(in oklab, var(--mk-seed-primary) 28%, transparent),
+      transparent 72%
+    ),
+    linear-gradient(
+      160deg,
+      color-mix(in oklab, var(--mk-seed-accent) 14%, var(--mk-card)),
+      var(--mk-bg)
+    );
+}
+
+/* A slightly deeper variant for the hero stage ground. */
+.v-cozy .cozy-hero-ground {
+  background:
+    radial-gradient(
+      80% 90% at 78% 8%,
+      color-mix(in oklab, var(--mk-seed-accent) 22%, transparent),
+      transparent 65%
+    ),
+    radial-gradient(
+      70% 80% at 12% 95%,
+      color-mix(in oklab, var(--mk-seed-primary) 14%, transparent),
+      transparent 70%
+    ),
+    var(--mk-bg);
+}
+
+/* ----------------------------------------------------------------------- */
+/* Grain overlay (feTurbulence data-URI). Sits BELOW the text/scrim layer
+ * everywhere so it never reduces text contrast; opacity capped by token. */
+.v-cozy .cozy-grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%' height='100%' filter='url(%23g)' opacity='0.5'/></svg>");
+  background-size: 160px 160px;
+  mix-blend-mode: soft-light;
+  opacity: var(--v-grain-light);
+  border-radius: inherit;
+}
+.dark .v-cozy .cozy-grain::after {
+  mix-blend-mode: overlay;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Duotone treatment for the single real photo (cover-sand) and any future
+ * imagery: desaturate + a warm-shadow / cream-highlight gradient blended in
+ * `color`. Auto-matches the palette and ties cover-sand into the mood. */
+.v-cozy .cozy-duotone {
+  position: relative;
+  overflow: hidden;
+}
+.v-cozy .cozy-duotone img {
+  filter: grayscale(1) contrast(1.04) brightness(0.98);
+}
+.v-cozy .cozy-duotone::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: color;
+  background: linear-gradient(
+    150deg,
+    var(--v-duo-shadow),
+    var(--v-duo-highlight)
+  );
+}
+
+/* ----------------------------------------------------------------------- */
+/* Floating hero pieces — slow, small-amplitude drift; stays inside the clip. */
+.v-cozy .cozy-drift {
+  will-change: transform;
+  animation: cozy-drift var(--v-drift-dur) ease-in-out infinite;
+}
+@keyframes cozy-drift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(var(--cozy-rot, 0deg));
+  }
+  50% {
+    transform: translate3d(0, -12px, 0)
+      rotate(calc(var(--cozy-rot, 0deg) + 4deg));
+  }
+}
+
+/* Soft "lamp glow" radial behind the final CTA lockup. */
+.v-cozy .cozy-lamp-glow {
+  background: radial-gradient(
+    closest-side at 50% 38%,
+    color-mix(in oklab, var(--mk-seed-accent) 30%, transparent),
+    transparent 75%
+  );
+}
+
+/* Card hover lift used by vignettes. */
+.v-cozy .cozy-lift {
+  transition:
+    box-shadow 0.3s var(--ease-mk-out),
+    transform 0.3s var(--ease-mk-out);
+}
+.v-cozy .cozy-lift:hover {
+  box-shadow: var(--shadow-mk-lg);
+  transform: translateY(-2px);
+}
+
+/* Decorative motion stops fully under reduced-motion; static grain stays. */
+@media (prefers-reduced-motion: reduce) {
+  .v-cozy .cozy-drift {
+    animation: none !important;
+  }
 }

--- a/apps/web/src/components/marketing/variants/cozy/cozy.css
+++ b/apps/web/src/components/marketing/variants/cozy/cozy.css
@@ -1,8 +1,9 @@
 /* Cozy/Hygge variant — scoped styles under `.v-cozy`.
- * Warm amber/terracotta re-seed, soft cream surfaces, humanist soft serif
- * (Fraunces) display, generous radii, gentle grain + warm photo-fallback.
- * Everything below lives ONLY under `.v-cozy` / `.dark .v-cozy` — no global
- * token file is touched, so shared Button/Section/cards re-skin warm for free.
+ * Keeps JigSwap's ORIGINAL brand palette — surfaces, text, ramps and ring all
+ * inherit the global brand --mk-*. Only the LAYOUT changes: a soft humanist
+ * serif (Fraunces) display, generous radii, gentle grain, gradient photo
+ * fallbacks and unhurried section rhythm. Everything below lives ONLY under
+ * `.v-cozy` / `.dark .v-cozy`; the global token file is never touched.
  */
 
 /* Display font — Fraunces (humanist soft serif). swap + metric serif fallback.
@@ -10,151 +11,37 @@
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..600;1,9..144,400..500&display=swap");
 
 .v-cozy {
-  /* ---- Re-seed toward warm (keeps the ramp relationships coherent) ---- */
-  --mk-seed-primary: #c2683d; /* terracotta — replaces violet "brand" */
-  --mk-seed-secondary: #7d8b5a; /* sage/olive — replaces go-green */
-  --mk-seed-accent: #d9a441; /* honey — replaces pink highlight */
-
-  /* ---- Warm cream grounds (lamplight, not screen-blue) ---- */
-  --mk-ground: #f6ede0;
-  --mk-card-base: #fffaf2;
-  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 5%, var(--mk-ground));
-  --mk-card: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 3%,
-    var(--mk-card-base)
-  );
-  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 8%, #efe2d0);
-
-  /* ---- Warm-neutral ink (AA on cream — -muted darkened to clear 4.5:1) ---- */
-  --mk-text-strong: #2e2117;
-  --mk-text-body: #4a3a2c;
-  --mk-text-muted: #7a6450;
-
-  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 16%, #e6d6c2);
-  --mk-input-border: var(--mk-border);
-  --mk-ring: var(--mk-seed-primary);
-
-  /* ---- Re-point the violet/green ramps so component utilities that bypass
-          var(--mk-*) via Tailwind classes (Wordmark, Eyebrow, header/footer
-          links: text-mk-violet-600 / text-mk-green-600 / bg-mk-violet-400)
-          turn warm instead of staying violet/green on cream. ---- */
-  --mk-violet-200: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 26%,
-    var(--mk-card)
-  );
-  --mk-violet-300: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 40%,
-    var(--mk-card)
-  );
-  --mk-violet-400: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 55%,
-    var(--mk-card)
-  );
-  --mk-violet-500: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 80%,
-    var(--mk-card)
-  );
-  --mk-violet-600: var(--mk-seed-primary); /* "Jig" + eyebrow → terracotta */
-  --mk-violet-700: color-mix(in oklab, var(--mk-seed-primary) 80%, #2e2117);
-  --mk-green-300: color-mix(
-    in oklab,
-    var(--mk-seed-secondary) 40%,
-    var(--mk-card)
-  );
-  --mk-green-400: color-mix(
-    in oklab,
-    var(--mk-seed-secondary) 60%,
-    var(--mk-card)
-  );
-  --mk-green-500: color-mix(
-    in oklab,
-    var(--mk-seed-secondary) 80%,
-    var(--mk-card)
-  );
-  --mk-green-600: var(--mk-seed-secondary); /* "Swap" → sage */
-  --mk-pink-300: color-mix(in oklab, var(--mk-seed-accent) 40%, var(--mk-card));
-  --mk-pink-400: color-mix(in oklab, var(--mk-seed-accent) 60%, var(--mk-card));
-  --mk-pink-500: var(--mk-seed-accent);
-
-  /* ---- Softer, warmer shadows than the cool-neutral defaults ---- */
-  --shadow-mk-md: 0 6px 18px -4px rgb(120 70 30 / 0.16);
-  --shadow-mk-lg: 0 16px 36px -8px rgb(120 70 30 / 0.2);
-  --shadow-mk-brand: 0 10px 30px -8px rgb(194 104 61 / 0.34);
-
-  /* ---- Radii ---- */
+  /* ---- Generous, soft radii (the "blanket" feeling) ---- */
   --mk-radius-card: 22px;
   --v-radius-note: 26px;
   --v-radius-pill: 999px;
 
-  /* ---- Display font + variant-only texture/motion tokens ---- */
+  /* ---- Display font wired into shared headings (body stays sans) ---- */
   --v-font-display: "Fraunces", Georgia, "Times New Roman", serif;
-  --font-mk-heading: var(
-    --v-font-display
-  ); /* wires shared headings warm-serif */
+  --font-mk-heading: var(--v-font-display);
+
+  /* ---- Texture / motion knobs ---- */
   --v-paper-warmth: 0.06; /* gradient/texture intensity */
   --v-grain-light: 0.045; /* grain overlay opacity (light) */
   --v-drift-dur: 14s; /* floating-piece drift period */
 
-  /* ---- Duotone (for cover-sand now, real photos later) ---- */
-  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #2e2117);
-  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 35%, #fffaf2);
+  /* ---- Duotone for cover-sand (and future photos): derived from the BRAND
+          seeds so imagery ties into the violet/pink palette. Anchored to
+          literal dark/light so shadow stays dark and highlight light. ---- */
+  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #14121c);
+  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 35%, #ffffff);
 }
 
-/* Dark cozy: candle-lit, not black. Re-derive grounds + ramps. */
+/* Dark cozy inherits the global brand .dark surfaces/text/ramps; only the
+   grain + duotone anchors shift for the dark ground. */
 .dark .v-cozy {
-  --mk-ground: #221913;
-  --mk-card-base: #2c211a;
-  --mk-bg: color-mix(in oklab, var(--mk-seed-primary) 10%, var(--mk-ground));
-  --mk-card: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 8%,
-    var(--mk-card-base)
-  );
-  --mk-muted: color-mix(in oklab, var(--mk-seed-primary) 12%, #2e231b);
-
-  --mk-text-strong: #f4e9da;
-  --mk-text-body: #e4d4c2;
-  --mk-text-muted: #b39e88;
-  --mk-border: color-mix(in oklab, var(--mk-seed-primary) 18%, #3a2c22);
-
-  --mk-violet-200: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 30%,
-    var(--mk-card)
-  );
-  --mk-violet-300: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 45%,
-    var(--mk-card)
-  );
-  --mk-violet-400: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 60%,
-    var(--mk-card)
-  );
-  --mk-violet-600: color-mix(in oklab, var(--mk-seed-primary) 78%, #f4e9da);
-  --mk-violet-700: color-mix(in oklab, var(--mk-seed-primary) 90%, #f4e9da);
-  --mk-green-400: color-mix(
-    in oklab,
-    var(--mk-seed-secondary) 55%,
-    var(--mk-card)
-  );
-  --mk-green-600: color-mix(in oklab, var(--mk-seed-secondary) 72%, #f4e9da);
-  --mk-pink-400: color-mix(in oklab, var(--mk-seed-accent) 55%, var(--mk-card));
-  --mk-pink-500: color-mix(in oklab, var(--mk-seed-accent) 72%, #f4e9da);
-
   --v-grain-light: 0.07; /* slightly more grain survives on dark */
-  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #160f0a);
-  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 30%, #2c211a);
+  --v-duo-shadow: color-mix(in oklab, var(--mk-seed-primary) 70%, #08060d);
+  --v-duo-highlight: color-mix(in oklab, var(--mk-seed-accent) 30%, #1b1d24);
 }
 
 /* ----------------------------------------------------------------------- */
-/* Warm photo-fallback: layered radial + linear gradients off the warm
+/* Soft photo-fallback: layered radial + linear gradients off the BRAND
  * seeds. Every [PHOTO PLACEHOLDER] uses this. A real photo later drops in
  * over the same box as a background-image — the gradient is the SSR/no-image
  * baseline. */
@@ -213,7 +100,7 @@
 
 /* ----------------------------------------------------------------------- */
 /* Duotone treatment for the single real photo (cover-sand) and any future
- * imagery: desaturate + a warm-shadow / cream-highlight gradient blended in
+ * imagery: desaturate + a brand-shadow / bright-highlight gradient blended in
  * `color`. Auto-matches the palette and ties cover-sand into the mood. */
 .v-cozy .cozy-duotone {
   position: relative;

--- a/apps/web/src/components/marketing/variants/cozy/cozy.css
+++ b/apps/web/src/components/marketing/variants/cozy/cozy.css
@@ -1,0 +1,6 @@
+/* Cozy/Hygge variant — scoped styles under `.v-cozy`.
+ * Warm palette, soft shadows, lifestyle treatment. Redeclare `--mk-*` / add
+ * `--v-*` custom properties here. Replaced/expanded by the Frontend Developer. */
+.v-cozy {
+  /* scope marker — variant styles go here */
+}

--- a/apps/web/src/components/marketing/variants/cozy/feel-vignettes.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/feel-vignettes.tsx
@@ -1,0 +1,123 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { Section, SectionHead } from "@/components/marketing/section";
+import * as React from "react";
+import { PhotoFallback } from "./photo-fallback";
+
+type Vignette = {
+  title: string;
+  caption: string;
+  photo: string;
+  icon: React.ReactNode;
+};
+
+// Tiny decorative line-icons (inline SVG, currentColor → terracotta via ramp).
+const shelfIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+    <path d="M3 6h18M3 12h18M3 18h18" strokeLinecap="round" />
+    <rect
+      x="5"
+      y="2.5"
+      width="3"
+      height="3.5"
+      rx="0.7"
+      fill="currentColor"
+      stroke="none"
+    />
+    <rect
+      x="14"
+      y="8.5"
+      width="3"
+      height="3.5"
+      rx="0.7"
+      fill="currentColor"
+      stroke="none"
+    />
+  </svg>
+);
+const shareIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+    <path
+      d="M4 12a4 4 0 0 1 4-4h3M20 12a4 4 0 0 1-4 4h-3"
+      strokeLinecap="round"
+    />
+    <path
+      d="M9 9l-3 3 3 3M15 9l3 3-3 3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+const pinIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+    <path
+      d="M12 21s7-6.2 7-11a7 7 0 1 0-14 0c0 4.8 7 11 7 11Z"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="10" r="2.4" />
+  </svg>
+);
+
+const VIGNETTES: Vignette[] = [
+  {
+    title: "Fill your shelf",
+    caption:
+      "Add your boxes one cozy evening at a time. Your whole collection, in one warm place.",
+    photo: "hands sorting puzzle boxes on a shelf, warm light",
+    icon: shelfIcon,
+  },
+  {
+    title: "Share & borrow",
+    caption:
+      "Lend a finished puzzle, borrow one you've been eyeing. Sharing beats hoarding.",
+    photo: "a puzzle box passed between two people at a table",
+    icon: shareIcon,
+  },
+  {
+    title: "Always know where it is",
+    caption: "Lent it out? You'll always know whose table it's on.",
+    photo: 'a phone showing "who has my box", cozy desk',
+    icon: pinIcon,
+  },
+];
+
+function VignetteCard({ v }: { v: Vignette }) {
+  return (
+    <article className="cozy-lift bg-mk-card border-mk-border shadow-mk-md flex h-full flex-col overflow-hidden rounded-[var(--mk-radius-card)] border">
+      <PhotoFallback label={v.photo} className="aspect-[5/4] w-full" />
+      <div className="flex flex-1 flex-col p-6">
+        <span className="text-mk-violet-600 mb-3 inline-flex h-9 w-9 items-center justify-center">
+          {v.icon}
+        </span>
+        <h3 className="font-mk-heading text-mk-text-strong text-[20px] font-semibold tracking-tight">
+          {v.title}
+        </h3>
+        <p className="text-mk-text-body mt-2 text-[15px] leading-relaxed text-pretty">
+          {v.caption}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+// Section 3 — "How sharing feels": the share loop as three gentle, unhurried
+// vignettes. Reveal staggers them; reduced-motion users get them already shown.
+export function FeelVignettes() {
+  return (
+    <Section>
+      <Container>
+        <SectionHead
+          eyebrow="How sharing feels"
+          title="Three small, unhurried steps."
+        />
+        <div className="mt-10 grid grid-cols-3 gap-[clamp(20px,3vw,32px)] max-[860px]:grid-cols-1 max-[860px]:gap-6">
+          {VIGNETTES.map((v, i) => (
+            <Reveal key={v.title} delay={i * 90}>
+              <VignetteCard v={v} />
+            </Reveal>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/final-cta.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/final-cta.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@/compat/link";
+import { Container } from "@/components/marketing/container";
+import { Section } from "@/components/marketing/section";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+
+// Section 6 — gentle final CTA. Warm ground with a soft radial "lamp glow"
+// behind the lockup; no pressure, just an open door.
+export function FinalCta() {
+  const startHref = useStartHref();
+
+  return (
+    <Section className="relative overflow-clip">
+      {/* Soft lamp glow behind the lockup (decorative). */}
+      <div
+        aria-hidden="true"
+        className="cozy-lamp-glow pointer-events-none absolute inset-x-0 top-1/2 -z-0 mx-auto h-[420px] max-w-[760px] -translate-y-1/2"
+      />
+      <Container>
+        <div className="relative mx-auto flex max-w-[760px] flex-col items-center text-center">
+          <h2 className="font-mk-heading text-mk-text-strong font-semibold tracking-tight text-[clamp(28px,4.4vw,44px)] leading-[1.08]">
+            Pull up a chair. Bring your puzzles.
+          </h2>
+          <p className="text-mk-text-body mt-4 max-w-[52ch] text-[clamp(16px,1.8vw,19px)] leading-relaxed text-pretty">
+            A warm home for your jigsaw collection — lend, swap, and share with
+            people who love them as much as you do.
+          </p>
+
+          <div className="mt-8 flex w-full flex-wrap justify-center gap-3 max-[540px]:flex-col">
+            <Button
+              variant="brand"
+              className="h-12 px-6 text-[15px] max-[540px]:w-full"
+              asChild
+            >
+              <Link href={startHref}>
+                Find your puzzle people
+                <ArrowRight size={17} />
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              className="bg-mk-card border-mk-border text-mk-text-strong hover:bg-mk-muted h-12 px-6 text-[15px] max-[540px]:w-full"
+              asChild
+            >
+              <Link href="/how-it-works">Take a look around</Link>
+            </Button>
+          </div>
+
+          <p className="text-mk-text-muted mt-6 text-[14px]">
+            Kettle&rsquo;s on. Add your first puzzle whenever you&rsquo;re
+            ready.
+          </p>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/founders-note.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/founders-note.tsx
@@ -1,0 +1,39 @@
+import { Container } from "@/components/marketing/container";
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import { Reveal } from "@/components/marketing/reveal";
+import { Section } from "@/components/marketing/section";
+
+// Section 5 — Founders' note. The human trust anchor, rendered as a grainy,
+// faintly-rotated note "placed on the table". Rotation is a static transform
+// (not an animation), reduced to 0.8deg on the smallest screens to guarantee no
+// overflow at 320px. The card lives inside the page's overflow-x-clip root.
+export function FoundersNote() {
+  return (
+    <Section>
+      <Container>
+        <Reveal>
+          <figure className="cozy-grain bg-mk-card border-mk-border shadow-mk-lg relative mx-auto max-w-[680px] rotate-[1.5deg] rounded-[var(--v-radius-note)] border p-[clamp(24px,6vw,40px)] max-[540px]:rotate-[0.8deg]">
+            {/* Decorative "pin" holding the note to the table. */}
+            <PieceMotif
+              size={40}
+              color="var(--mk-seed-primary)"
+              rotate={-18}
+              className="absolute -top-4 -left-3 drop-shadow-sm"
+              style={{ opacity: 0.85 }}
+            />
+
+            <blockquote className="font-mk-heading text-mk-text-strong text-[clamp(20px,3vw,27px)] leading-[1.4] font-normal italic text-pretty">
+              “We built JigSwap because our finished puzzles deserved better
+              than the attic — and because puzzling is more fun when you share
+              it.”
+            </blockquote>
+            <figcaption className="text-mk-text-muted mt-5 text-[13px] font-semibold tracking-[0.08em] uppercase">
+              The family behind JigSwap, puzzling at the kitchen table since
+              2025.
+            </figcaption>
+          </figure>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/hero.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/hero.tsx
@@ -1,0 +1,138 @@
+import { Link } from "@/compat/link";
+import coverSand from "@/components/marketing/assets/cover-sand.webp";
+import { Container } from "@/components/marketing/container";
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import { Eyebrow } from "@/components/marketing/section";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import type { LandingStats } from "@/components/marketing/variants/use-landing-data";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import { PhotoFallback } from "./photo-fallback";
+
+// Humanized live trust line. While stats load we show "Pull up a chair…" — we
+// never announce 0. Once loaded we inject the real totalUsers.
+function TrustLine({ stats }: { stats: LandingStats | undefined }) {
+  if (stats === undefined) {
+    return (
+      <p className="text-mk-text-muted mt-7 text-[15px] leading-snug">
+        Pull up a chair…
+      </p>
+    );
+  }
+  return (
+    <p className="text-mk-text-muted mt-7 text-[15px] leading-snug">
+      <span className="text-mk-text-strong font-semibold">
+        {stats.totalUsers.toLocaleString()}
+      </span>{" "}
+      puzzlers gathered round the table
+    </p>
+  );
+}
+
+// The "warm window" art zone: a [PHOTO PLACEHOLDER] gradient box with the one
+// real photo (cover-sand) tucked into a corner as a small duotone card, plus a
+// couple of softly drifting puzzle pieces. Entirely decorative.
+function WarmWindow() {
+  return (
+    <div className="relative" aria-hidden="true">
+      <PhotoFallback
+        label="hands placing a puzzle piece, warm window light, coffee mug"
+        className="aspect-[4/3] w-full rounded-[28px] shadow-mk-lg max-[860px]:aspect-[4/3] min-[861px]:aspect-[5/6]"
+      />
+
+      {/* The single real photographic touch — duotone-tinted into the palette. */}
+      <div className="cozy-duotone absolute -top-5 -right-3 h-[96px] w-[96px] rotate-[4deg] rounded-2xl shadow-mk-md ring-4 ring-[var(--mk-card)] min-[861px]:h-[140px] min-[861px]:w-[140px]">
+        <img
+          src={coverSand}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="eager"
+          decoding="async"
+        />
+      </div>
+
+      {/* Floating soft pieces — drift stops under reduced-motion. */}
+      <PieceMotif
+        size={64}
+        color="var(--mk-violet-300)"
+        className="cozy-drift absolute -bottom-6 -left-5"
+        style={{ opacity: 0.16, ["--cozy-rot" as string]: "-8deg" }}
+      />
+      <PieceMotif
+        size={44}
+        color="var(--mk-green-400)"
+        className="cozy-drift absolute top-1/2 -left-8"
+        style={{
+          opacity: 0.12,
+          animationDelay: "-5s",
+          ["--cozy-rot" as string]: "12deg",
+        }}
+      />
+      <PieceMotif
+        size={38}
+        color="var(--mk-pink-400)"
+        className="cozy-drift absolute bottom-8 right-6"
+        style={{
+          opacity: 0.14,
+          animationDelay: "-9s",
+          ["--cozy-rot" as string]: "6deg",
+        }}
+      />
+    </div>
+  );
+}
+
+// Cozy hero — "lamplight, not screen-light". A layered, warm, photographic-
+// feeling scene built from CSS gradients + grain + one real corner photo + soft
+// drifting pieces. No interactive gimmick: the warmth itself is the hook, and
+// the static SSR render carries all meaning (headline + subhead + CTAs + count).
+export function CozyHero({ stats }: { stats: LandingStats | undefined }) {
+  const startHref = useStartHref();
+
+  return (
+    <section className="cozy-hero-ground cozy-grain relative overflow-clip">
+      <Container>
+        <div className="grid min-h-[clamp(560px,78vh,760px)] items-center gap-[clamp(32px,5vw,64px)] py-[clamp(48px,7vw,88px)] min-[861px]:grid-cols-[58fr_42fr]">
+          {/* On mobile the art comes first (emotional hook), then the lockup. */}
+          <div className="order-1 min-[861px]:order-2">
+            <WarmWindow />
+          </div>
+
+          {/* Lockup — bottom-biased on desktop. A soft scrim keeps AA over art. */}
+          <div className="order-2 flex flex-col justify-end min-[861px]:order-1">
+            <Eyebrow>Rainy-day approved · since 2025</Eyebrow>
+            <h1 className="font-mk-heading text-mk-text-strong mt-4 font-semibold tracking-tight text-[clamp(34px,6.2vw,60px)] leading-[1.06]">
+              Every puzzle deserves another rainy afternoon.
+            </h1>
+            <p className="text-mk-text-body mt-5 max-w-[46ch] text-[clamp(16px,2.2vw,20px)] leading-relaxed text-pretty">
+              Shelve your boxes, share them with the community, and give
+              finished puzzles a second life.
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3 max-[540px]:flex-col">
+              <Button
+                variant="brand"
+                className="h-12 px-6 text-[15px] max-[540px]:w-full"
+                asChild
+              >
+                <Link href={startHref}>
+                  Find your puzzle people
+                  <ArrowRight size={17} />
+                </Link>
+              </Button>
+              <Button
+                variant="outline"
+                className="bg-mk-card border-mk-border text-mk-text-strong hover:bg-mk-muted h-12 px-6 text-[15px] max-[540px]:w-full"
+                asChild
+              >
+                <Link href="/how-it-works">Take a look around</Link>
+              </Button>
+            </div>
+
+            <TrustLine stats={stats} />
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/index.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/index.tsx
@@ -1,13 +1,43 @@
 import "./cozy.css";
 
-// PLACEHOLDER — replaced by the Frontend Developer building the Cozy/Hygge
-// variant. Root must keep the `v-cozy` scope class and import its CSS.
+import { MarketingFooter } from "@/components/marketing/footer";
+import { MarketingHeader } from "@/components/marketing/header";
+import { useLandingData } from "@/components/marketing/variants/use-landing-data";
+import { FeelVignettes } from "./feel-vignettes";
+import { FinalCta } from "./final-cta";
+import { FoundersNote } from "./founders-note";
+import { CozyHero } from "./hero";
+import { MomentStrip } from "./moment-strip";
+import { SecondLife } from "./second-life";
+
+// Cozy / Hygge landing — "a warm little corner for your puzzles and the people
+// you share them with." Warm cream surfaces, terracotta/sage/honey re-seed, a
+// humanist soft-serif display (Fraunces), gentle grain + warm photo-fallbacks.
+//
+// The 3D plank is intentionally CUT (it's cool/techy and fights hygge — also
+// keeps Three.js out of this variant's bundle). No real lifestyle photos exist,
+// so every photographic slot ships as a deliberate CSS gradient + grain
+// fallback; cover-sand.webp anchors exactly one duotone hero corner.
 export default function CozyLanding() {
+  // Single data source — never re-fetch Convex directly. Plank is cut, so we
+  // ignore plankPuzzles (request 0). Real stats power the humanized count.
+  const { stats, communityAvatars } = useLandingData({
+    avatarLimit: 4,
+    plankLimit: 0,
+  });
+
   return (
-    <div className="v-cozy font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
-      <p className="text-mk-text-muted text-sm">
-        Cozy/Hygge variant — under construction.
-      </p>
+    <div className="v-cozy font-mk-sans min-h-screen overflow-x-clip">
+      <MarketingHeader />
+      <main>
+        <CozyHero stats={stats} />
+        <MomentStrip stats={stats} avatars={communityAvatars} />
+        <FeelVignettes />
+        <SecondLife />
+        <FoundersNote />
+        <FinalCta />
+      </main>
+      <MarketingFooter />
     </div>
   );
 }

--- a/apps/web/src/components/marketing/variants/cozy/index.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/index.tsx
@@ -1,0 +1,13 @@
+import "./cozy.css";
+
+// PLACEHOLDER — replaced by the Frontend Developer building the Cozy/Hygge
+// variant. Root must keep the `v-cozy` scope class and import its CSS.
+export default function CozyLanding() {
+  return (
+    <div className="v-cozy font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
+      <p className="text-mk-text-muted text-sm">
+        Cozy/Hygge variant — under construction.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/moment-strip.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/moment-strip.tsx
@@ -1,0 +1,88 @@
+import { Container } from "@/components/marketing/container";
+import { Section } from "@/components/marketing/section";
+import type {
+  CommunityAvatar,
+  LandingStats,
+} from "@/components/marketing/variants/use-landing-data";
+
+const AVATAR_COLORS = [
+  "var(--mk-violet-400)",
+  "var(--mk-green-500)",
+  "var(--mk-pink-400)",
+  "var(--mk-violet-600)",
+] as const;
+
+// Small warm overlapping avatar cluster (decorative — meaning is in the text).
+function AvatarCluster({ avatars }: { avatars: CommunityAvatar[] }) {
+  return (
+    <div aria-hidden="true" className="flex justify-center">
+      {avatars.map((member, i) =>
+        member.image != null ? (
+          <span
+            key={i}
+            className="border-mk-card ring-mk-border inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-full border-2 ring-1"
+            style={{ marginLeft: i ? -8 : 0 }}
+          >
+            <img
+              src={member.image}
+              alt=""
+              className="h-full w-full rounded-full object-cover"
+            />
+          </span>
+        ) : (
+          <span
+            key={i}
+            className="font-mk-heading border-mk-card inline-flex h-9 w-9 items-center justify-center rounded-full border-2 text-[12px] font-semibold text-white"
+            style={{
+              background: AVATAR_COLORS[i % AVATAR_COLORS.length],
+              marginLeft: i ? -8 : 0,
+            }}
+          >
+            {member.initials}
+          </span>
+        ),
+      )}
+    </div>
+  );
+}
+
+// Section 2 — warm "moment" strip. Humanizes the live user count into one warm
+// sentence sitting on warm sand, with a small real-avatar cluster. While stats
+// load we render a skeleton sentence and never announce 0.
+export function MomentStrip({
+  stats,
+  avatars,
+}: {
+  stats: LandingStats | undefined;
+  avatars: CommunityAvatar[] | undefined;
+}) {
+  const hasAvatars = avatars != null && avatars.length >= 1;
+
+  return (
+    <Section tint>
+      <Container>
+        <div className="mx-auto flex max-w-[760px] flex-col items-center gap-5 text-center">
+          {hasAvatars && <AvatarCluster avatars={avatars} />}
+
+          {stats === undefined ? (
+            <p className="font-mk-heading text-mk-text-muted text-[clamp(22px,3.4vw,30px)] leading-snug font-semibold">
+              Pull up a chair…
+            </p>
+          ) : (
+            <h2 className="font-mk-heading text-mk-text-strong text-[clamp(22px,3.4vw,30px)] leading-snug font-semibold tracking-tight">
+              <span className="text-mk-violet-600">
+                {stats.totalUsers.toLocaleString()}
+              </span>{" "}
+              puzzlers gathered round the table.
+            </h2>
+          )}
+
+          <p className="text-mk-text-body max-w-[52ch] text-[clamp(15px,1.6vw,17px)] leading-relaxed text-pretty">
+            Not a crowd — a community. Real people shelving, lending, and
+            passing their puzzles on.
+          </p>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/photo-fallback.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/photo-fallback.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+// Single source for every photographic slot in the Cozy variant. No real
+// lifestyle photos exist, so each slot ships as a warm CSS gradient + SVG
+// grain fallback that reads as deliberate art, not a missing image. When a
+// real photo lands later it drops in over this same box as `background-image`
+// (progressive enhancement); the gradient stays as the SSR/no-image baseline.
+//
+// The `label` is the designer's [PHOTO PLACEHOLDER: …] note — surfaced only to
+// devs via a `data-photo` attribute and an HTML comment, never visible/announced.
+// The whole box is decorative: callers keep it `aria-hidden` and carry meaning
+// in text. Optional `src` is reserved for the future real photo.
+export function PhotoFallback({
+  label,
+  src,
+  className,
+  style,
+  children,
+}: {
+  label: string;
+  src?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}) {
+  const bgStyle: React.CSSProperties = src
+    ? {
+        backgroundImage: `image-set(url("${src}") 1x), var(--cozy-fallback-bg, none)`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        ...style,
+      }
+    : (style ?? {});
+
+  return (
+    <div
+      aria-hidden="true"
+      data-photo={label}
+      className={cn(
+        "cozy-photo-fallback cozy-grain relative overflow-hidden",
+        className,
+      )}
+      style={bgStyle}
+    >
+      {/* [PHOTO PLACEHOLDER] — see data-photo attr for the intended shot. */}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/cozy/second-life.tsx
+++ b/apps/web/src/components/marketing/variants/cozy/second-life.tsx
@@ -1,0 +1,54 @@
+import { Link } from "@/compat/link";
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow } from "@/components/marketing/section";
+import { ArrowRight } from "lucide-react";
+import { PhotoFallback } from "./photo-fallback";
+
+// Section 4 — Second life, promoted to a hero-weight emotional section (the
+// cozy "why"). Deeper warm band, asymmetric two-column, extra whitespace.
+export function SecondLife() {
+  return (
+    <section
+      className="py-[clamp(72px,9vw,104px)]"
+      style={{
+        background:
+          "linear-gradient(180deg, color-mix(in oklab, var(--mk-seed-accent) 12%, var(--mk-bg)), color-mix(in oklab, var(--mk-seed-primary) 9%, var(--mk-bg)))",
+      }}
+    >
+      <Container>
+        <div className="grid items-center gap-[clamp(32px,5vw,64px)] min-[861px]:grid-cols-[52fr_48fr]">
+          <Reveal>
+            <PhotoFallback
+              label="a puzzle being handed from one person to another"
+              className="aspect-[4/3] w-full rounded-[28px] shadow-mk-lg"
+            />
+          </Reveal>
+
+          <div className="max-w-[560px]">
+            <Eyebrow>The cozy why</Eyebrow>
+            <h2 className="font-mk-heading text-mk-text-strong mt-4 font-semibold tracking-tight text-[clamp(28px,4.4vw,44px)] leading-[1.08]">
+              A finished puzzle isn&rsquo;t finished.
+            </h2>
+            <p className="text-mk-text-body mt-5 text-[clamp(16px,1.8vw,19px)] leading-relaxed text-pretty">
+              Most puzzles get done once, then live out their days in the attic.
+              Here, they get handed on — a second rainy afternoon for someone
+              new, a smaller pile of forgotten boxes for everyone.
+            </p>
+            <p className="text-mk-text-strong mt-5 border-l-2 border-[var(--mk-seed-secondary)] pl-4 text-[15px] leading-relaxed font-medium italic">
+              Every 1,000-piece box passed on is one less in a landfill — and
+              one more shared evening.
+            </p>
+            <Link
+              href="/how-it-works"
+              className="text-mk-violet-600 ring-offset-mk-bg focus-visible:ring-mk-ring mt-7 inline-flex min-h-11 items-center gap-1.5 text-[15px] font-semibold hover:underline focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              See how second life works
+              <ArrowRight size={16} />
+            </Link>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/closing-cover.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/closing-cover.tsx
@@ -1,0 +1,47 @@
+import { Link } from "@/compat/link";
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+
+// Closing cover — the "back cover". Inverts to the ink ground via the
+// `editorial-invert` scope (which re-points --mk-* so shared Button + text
+// stay correct in both light and dark). Big-type sign-off + the final ask.
+export function ClosingCover() {
+  const startHref = useStartHref();
+
+  return (
+    <section className="editorial-invert bg-mk-bg text-mk-text-strong py-[clamp(64px,10vw,140px)]">
+      <Container>
+        <Reveal>
+          <p className="ed-mono text-[12px] font-semibold tracking-[0.16em] uppercase text-[var(--v-accent)]">
+            Stop hoarding masterpieces. Start a shelf.
+          </p>
+          <h2 className="ed-bigtype mt-5">
+            GET ON THE SHELF<span className="ed-dot">.</span>
+          </h2>
+          <div className="mt-9 flex flex-col min-[861px]:flex-row gap-3 min-[861px]:items-center">
+            <Button
+              variant="brand"
+              className="h-12 px-7 text-[15px] rounded-[4px] max-[860px]:w-full"
+              asChild
+            >
+              <Link href={startHref}>
+                Get on the shelf
+                <ArrowRight size={17} />
+              </Link>
+            </Button>
+            <Button
+              variant="ghost"
+              className="h-12 px-5 text-[15px] rounded-[4px] text-mk-text-strong underline underline-offset-4 decoration-mk-border hover:bg-transparent hover:decoration-[var(--v-accent)] max-[860px]:w-full"
+              asChild
+            >
+              <Link href="/how-it-works">Read how it works</Link>
+            </Button>
+          </div>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/custody-spread.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/custody-spread.tsx
@@ -1,0 +1,138 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+
+// Custody spread — the trust differentiator, confidently stated. Left: heading
+// + body (the meaning). Right: a purely-decorative typographic diagram of the
+// custody loop (YOUR SHELF → A FELLOW PUZZLER → BACK TO YOU).
+
+function Node({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center justify-center border border-mk-border rounded-full px-4 py-2 ed-mono text-[11px] font-semibold tracking-[0.14em] uppercase text-mk-text-body bg-mk-card whitespace-nowrap">
+      {label}
+    </span>
+  );
+}
+
+function Arrow({ vertical = false }: { vertical?: boolean }) {
+  return vertical ? (
+    <svg
+      width="20"
+      height="34"
+      viewBox="0 0 20 34"
+      fill="none"
+      aria-hidden="true"
+      className="my-1"
+    >
+      <path
+        d="M10 2 V26"
+        stroke="var(--v-accent)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4 22 L10 30 L16 22"
+        stroke="var(--v-accent)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  ) : (
+    <svg
+      width="42"
+      height="20"
+      viewBox="0 0 42 20"
+      fill="none"
+      aria-hidden="true"
+      className="mx-1 shrink-0"
+    >
+      <path
+        d="M2 10 H34"
+        stroke="var(--v-accent)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M28 4 L36 10 L28 16"
+        stroke="var(--v-accent)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export function CustodySpread() {
+  return (
+    <section className="bg-mk-muted border-y border-mk-border py-[clamp(56px,8vw,104px)]">
+      <Container>
+        <Reveal>
+          <div className="grid gap-12 min-[861px]:grid-cols-2 min-[861px]:items-center">
+            <div>
+              <h2 className="font-mk-heading font-bold tracking-tight text-mk-text-strong text-[clamp(30px,5vw,56px)] leading-[1.04]">
+                Who has your box?
+              </h2>
+              <p className="mt-5 text-[clamp(16px,1.4vw,19px)] leading-relaxed text-mk-text-body max-w-[48ch] text-pretty">
+                Lend a puzzle and you&rsquo;ll never wonder where it went. Every
+                box you send out shows exactly who&rsquo;s holding it — so
+                sharing your favourites never means losing them.
+              </p>
+            </div>
+
+            {/* Decorative typographic diagram */}
+            <div aria-hidden="true">
+              {/* Desktop: horizontal flow with loop-back */}
+              <div className="hidden min-[861px]:block">
+                <div className="flex items-center justify-center flex-wrap gap-y-3">
+                  <Node label="Your shelf" />
+                  <Arrow />
+                  <Node label="A fellow puzzler" />
+                  <Arrow />
+                  <Node label="Back to you" />
+                </div>
+                <div className="mt-4 flex justify-center">
+                  <svg
+                    width="100%"
+                    height="28"
+                    viewBox="0 0 320 28"
+                    fill="none"
+                    preserveAspectRatio="none"
+                    className="max-w-[320px]"
+                  >
+                    <path
+                      d="M300 2 V14 Q300 22 292 22 H28 Q20 22 20 14 V2"
+                      stroke="var(--v-accent)"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      fill="none"
+                      strokeDasharray="4 5"
+                    />
+                    <path
+                      d="M14 8 L20 1 L26 8"
+                      stroke="var(--v-accent)"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+              {/* Mobile: vertical flow */}
+              <div className="min-[861px]:hidden flex flex-col items-center">
+                <Node label="Your shelf" />
+                <Arrow vertical />
+                <Node label="A fellow puzzler" />
+                <Arrow vertical />
+                <Node label="Back to you" />
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/editorial.css
+++ b/apps/web/src/components/marketing/variants/editorial/editorial.css
@@ -1,0 +1,6 @@
+/* Bold/Editorial variant — scoped styles under `.v-editorial`.
+ * Redeclare `--mk-*` / add `--v-*` custom properties here for this variant's
+ * display type, palette and layout. Replaced/expanded by the Frontend Developer. */
+.v-editorial {
+  /* scope marker — variant styles go here */
+}

--- a/apps/web/src/components/marketing/variants/editorial/editorial.css
+++ b/apps/web/src/components/marketing/variants/editorial/editorial.css
@@ -1,6 +1,266 @@
-/* Bold/Editorial variant — scoped styles under `.v-editorial`.
- * Redeclare `--mk-*` / add `--v-*` custom properties here for this variant's
- * display type, palette and layout. Replaced/expanded by the Frontend Developer. */
+/* apps/web/src/components/marketing/variants/editorial/editorial.css
+   Bold / Editorial: ink-on-paper near-monochrome, ONE editorial accent (red),
+   oversized Fraunces display. Re-points --mk-* so shared Button/Section/cards,
+   header & footer re-skin with zero component edits. All overrides live under
+   .v-editorial (and .dark .v-editorial); never touches the global token file. */
+
+/* ONE display family, loaded only here. Two weights max (400 + 800). */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,800&display=swap");
+
 .v-editorial {
-  /* scope marker — variant styles go here */
+  /* ---- Paper + ink grounds (literal: bright off-white page, near-black ink) ---- */
+  --v-paper: #f7f4ee; /* warm off-white — keeps the kitchen-table warmth */
+  --v-ink: #15130f; /* near-black, faintly warm (not pure #000) */
+
+  --mk-ground: var(--v-paper);
+  --mk-card-base: #fffdf8;
+  --mk-bg: var(--v-paper);
+  --mk-card: var(--mk-card-base);
+  --mk-muted: #efe9df; /* the tinted band ground (figures/custody) */
+
+  /* ---- Ink scale (still warm, AA on paper) ---- */
+  --mk-text-strong: #15130f; /* ~16:1 on paper */
+  --mk-text-body: #38332b; /* ~9:1  on paper */
+  --mk-text-muted: #655d52; /* darkened so it clears AA on the muted band too */
+
+  --mk-border: #d8cfbf;
+  --mk-input-border: #c9bfac;
+
+  /* ---- ONE editorial accent (high-chroma red) ---- */
+  --v-accent: #d6253b; /* punctuation, kickers, watermark, accent word */
+  --v-accent-ink: #b21d30; /* the same accent darkened for accent BODY text (AA 4.5:1) */
+  --mk-ring: var(--v-accent);
+  --shadow-mk-brand: 0 10px 30px -8px rgb(214 37 59 / 0.32);
+
+  /* ---- Hero three-word display colors (large text only; >=3:1 on paper) ---- */
+  --v-accent-violet: var(--mk-seed-primary); /* LEND. */
+  --v-accent-green: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 78%,
+    var(--v-ink)
+  ); /* SWAP. (darkened to pass 3:1) */
+  --v-accent-pink: color-mix(
+    in oklab,
+    var(--mk-seed-accent) 88%,
+    var(--v-ink)
+  ); /* SHARE. */
+
+  /* ---- Radii: editorial = sharp. Near-zero rounding everywhere. ---- */
+  --mk-radius-card: 4px;
+  --v-radius-pill: 999px; /* only for diagram nodes / contributor avatars */
+
+  /* ---- Shadows: minimal; editorial leans on hairlines, not elevation ---- */
+  --shadow-mk-xs: 0 1px 0 0 var(--mk-border);
+  --shadow-mk-md: 0 2px 0 0 var(--mk-border);
+  --shadow-mk-lg: 0 8px 28px -12px rgb(21 19 15 / 0.22);
+
+  /* ---- Display font wired into shared headings ---- */
+  --v-font-display: "Fraunces", "Times New Roman", Georgia, serif;
+  --font-mk-heading: var(--v-font-display);
+
+  /* ---- Texture + motion knobs ---- */
+  --v-grain-opacity: 0.035; /* paper grain, light */
+}
+
+/* Closing-cover inverts to ink ground in BOTH modes; supply paper text there. */
+.v-editorial .editorial-invert {
+  --mk-bg: var(--v-ink);
+  --mk-card: var(--v-ink);
+  --mk-text-strong: var(--v-paper);
+  --mk-text-body: #e7e1d6;
+  --mk-text-muted: #b7af9f; /* ~AA on ink */
+  --mk-border: #3a352c;
+}
+
+/* ---- Dark editorial: newsprint-at-night, not pure black ---- */
+.dark .v-editorial {
+  --v-paper: #16140f; /* dark "paper" */
+  --v-ink: #f4efe4; /* light "ink"  */
+
+  --mk-ground: var(--v-paper);
+  --mk-card-base: #1d1a14;
+  --mk-bg: var(--v-paper);
+  --mk-card: var(--mk-card-base);
+  --mk-muted: #211d16;
+
+  --mk-text-strong: #f4efe4; /* AA+ on dark paper */
+  --mk-text-body: #ddd5c6;
+  --mk-text-muted: #a59c8a; /* >=4.5:1 on --mk-muted */
+
+  --mk-border: #38322a;
+  --mk-input-border: #463f34;
+
+  --v-accent: #ff5167; /* brighter red so it pops & passes on dark */
+  --v-accent-ink: #ff8a98; /* accent body text on dark — >=4.5:1 */
+  --mk-ring: var(--v-accent);
+
+  --v-accent-violet: color-mix(
+    in oklab,
+    var(--mk-seed-primary) 70%,
+    var(--v-ink)
+  );
+  --v-accent-green: var(--mk-seed-secondary); /* fine & bright on dark */
+  --v-accent-pink: var(--mk-seed-accent);
+
+  --shadow-mk-lg: 0 8px 28px -12px rgb(0 0 0 / 0.55);
+  --v-grain-opacity: 0.05; /* allowed up to ~0.09 dark — keep low */
+}
+
+/* Dark + inverted closing cover flips back to a light ink for contrast */
+.dark .v-editorial .editorial-invert {
+  --mk-bg: #0e0c09;
+  --mk-card: #0e0c09;
+  --mk-text-strong: #f7f4ee;
+  --mk-text-body: #e7e1d6;
+  --mk-text-muted: #b7af9f;
+  --mk-border: #2a251e;
+}
+
+/* ===========================================================================
+   Variant-only styling (all scoped under .v-editorial)
+   =========================================================================== */
+
+/* Paper grain overlay — pure inline SVG feTurbulence, no binary asset.
+   Applied via the <Paper> wrapper. Decorative, never affects layout/contrast. */
+.v-editorial .grain {
+  position: relative;
+}
+.v-editorial .grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: var(--v-grain-opacity);
+  mix-blend-mode: multiply;
+}
+.dark .v-editorial .grain::after {
+  mix-blend-mode: screen;
+}
+.v-editorial .grain > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* The hero headline — three stacked oversized display words. */
+.v-editorial .ed-headline {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  font-size: clamp(40px, 11vw, 128px);
+  line-height: 0.92;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.v-editorial .ed-headline span.ed-word {
+  display: block;
+}
+/* The period after each word is the recurring accent punctuation motif. */
+.v-editorial .ed-headline .ed-dot {
+  color: var(--v-accent);
+  display: inline-block;
+}
+
+/* Optional micro-flourish: the accent periods scale/fade in. */
+@keyframes ed-dot-in {
+  from {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.v-editorial .ed-headline .ed-dot {
+  animation: ed-dot-in 280ms var(--ease-mk-out, ease-out) both;
+}
+.v-editorial .ed-headline .ed-word:nth-child(1) .ed-dot {
+  animation-delay: 120ms;
+}
+.v-editorial .ed-headline .ed-word:nth-child(2) .ed-dot {
+  animation-delay: 220ms;
+}
+.v-editorial .ed-headline .ed-word:nth-child(3) .ed-dot {
+  animation-delay: 320ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  .v-editorial .ed-headline .ed-dot {
+    animation: none;
+  }
+}
+
+/* Big-number figures band. */
+.v-editorial .ed-figure {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  font-size: clamp(52px, 9vw, 128px);
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--mk-text-strong);
+}
+
+/* Manifesto pull-quote. */
+.v-editorial .ed-quote {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  font-size: clamp(30px, 5.5vw, 68px);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  color: var(--mk-text-strong);
+}
+.v-editorial .ed-quote .ed-quote-accent {
+  color: var(--v-accent);
+}
+/* The hanging quotation mark. */
+.v-editorial .ed-quote-mark {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  color: var(--v-accent);
+  line-height: 0.7;
+  font-size: clamp(56px, 9vw, 120px);
+}
+
+/* The loop spreads watermark numerals. */
+.v-editorial .ed-watermark {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  font-size: clamp(72px, 14vw, 200px);
+  line-height: 0.8;
+  letter-spacing: -0.03em;
+  color: color-mix(in oklab, var(--v-accent) 18%, transparent);
+  user-select: none;
+}
+
+/* Founders' letter drop-cap. */
+.v-editorial .ed-dropcap::first-letter {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  float: left;
+  line-height: 0.78;
+  font-size: clamp(58px, 9vw, 92px);
+  padding-right: 0.08em;
+  margin-top: 0.04em;
+  color: var(--v-accent);
+}
+
+/* Closing cover big-type lockup. */
+.v-editorial .ed-bigtype {
+  font-family: var(--v-font-display);
+  font-weight: 800;
+  font-size: clamp(46px, 10vw, 132px);
+  line-height: 0.92;
+  letter-spacing: -0.02em;
+  color: var(--mk-text-strong);
+}
+.v-editorial .ed-bigtype .ed-dot {
+  color: var(--v-accent);
+}
+
+/* Mono labels (kickers, rules, datelines). */
+.v-editorial .ed-mono {
+  font-family:
+    ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas,
+    monospace;
 }

--- a/apps/web/src/components/marketing/variants/editorial/editorial.css
+++ b/apps/web/src/components/marketing/variants/editorial/editorial.css
@@ -1,119 +1,71 @@
 /* apps/web/src/components/marketing/variants/editorial/editorial.css
-   Bold / Editorial: ink-on-paper near-monochrome, ONE editorial accent (red),
-   oversized Fraunces display. Re-points --mk-* so shared Button/Section/cards,
-   header & footer re-skin with zero component edits. All overrides live under
-   .v-editorial (and .dark .v-editorial); never touches the global token file. */
+   Bold / Editorial: oversized Fraunces display + asymmetric magazine layout.
+   Keeps JigSwap's ORIGINAL brand palette — only the LAYOUT and typography
+   change. Surfaces, text, border and ring all inherit the global brand --mk-*;
+   this file only sets the display font, sharp radii, hairline shadows, and
+   which brand hue plays the recurring editorial "accent". All scoped under
+   .v-editorial; never touches the global token file. */
 
 /* ONE display family, loaded only here. Two weights max (400 + 800). */
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,800&display=swap");
 
 .v-editorial {
-  /* ---- Paper + ink grounds (literal: bright off-white page, near-black ink) ---- */
-  --v-paper: #f7f4ee; /* warm off-white — keeps the kitchen-table warmth */
-  --v-ink: #15130f; /* near-black, faintly warm (not pure #000) */
+  /* The recurring editorial accent = the signature brand violet. */
+  --v-accent: var(
+    --mk-violet-600
+  ); /* punctuation, kickers, watermark, accent word */
+  --v-accent-ink: var(
+    --mk-violet-700
+  ); /* accent BODY text (AA 4.5:1 on light) */
 
-  --mk-ground: var(--v-paper);
-  --mk-card-base: #fffdf8;
-  --mk-bg: var(--v-paper);
-  --mk-card: var(--mk-card-base);
-  --mk-muted: #efe9df; /* the tinted band ground (figures/custody) */
+  /* Hero three-word display colours — the brand trio (large text, >=3:1). */
+  --v-accent-violet: var(--mk-violet-600); /* LEND. */
+  --v-accent-green: var(--mk-green-600); /* SWAP. */
+  --v-accent-pink: var(--mk-pink-500); /* SHARE. */
 
-  /* ---- Ink scale (still warm, AA on paper) ---- */
-  --mk-text-strong: #15130f; /* ~16:1 on paper */
-  --mk-text-body: #38332b; /* ~9:1  on paper */
-  --mk-text-muted: #655d52; /* darkened so it clears AA on the muted band too */
-
-  --mk-border: #d8cfbf;
-  --mk-input-border: #c9bfac;
-
-  /* ---- ONE editorial accent (high-chroma red) ---- */
-  --v-accent: #d6253b; /* punctuation, kickers, watermark, accent word */
-  --v-accent-ink: #b21d30; /* the same accent darkened for accent BODY text (AA 4.5:1) */
-  --mk-ring: var(--v-accent);
-  --shadow-mk-brand: 0 10px 30px -8px rgb(214 37 59 / 0.32);
-
-  /* ---- Hero three-word display colors (large text only; >=3:1 on paper) ---- */
-  --v-accent-violet: var(--mk-seed-primary); /* LEND. */
-  --v-accent-green: color-mix(
-    in oklab,
-    var(--mk-seed-secondary) 78%,
-    var(--v-ink)
-  ); /* SWAP. (darkened to pass 3:1) */
-  --v-accent-pink: color-mix(
-    in oklab,
-    var(--mk-seed-accent) 88%,
-    var(--v-ink)
-  ); /* SHARE. */
-
-  /* ---- Radii: editorial = sharp. Near-zero rounding everywhere. ---- */
+  /* Editorial = sharp. Near-zero rounding everywhere. */
   --mk-radius-card: 4px;
   --v-radius-pill: 999px; /* only for diagram nodes / contributor avatars */
 
-  /* ---- Shadows: minimal; editorial leans on hairlines, not elevation ---- */
+  /* Minimal elevation: editorial leans on hairlines, not shadows. The hairline
+     shadows pick up the (brand) --mk-border automatically. */
   --shadow-mk-xs: 0 1px 0 0 var(--mk-border);
   --shadow-mk-md: 0 2px 0 0 var(--mk-border);
-  --shadow-mk-lg: 0 8px 28px -12px rgb(21 19 15 / 0.22);
+  --shadow-mk-lg: 0 8px 28px -12px rgb(31 27 46 / 0.22);
 
-  /* ---- Display font wired into shared headings ---- */
+  /* Display font wired into shared headings. */
   --v-font-display: "Fraunces", "Times New Roman", Georgia, serif;
   --font-mk-heading: var(--v-font-display);
 
-  /* ---- Texture + motion knobs ---- */
-  --v-grain-opacity: 0.035; /* paper grain, light */
+  /* Paper grain knob (decorative, never affects layout/contrast). */
+  --v-grain-opacity: 0.04;
 }
 
-/* Closing-cover inverts to ink ground in BOTH modes; supply paper text there. */
+/* Closing cover = a dramatic deep brand-violet block in both modes (the
+   signature hue at full depth), with light type. Layout device only — echoes
+   the original violet final-CTA. */
 .v-editorial .editorial-invert {
-  --mk-bg: var(--v-ink);
-  --mk-card: var(--v-ink);
-  --mk-text-strong: var(--v-paper);
-  --mk-text-body: #e7e1d6;
-  --mk-text-muted: #b7af9f; /* ~AA on ink */
-  --mk-border: #3a352c;
+  --mk-bg: var(--mk-violet-900);
+  --mk-card: var(--mk-violet-900);
+  --mk-text-strong: #ffffff;
+  --mk-text-body: color-mix(in oklab, #ffffff 86%, var(--mk-seed-primary));
+  --mk-text-muted: color-mix(in oklab, #ffffff 66%, var(--mk-seed-primary));
+  --mk-border: color-mix(in oklab, #ffffff 22%, transparent);
+  --v-accent: var(--mk-pink-400); /* accent pops against the deep violet */
 }
 
-/* ---- Dark editorial: newsprint-at-night, not pure black ---- */
+/* Dark editorial inherits the global brand .dark surfaces/text; only the
+   accent + grain shift for legibility on the dark ground. */
 .dark .v-editorial {
-  --v-paper: #16140f; /* dark "paper" */
-  --v-ink: #f4efe4; /* light "ink"  */
+  --v-accent: var(--mk-violet-400);
+  --v-accent-ink: var(--mk-violet-300);
 
-  --mk-ground: var(--v-paper);
-  --mk-card-base: #1d1a14;
-  --mk-bg: var(--v-paper);
-  --mk-card: var(--mk-card-base);
-  --mk-muted: #211d16;
-
-  --mk-text-strong: #f4efe4; /* AA+ on dark paper */
-  --mk-text-body: #ddd5c6;
-  --mk-text-muted: #a59c8a; /* >=4.5:1 on --mk-muted */
-
-  --mk-border: #38322a;
-  --mk-input-border: #463f34;
-
-  --v-accent: #ff5167; /* brighter red so it pops & passes on dark */
-  --v-accent-ink: #ff8a98; /* accent body text on dark — >=4.5:1 */
-  --mk-ring: var(--v-accent);
-
-  --v-accent-violet: color-mix(
-    in oklab,
-    var(--mk-seed-primary) 70%,
-    var(--v-ink)
-  );
-  --v-accent-green: var(--mk-seed-secondary); /* fine & bright on dark */
-  --v-accent-pink: var(--mk-seed-accent);
+  --v-accent-violet: var(--mk-violet-400);
+  --v-accent-green: var(--mk-green-400);
+  --v-accent-pink: var(--mk-pink-400);
 
   --shadow-mk-lg: 0 8px 28px -12px rgb(0 0 0 / 0.55);
-  --v-grain-opacity: 0.05; /* allowed up to ~0.09 dark — keep low */
-}
-
-/* Dark + inverted closing cover flips back to a light ink for contrast */
-.dark .v-editorial .editorial-invert {
-  --mk-bg: #0e0c09;
-  --mk-card: #0e0c09;
-  --mk-text-strong: #f7f4ee;
-  --mk-text-body: #e7e1d6;
-  --mk-text-muted: #b7af9f;
-  --mk-border: #2a251e;
+  --v-grain-opacity: 0.06; /* allowed up to ~0.09 dark — keep low */
 }
 
 /* ===========================================================================

--- a/apps/web/src/components/marketing/variants/editorial/figure.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/figure.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+
+// A single big-number editorial figure. The giant numeral is decorative scale
+// (aria-hidden); the sr-only <figcaption> carries the real meaning for screen
+// readers. While loading we show a pulsing bar placeholder — never "0".
+export function Figure({
+  value,
+  caption,
+  sentence,
+  loading,
+  className,
+}: {
+  value: string;
+  caption: string;
+  /** Full sentence for screen readers, e.g. "312 puzzles in circulation". */
+  sentence: string;
+  loading: boolean;
+  className?: string;
+}) {
+  return (
+    <figure className={cn("px-[clamp(16px,4vw,40px)]", className)}>
+      {loading ? (
+        <div
+          aria-hidden="true"
+          className="h-[clamp(52px,9vw,128px)] flex items-end"
+        >
+          <span className="block w-[60%] h-[0.62em] rounded-[2px] bg-mk-border animate-pulse" />
+        </div>
+      ) : (
+        <div aria-hidden="true" className="ed-figure">
+          {value}
+        </div>
+      )}
+      <div
+        aria-hidden="true"
+        className="ed-mono mt-3 text-[12px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted"
+      >
+        {caption}
+      </div>
+      <figcaption className="sr-only">
+        {loading ? `Loading ${caption}` : sentence}
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/figures-band.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/figures-band.tsx
@@ -1,0 +1,48 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import { useFormatter } from "use-intl";
+
+import { Figure } from "./figure";
+
+// Big-number band: the three live platform numbers rendered as enormous
+// editorial figures — credibility through scale, "the issue stats".
+export function FiguresBand({ data }: { data: LandingData }) {
+  const format = useFormatter();
+  const { stats } = data;
+  const loading = stats == null;
+
+  const n = (v: number) => format.number(v);
+
+  return (
+    <section className="bg-mk-muted border-y border-mk-border py-[clamp(48px,7vw,88px)]">
+      <Container>
+        <Reveal>
+          <div className="grid min-[861px]:grid-cols-3 divide-y min-[861px]:divide-y-0 min-[861px]:divide-x divide-mk-border text-center">
+            <Figure
+              loading={loading}
+              value={stats ? n(stats.totalUsers) : "—"}
+              caption="puzzlers"
+              sentence={`${stats ? n(stats.totalUsers) : ""} puzzlers in the community`}
+              className="py-7 min-[861px]:py-0"
+            />
+            <Figure
+              loading={loading}
+              value={stats ? n(stats.totalPuzzles) : "—"}
+              caption="in circulation"
+              sentence={`${stats ? n(stats.totalPuzzles) : ""} puzzles in circulation`}
+              className="py-7 min-[861px]:py-0"
+            />
+            <Figure
+              loading={loading}
+              value={stats ? n(stats.totalOwnedPuzzles) : "—"}
+              caption="on shelves"
+              sentence={`${stats ? n(stats.totalOwnedPuzzles) : ""} puzzles on shelves`}
+              className="py-7 min-[861px]:py-0"
+            />
+          </div>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/footer.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/footer.tsx
@@ -1,0 +1,147 @@
+import { Link } from "@/compat/link";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import { Wordmark } from "@/components/marketing/wordmark";
+
+// Editorial footer / colophon (rebuilt from MarketingFooter). Publication
+// credits: a top hairline rule echo, the wordmark + positioning + issue line,
+// nav columns, and a live "Contributors" avatars row. Keeps the <footer>
+// landmark and the same nav destinations; re-skins via --mk-* under .v-editorial.
+
+const PRODUCT = [
+  { href: "/how-it-works", label: "How it works" },
+  { href: "/features", label: "Features" },
+  { href: "/docs", label: "Docs" },
+  { href: "/sign-up", label: "Get on the shelf" },
+] as const;
+
+const LEGAL = [
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/terms", label: "Terms" },
+] as const;
+
+const AVATAR_COLORS = [
+  "var(--mk-violet-400)",
+  "var(--mk-green-500)",
+  "var(--mk-pink-400)",
+  "var(--mk-violet-600)",
+] as const;
+
+export function EditorialFooter({ data }: { data: LandingData }) {
+  const avatars = data.communityAvatars;
+  const hasLive = avatars != null && avatars.length >= 1;
+
+  return (
+    <footer className="border-t border-mk-border bg-mk-card">
+      <div className="w-full max-w-[1200px] mx-auto px-6">
+        {/* Masthead echo rule */}
+        <div className="h-[34px] flex items-center justify-between border-b border-mk-border ed-mono text-[11px] tracking-[0.18em] uppercase text-mk-text-muted">
+          <span>JigSwap</span>
+          <span className="max-[540px]:hidden">Colophon</span>
+          <span>2025</span>
+        </div>
+
+        <div className="grid gap-10 py-[clamp(40px,6vw,72px)] min-[861px]:[grid-template-columns:2fr_1fr_1fr_1.5fr] max-[860px]:grid-cols-2 max-[540px]:grid-cols-1">
+          {/* (1) Wordmark + positioning + issue line */}
+          <div className="max-w-[340px]">
+            <Wordmark />
+            <p className="mt-4 text-[14.5px] leading-relaxed text-mk-text-body text-pretty">
+              Puzzling, redrawn — a bold home for the people who love finishing
+              them and passing them on.
+            </p>
+            <p className="mt-5 ed-mono text-[11px] tracking-[0.14em] uppercase text-mk-text-muted">
+              Issue 01 · Est. 2025 · Made in the Netherlands
+            </p>
+          </div>
+
+          {/* (2) Product nav */}
+          <FooterCol title="Index" links={PRODUCT} />
+
+          {/* (3) Legal / secondary */}
+          <FooterCol title="More" links={LEGAL} />
+
+          {/* (4) Contributors */}
+          <div>
+            <div className="ed-mono text-[11px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted">
+              Contributors
+            </div>
+            <div className="mt-4 flex items-center" aria-hidden="true">
+              {hasLive
+                ? avatars.map((member, i) =>
+                    member.image != null ? (
+                      <span
+                        key={i}
+                        className="w-7 h-7 rounded-full inline-flex items-center justify-center border-2 border-mk-card overflow-hidden"
+                        style={{ marginLeft: i ? -8 : 0 }}
+                      >
+                        <img
+                          src={member.image}
+                          alt=""
+                          className="w-full h-full rounded-full object-cover"
+                        />
+                      </span>
+                    ) : (
+                      <span
+                        key={i}
+                        className="w-7 h-7 rounded-full text-white font-mk-heading font-semibold text-[11px] inline-flex items-center justify-center border-2 border-mk-card"
+                        style={{
+                          background: AVATAR_COLORS[i % AVATAR_COLORS.length],
+                          marginLeft: i ? -8 : 0,
+                        }}
+                      >
+                        {member.initials}
+                      </span>
+                    ),
+                  )
+                : AVATAR_COLORS.map((bg, i) => (
+                    <span
+                      key={i}
+                      className="w-7 h-7 rounded-full border-2 border-mk-card bg-mk-muted"
+                      style={{ background: bg, marginLeft: i ? -8 : 0 }}
+                    />
+                  ))}
+            </div>
+            <p className="mt-3 text-[13px] text-mk-text-muted">
+              The JigSwap community
+            </p>
+          </div>
+        </div>
+
+        <div className="py-6 border-t border-mk-border flex justify-between items-center flex-wrap gap-3">
+          <span className="text-[13px] text-mk-text-muted">
+            © {new Date().getFullYear()} JigSwap
+          </span>
+          <span className="ed-mono text-[11px] tracking-[0.16em] uppercase text-mk-text-muted">
+            Netherlands
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterCol({
+  title,
+  links,
+}: {
+  title: string;
+  links: readonly { href: string; label: string }[];
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="ed-mono text-[11px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted">
+        {title}
+      </div>
+      {links.map((lk) => (
+        <Link
+          key={lk.href + lk.label}
+          href={lk.href}
+          className="text-[14.5px] text-mk-text-body transition-colors hover:text-mk-text-strong hover:underline underline-offset-4 decoration-[var(--v-accent)]"
+        >
+          {lk.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/founders-letter.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/founders-letter.tsx
@@ -1,0 +1,33 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+
+import { RuleLabel } from "./rule";
+
+// Founders' letter — reframed as a magazine "letter from the founders". This is
+// where the warmth is protected: real family, est. 2025, Netherlands, on
+// readable --mk-text-body. The drop-cap is decorative (::first-letter) and does
+// not alter the real text.
+export function FoundersLetter() {
+  return (
+    <section>
+      <RuleLabel label="No. 03 — A letter" />
+      <Container narrow className="pb-[clamp(48px,8vw,112px)]">
+        <Reveal>
+          <p className="ed-mono text-[12px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted">
+            A letter · Netherlands · 2025
+          </p>
+          <blockquote className="mt-7">
+            <p className="ed-dropcap text-[clamp(19px,2.2vw,26px)] leading-relaxed text-mk-text-body text-pretty">
+              We built JigSwap because our finished puzzles deserved better than
+              the attic — and because puzzling is more fun when you share it.
+            </p>
+            <footer className="mt-6 text-[15px] text-mk-text-muted">
+              — The family behind JigSwap, puzzling at the kitchen table since
+              2025.
+            </footer>
+          </blockquote>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/header.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/header.tsx
@@ -1,0 +1,223 @@
+import { Link } from "@/compat/link";
+import { Wordmark } from "@/components/marketing/wordmark";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { clearIntlCache, type Locale, setLocale } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
+import { useLocation, useRouter } from "@tanstack/react-router";
+import { Authenticated, Unauthenticated } from "convex/react";
+import { Menu, Moon, Sun, X } from "lucide-react";
+import { useTheme } from "next-themes";
+import * as React from "react";
+import { useLocale, useTranslations } from "use-intl";
+
+// Editorial masthead header (rebuilt from MarketingHeader). Two-row magazine
+// masthead: an "issue rule" over the nameplate. Keeps the same NAV
+// destinations, auth Buttons, ModeToggle + LangToggle, and the semantic
+// <header> landmark. Re-skins via --mk-* under .v-editorial like everything else.
+
+const NAV = [
+  { href: "/how-it-works", key: "howItWorks" },
+  { href: "/features", key: "features" },
+  { href: "/about", key: "about" },
+  { href: "/docs", key: "docs" },
+  { href: "/contact", key: "contact" },
+] as const;
+
+export function EditorialHeader() {
+  const t = useTranslations("marketing.nav");
+  const { pathname } = useLocation();
+  const [scrolled, setScrolled] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const navLink = (item: (typeof NAV)[number], mobile = false) => (
+    <Link
+      key={item.href}
+      href={item.href}
+      onClick={() => setOpen(false)}
+      className={cn(
+        mobile
+          ? "text-[17px] font-semibold text-mk-text-strong py-3 px-1 border-b border-mk-border"
+          : "text-[14px] font-medium tracking-tight py-1.5 transition-colors hover:text-mk-text-strong",
+        !mobile &&
+          (pathname === item.href
+            ? "text-mk-text-strong"
+            : "text-mk-text-body"),
+      )}
+    >
+      {t(item.key)}
+    </Link>
+  );
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-50 transition-[background-color,border-color] duration-250 border-b",
+        scrolled
+          ? "bg-[color-mix(in_oklab,var(--mk-card)_90%,transparent)] backdrop-blur-md border-mk-border"
+          : "bg-transparent border-transparent",
+      )}
+    >
+      {/* Row 1 — the masthead rule (desktop) */}
+      <div className="hidden min-[861px]:block border-b border-mk-border">
+        <div className="w-full max-w-[1200px] mx-auto px-6 h-[34px] flex items-center justify-between ed-mono text-[11px] tracking-[0.18em] uppercase text-mk-text-muted">
+          <span>EST. 2025</span>
+          <span className="text-mk-text-body">
+            MADE AT A DUTCH KITCHEN TABLE
+          </span>
+          <span>NETHERLANDS</span>
+        </div>
+      </div>
+      {/* Row 1 — compact rule (mobile) */}
+      <div className="min-[861px]:hidden border-b border-mk-border">
+        <div className="w-full max-w-[1200px] mx-auto px-6 h-[26px] flex items-center ed-mono text-[10px] tracking-[0.18em] uppercase text-mk-text-muted">
+          EST. 2025 · NL
+        </div>
+      </div>
+
+      {/* Row 2 — the nameplate */}
+      <div className="w-full max-w-[1200px] mx-auto px-6 flex items-center gap-5 h-16 border-b border-mk-border">
+        <Link href="/" aria-label="JigSwap">
+          <Wordmark size={26} />
+        </Link>
+        <nav className="hidden min-[861px]:flex items-center gap-[26px] ml-auto">
+          {NAV.map((item) => navLink(item))}
+        </nav>
+        <div className="hidden min-[861px]:flex items-center gap-2.5">
+          <LangToggle />
+          <ModeToggle />
+          <Unauthenticated>
+            <Link
+              href="/sign-in"
+              className="text-[14px] font-semibold text-mk-text-body py-1.5 px-1 transition-colors hover:text-mk-text-strong"
+            >
+              {t("login")}
+            </Link>
+            <Button variant="brand" asChild>
+              <Link href="/sign-up">{t("startTrading")}</Link>
+            </Button>
+          </Unauthenticated>
+          <Authenticated>
+            <Button variant="brand" asChild>
+              <Link href="/dashboard">{t("dashboard")}</Link>
+            </Button>
+          </Authenticated>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-label={open ? t("closeMenu") : t("openMenu")}
+          aria-expanded={open}
+          className="min-[861px]:hidden ml-auto inline-flex items-center justify-center w-11 h-11 rounded-[4px] border border-mk-border bg-mk-card text-mk-text-body"
+        >
+          {open ? <X size={20} /> : <Menu size={20} />}
+        </button>
+      </div>
+
+      {/* Mobile sheet */}
+      {open && (
+        <div className="min-[861px]:hidden border-b border-mk-border bg-mk-card">
+          <div className="w-full max-w-[1200px] mx-auto flex flex-col gap-1 px-6 pt-3 pb-[18px]">
+            <div className="flex items-center gap-2.5 pb-3 mb-1 border-b border-mk-border">
+              <LangToggle />
+              <ModeToggle />
+            </div>
+            {NAV.map((item) => navLink(item, true))}
+            <Unauthenticated>
+              <Link
+                href="/sign-in"
+                onClick={() => setOpen(false)}
+                className="text-[17px] font-semibold text-mk-text-strong py-3 px-1 border-b border-mk-border"
+              >
+                {t("login")}
+              </Link>
+              <Button variant="brand" className="mt-3 w-full" asChild>
+                <Link href="/sign-up" onClick={() => setOpen(false)}>
+                  {t("startTrading")}
+                </Link>
+              </Button>
+            </Unauthenticated>
+            <Authenticated>
+              <Button variant="brand" className="mt-3 w-full" asChild>
+                <Link href="/dashboard" onClick={() => setOpen(false)}>
+                  {t("dashboard")}
+                </Link>
+              </Button>
+            </Authenticated>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
+
+const LANGUAGES = [
+  { code: "en", name: "English", flag: "🇺🇸" },
+  { code: "nl", name: "Nederlands", flag: "🇳🇱" },
+] as const satisfies readonly { code: Locale; name: string; flag: string }[];
+
+function LangToggle() {
+  const t = useTranslations("marketing.nav");
+  const locale = useLocale();
+  const router = useRouter();
+  const change = async (next: Locale) => {
+    if (next === locale) return;
+    await setLocale({ data: next });
+    clearIntlCache();
+    await router.invalidate();
+  };
+  const current =
+    LANGUAGES.find((lang) => lang.code === locale) ?? LANGUAGES[0];
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={t("switchLanguage")}
+          className="inline-flex items-center justify-center w-11 h-11 rounded-[4px] border border-mk-border bg-mk-card text-[18px] leading-none"
+        >
+          {current.flag}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {LANGUAGES.map((language) => (
+          <DropdownMenuItem
+            key={language.code}
+            onClick={() => change(language.code)}
+            className={cn(locale === language.code && "bg-accent")}
+          >
+            <span className="mr-2">{language.flag}</span>
+            {language.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      aria-label="Toggle dark mode"
+      className="inline-flex items-center justify-center w-11 h-11 rounded-[4px] border border-mk-border bg-mk-card text-mk-text-body"
+    >
+      <Sun size={18} className="hidden dark:block" />
+      <Moon size={18} className="dark:hidden" />
+    </button>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/hero-cover.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/hero-cover.tsx
@@ -1,0 +1,138 @@
+import { Link } from "@/compat/link";
+import { JigPlank3D } from "@/components/marketing/plank-3d";
+import { Reveal } from "@/components/marketing/reveal";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import * as React from "react";
+import { useFormatter } from "use-intl";
+
+import { PLANK_WIDE, toPlankBox, toRows } from "./plank-data";
+
+// Hero / cover — the signature moment. Oversized stacked typographic art on the
+// left, the 3D plank cropped/bleeding off the right edge as a "cover image".
+// The <h1> is pure CSS and fully legible with zero JS / zero motion — it is the
+// real signature, so the hero never depends on the plank. The plank reuses
+// JigPlank3D (lazy + WebGL-gated + reduced-motion-gated internally).
+
+export function HeroCover({ data }: { data: LandingData }) {
+  const startHref = useStartHref();
+  const format = useFormatter();
+  const { stats, plankPuzzles } = data;
+
+  const rows = React.useMemo(
+    () =>
+      toRows(
+        plankPuzzles && plankPuzzles.length >= 3
+          ? plankPuzzles.map(toPlankBox)
+          : PLANK_WIDE,
+      ),
+    [plankPuzzles],
+  );
+
+  const users = stats ? format.number(stats.totalUsers) : "—";
+  const puzzles = stats ? format.number(stats.totalPuzzles) : "—";
+
+  const headline = (
+    <h1 className="ed-headline mt-5">
+      <span className="sr-only">Lend. Swap. Share.</span>
+      <span
+        aria-hidden="true"
+        className="ed-word"
+        style={{ color: "var(--v-accent-violet)" }}
+      >
+        LEND<span className="ed-dot">.</span>
+      </span>
+      <span
+        aria-hidden="true"
+        className="ed-word"
+        style={{ color: "var(--v-accent-green)" }}
+      >
+        SWAP<span className="ed-dot">.</span>
+      </span>
+      <span
+        aria-hidden="true"
+        className="ed-word"
+        style={{ color: "var(--v-accent-pink)" }}
+      >
+        SHARE<span className="ed-dot">.</span>
+      </span>
+    </h1>
+  );
+
+  return (
+    <section className="overflow-x-clip">
+      <div className="w-full max-w-[1200px] mx-auto px-6">
+        <div className="grid items-center gap-10 min-[861px]:[grid-template-columns:minmax(0,7fr)_minmax(0,5fr)] pt-[clamp(40px,7vw,88px)] pb-[clamp(56px,8vw,112px)]">
+          {/* Type column */}
+          <div className="text-left">
+            <Reveal>
+              <p className="ed-mono text-[12px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted">
+                <span className="text-mk-text-strong">Est. 2025</span> · Made at
+                a Dutch kitchen table
+              </p>
+              {headline}
+              <p className="mt-7 text-[clamp(16px,1.4vw,19px)] leading-relaxed text-mk-text-body max-w-[42ch] text-pretty">
+                A library for jigsaw people. Build your shelf, pass your puzzles
+                on, never lose a box.
+              </p>
+              <div className="mt-8 flex flex-wrap items-center gap-3">
+                <Button
+                  variant="brand"
+                  className="h-11 px-6 text-[15px] rounded-[4px]"
+                  asChild
+                >
+                  <Link href={startHref}>
+                    Get on the shelf
+                    <ArrowRight size={17} />
+                  </Link>
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="h-11 px-4 text-[15px] rounded-[4px] text-mk-text-strong underline underline-offset-4 decoration-mk-border hover:bg-transparent hover:decoration-[var(--v-accent)]"
+                  asChild
+                >
+                  <Link href="/how-it-works">Read how it works</Link>
+                </Button>
+              </div>
+              <p className="mt-7 text-[14px] text-mk-text-muted">
+                <span className="text-mk-text-strong font-semibold tabular-nums">
+                  {users}
+                </span>{" "}
+                puzzlers ·{" "}
+                <span className="text-mk-text-strong font-semibold tabular-nums">
+                  {puzzles}
+                </span>{" "}
+                puzzles in the catalogue
+              </p>
+            </Reveal>
+          </div>
+
+          {/* Plank — desktop: bleeds off the right edge as a cropped cover */}
+          <div className="hidden min-[861px]:block relative" aria-hidden="true">
+            <div
+              className="relative"
+              style={{
+                height: "clamp(380px, 38vw, 540px)",
+                marginRight: "calc(50% - 50vw)",
+                transform: "rotate(-1.5deg)",
+              }}
+            >
+              <JigPlank3D rows={rows} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Plank — mobile: contained band below the type, no bleed */}
+      <div
+        className="min-[861px]:hidden border-y border-mk-border relative overflow-hidden"
+        aria-hidden="true"
+        style={{ height: "clamp(220px, 55vw, 360px)" }}
+      >
+        <JigPlank3D rows={rows} />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/index.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/index.tsx
@@ -1,0 +1,13 @@
+import "./editorial.css";
+
+// PLACEHOLDER — replaced by the Frontend Developer building the Bold/Editorial
+// variant. Root must keep the `v-editorial` scope class and import its CSS.
+export default function EditorialLanding() {
+  return (
+    <div className="v-editorial font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
+      <p className="text-mk-text-muted text-sm">
+        Bold/Editorial variant — under construction.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/index.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/index.tsx
@@ -1,13 +1,41 @@
-import "./editorial.css";
+import { useLandingData } from "@/components/marketing/variants/use-landing-data";
 
-// PLACEHOLDER — replaced by the Frontend Developer building the Bold/Editorial
-// variant. Root must keep the `v-editorial` scope class and import its CSS.
+import { ClosingCover } from "./closing-cover";
+import { CustodySpread } from "./custody-spread";
+import "./editorial.css";
+import { FiguresBand } from "./figures-band";
+import { EditorialFooter } from "./footer";
+import { FoundersLetter } from "./founders-letter";
+import { EditorialHeader } from "./header";
+import { HeroCover } from "./hero-cover";
+import { LoopSpreads } from "./loop-spreads";
+import { Manifesto } from "./manifesto";
+import { Paper } from "./paper";
+
+// Bold / Editorial landing — a design-magazine cover for a puzzle community.
+// Type-led, asymmetric magazine grid; ink-on-paper with one editorial accent.
+// Single data fetch shared across the page; one <header> / <main> / <footer>
+// landmark set, one <h1> (in the hero). Reuses Reveal/Container/Button/etc.;
+// the plank reuses JigPlank3D (lazy + WebGL/reduced-motion gated internally).
 export default function EditorialLanding() {
+  // One Convex read for the whole page (stats + avatars + plank puzzles).
+  const data = useLandingData({ plankLimit: 12, avatarLimit: 4 });
+
   return (
-    <div className="v-editorial font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
-      <p className="text-mk-text-muted text-sm">
-        Bold/Editorial variant — under construction.
-      </p>
+    <div className="v-editorial font-mk-sans min-h-screen overflow-x-clip bg-mk-bg text-mk-text-body">
+      <EditorialHeader />
+      <Paper as="div" className="bg-mk-bg">
+        <main>
+          <HeroCover data={data} />
+          <FiguresBand data={data} />
+          <Manifesto />
+          <LoopSpreads />
+          <CustodySpread />
+          <FoundersLetter />
+          <ClosingCover />
+        </main>
+      </Paper>
+      <EditorialFooter data={data} />
     </div>
   );
 }

--- a/apps/web/src/components/marketing/variants/editorial/loop-spreads.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/loop-spreads.tsx
@@ -1,0 +1,111 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { cn } from "@/lib/utils";
+
+import { RuleLabel } from "./rule";
+
+// The loop told as three numbered editorial "articles" (01 / 02 / 03),
+// alternating numeral-left / numeral-right. The numeral is a faint watermark
+// (aria-hidden); the kicker → h3 → body carry the meaning in DOM order.
+
+type Spread = {
+  no: string;
+  kicker: string;
+  title: string;
+  body: string;
+};
+
+const SPREADS: Spread[] = [
+  {
+    no: "01",
+    kicker: "No. 01 — Fill your shelf",
+    title: "Catalogue every box.",
+    body: "Shelve your whole collection in one place — covers, piece counts, the lot. Your library, finally organised.",
+  },
+  {
+    no: "02",
+    kicker: "No. 02 — Discover & request",
+    title: "Find your next 1,000 pieces.",
+    body: "Browse what the community is passing on, then request a swap or a borrow. New puzzles, no new clutter.",
+  },
+  {
+    no: "03",
+    kicker: "No. 03 — Lend & track",
+    title: "Pass it on, keep the thread.",
+    body: "Lend a box and JigSwap keeps the receipt — you always see who's got it and when it's coming home.",
+  },
+];
+
+function SpreadRow({ spread, index }: { spread: Spread; index: number }) {
+  const numeralRight = index === 1; // 01 left, 02 right, 03 left
+
+  const numeral = (
+    <div
+      aria-hidden="true"
+      className="hidden min-[861px]:flex items-center justify-center select-none pointer-events-none"
+    >
+      <span className="ed-watermark">{spread.no}</span>
+    </div>
+  );
+
+  const text = (
+    <div className="relative">
+      {/* Mobile watermark: sits behind the text, never pushes layout */}
+      <span
+        aria-hidden="true"
+        className="ed-watermark min-[861px]:hidden absolute -top-4 -left-2 opacity-90 pointer-events-none"
+      >
+        {spread.no}
+      </span>
+      <div className="relative">
+        <p className="ed-mono text-[12px] font-semibold tracking-[0.16em] uppercase text-mk-text-muted">
+          {spread.kicker}
+        </p>
+        <h3 className="font-mk-heading font-bold tracking-tight text-mk-text-strong text-[clamp(28px,4.5vw,46px)] leading-[1.05] mt-3">
+          {spread.title}
+        </h3>
+        <p className="mt-4 text-[clamp(16px,1.3vw,18px)] leading-relaxed text-mk-text-body max-w-[52ch] text-pretty">
+          {spread.body}
+        </p>
+      </div>
+    </div>
+  );
+
+  return (
+    <Reveal delay={index * 80}>
+      <div
+        className={cn(
+          "grid gap-8 items-center py-[clamp(40px,7vw,84px)]",
+          "min-[861px]:[grid-template-columns:minmax(0,4fr)_minmax(0,8fr)]",
+        )}
+      >
+        {numeralRight ? (
+          <>
+            <div className="min-[861px]:order-2">{numeral}</div>
+            <div className="min-[861px]:order-1">{text}</div>
+          </>
+        ) : (
+          <>
+            {numeral}
+            {text}
+          </>
+        )}
+      </div>
+    </Reveal>
+  );
+}
+
+export function LoopSpreads() {
+  return (
+    <section>
+      <RuleLabel label="No. 02 — The loop" />
+      <Container>
+        <div className="divide-y divide-mk-border">
+          {SPREADS.map((spread, i) => (
+            <SpreadRow key={spread.no} spread={spread} index={i} />
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/manifesto.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/manifesto.tsx
@@ -1,0 +1,37 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+
+import { RuleLabel } from "./rule";
+
+// Manifesto block: a single large pull-quote stating the conviction — sharing
+// beats hoarding. Asymmetric: the quote spans the wide column, a mono right
+// rail carries the supporting line.
+export function Manifesto() {
+  return (
+    <section>
+      <RuleLabel label="No. 01 — Manifesto" />
+      <Container className="pb-[clamp(48px,8vw,112px)]">
+        <Reveal>
+          <div className="grid gap-8 min-[861px]:[grid-template-columns:minmax(0,9fr)_minmax(0,3fr)] min-[861px]:items-end">
+            <blockquote className="relative">
+              <span
+                aria-hidden="true"
+                className="ed-quote-mark block mb-[-0.3em]"
+              >
+                &ldquo;
+              </span>
+              <p className="ed-quote max-w-[18ch]">
+                The attic was a terrible place to keep a{" "}
+                <span className="ed-quote-accent">masterpiece</span>.
+              </p>
+            </blockquote>
+            <p className="text-[15px] leading-relaxed text-mk-text-body max-w-[34ch] min-[861px]:text-right">
+              Finished puzzles deserve a second life — and a community to share
+              them with. Sharing beats hoarding.
+            </p>
+          </div>
+        </Reveal>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/paper.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/paper.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+// Wraps a region with the paper-grain overlay (defined in editorial.css as
+// `.grain`). The grain is an absolutely-positioned, aria-hidden ::after at
+// `--v-grain-opacity`; children are lifted above it. Use sparingly on large
+// paper grounds so the page reads like newsprint, never flat-digital.
+export function Paper({
+  as: Tag = "div",
+  className,
+  children,
+  ...rest
+}: {
+  as?: "div" | "section";
+  className?: string;
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLElement>) {
+  return (
+    <Tag className={cn("grain", className)} {...rest}>
+      {children}
+    </Tag>
+  );
+}

--- a/apps/web/src/components/marketing/variants/editorial/plank-data.ts
+++ b/apps/web/src/components/marketing/variants/editorial/plank-data.ts
@@ -1,0 +1,114 @@
+import { type PlankBox } from "@/components/marketing/plank";
+import type { PlankPuzzle } from "@/components/marketing/variants/use-landing-data";
+
+import coverSand from "@/components/marketing/assets/cover-sand.webp";
+
+// Plank data helpers for the editorial hero cover. Mirrors the mapping logic in
+// home/hero.tsx (toPlankBox / toRows) so the cropped plank reads the same real
+// catalog data — we never re-fetch Convex here, the entry passes plankPuzzles in.
+
+const WIDTHS = [100, 134, 96, 108, 90, 104, 98] as const;
+const COLOR_PAIRS: Array<[string, string]> = [
+  ["var(--mk-violet-400)", "var(--mk-violet-600)"],
+  ["var(--mk-green-400)", "var(--mk-green-600)"],
+  ["var(--mk-pink-400)", "var(--mk-pink-500)"],
+  ["var(--mk-violet-300)", "var(--mk-violet-700)"],
+];
+
+const SHELF_ROWS = 5;
+
+// Loading / sparse-catalog fallback boxes (decorative; one real cover).
+export const PLANK_WIDE: PlankBox[] = [
+  {
+    series: "Natuur",
+    title: "Boslicht",
+    pieceCount: 1000,
+    c1: "var(--mk-violet-400)",
+    c2: "var(--mk-violet-600)",
+    width: 100,
+  },
+  {
+    series: "Steden",
+    title: "Amsterdam",
+    pieceCount: 1500,
+    c1: "var(--mk-green-400)",
+    c2: "var(--mk-green-600)",
+    width: 96,
+  },
+  { cover: coverSand, title: "Zandsculpturen", width: 134 },
+  {
+    series: "Kunst",
+    title: "Sterrennacht",
+    pieceCount: 2000,
+    c1: "var(--mk-pink-400)",
+    c2: "var(--mk-pink-500)",
+    width: 108,
+  },
+  {
+    series: "Natuur",
+    title: "Waddenzee",
+    pieceCount: 500,
+    c1: "var(--mk-green-300)",
+    c2: "var(--mk-green-600)",
+    width: 90,
+  },
+  {
+    series: "Steden",
+    title: "Rotterdam",
+    pieceCount: 1000,
+    c1: "var(--mk-violet-300)",
+    c2: "var(--mk-violet-700)",
+    width: 104,
+  },
+  {
+    series: "Kunst",
+    title: "De Melkmeid",
+    pieceCount: 1500,
+    c1: "var(--mk-pink-300)",
+    c2: "var(--mk-pink-500)",
+    width: 98,
+  },
+  {
+    series: "Natuur",
+    title: "Keukenhof",
+    pieceCount: 1000,
+    c1: "var(--mk-green-400)",
+    c2: "var(--mk-green-600)",
+    width: 112,
+  },
+  {
+    series: "Steden",
+    title: "Utrecht",
+    pieceCount: 750,
+    c1: "var(--mk-violet-400)",
+    c2: "var(--mk-violet-600)",
+    width: 94,
+  },
+  {
+    series: "Kunst",
+    title: "De Nachtwacht",
+    pieceCount: 2000,
+    c1: "var(--mk-pink-400)",
+    c2: "var(--mk-pink-500)",
+    width: 118,
+  },
+];
+
+export function toPlankBox(p: PlankPuzzle, i: number): PlankBox {
+  const [c1, c2] = COLOR_PAIRS[i % COLOR_PAIRS.length];
+  return {
+    title: p.title,
+    pieceCount: p.pieceCount,
+    series: p.brand,
+    cover: p.image ?? undefined,
+    width: WIDTHS[i % WIDTHS.length],
+    c1,
+    c2,
+  };
+}
+
+export function toRows(boxes: PlankBox[]): PlankBox[][] {
+  const rows: PlankBox[][] = Array.from({ length: SHELF_ROWS }, () => []);
+  boxes.forEach((box, i) => rows[i % SHELF_ROWS].push(box));
+  return rows;
+}

--- a/apps/web/src/components/marketing/variants/editorial/rule.tsx
+++ b/apps/web/src/components/marketing/variants/editorial/rule.tsx
@@ -1,0 +1,25 @@
+import { Container } from "@/components/marketing/container";
+import { cn } from "@/lib/utils";
+
+// The editorial signature: a hairline horizontal rule with a centered mono
+// label (e.g. "No. 02 — Manifesto"). Used as a divider between major sections.
+// Purely presentational; the label is short context, not a heading.
+export function RuleLabel({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Container className={cn("py-[clamp(28px,5vw,56px)]", className)}>
+      <div className="flex items-center gap-4">
+        <span className="h-px flex-1 bg-mk-border" />
+        <span className="ed-mono text-[11px] font-semibold tracking-[0.22em] uppercase text-mk-text-muted whitespace-nowrap">
+          {label}
+        </span>
+        <span className="h-px flex-1 bg-mk-border" />
+      </div>
+    </Container>
+  );
+}

--- a/apps/web/src/components/marketing/variants/landing.tsx
+++ b/apps/web/src/components/marketing/variants/landing.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+
+import CozyLanding from "./cozy";
+import EditorialLanding from "./editorial";
+import OriginalLanding from "./original";
+import PlayfulLanding from "./playful";
+import { type VariantId } from "./registry";
+import RetroLanding from "./retro";
+import { VariantSwitcher } from "./switcher";
+
+// Renders the active landing-page variant and overlays the floating review
+// switcher. The active variant is owned by the home route (driven by the `?v=`
+// search param) and passed down so selection stays SSR-safe and shareable.
+
+const VARIANT_COMPONENTS: Record<VariantId, React.ComponentType> = {
+  original: OriginalLanding,
+  playful: PlayfulLanding,
+  editorial: EditorialLanding,
+  cozy: CozyLanding,
+  retro: RetroLanding,
+};
+
+export function Landing({
+  variant,
+  onVariantChange,
+}: {
+  variant: VariantId;
+  onVariantChange: (id: VariantId) => void;
+}) {
+  const Active = VARIANT_COMPONENTS[variant] ?? PlayfulLanding;
+  return (
+    <>
+      <Active />
+      <VariantSwitcher current={variant} onChange={onVariantChange} />
+    </>
+  );
+}

--- a/apps/web/src/components/marketing/variants/original/index.tsx
+++ b/apps/web/src/components/marketing/variants/original/index.tsx
@@ -1,0 +1,29 @@
+import { MarketingFooter } from "@/components/marketing/footer";
+import { MarketingHeader } from "@/components/marketing/header";
+import { FeatureRows } from "@/components/marketing/home/feature-rows";
+import { FinalCTA } from "@/components/marketing/home/final-cta";
+import { Hero } from "@/components/marketing/home/hero";
+import { HowPreview } from "@/components/marketing/home/how-preview";
+import { Stats } from "@/components/marketing/home/stats";
+import { Sustain } from "@/components/marketing/home/sustain";
+import { Testimonial } from "@/components/marketing/home/testimonial";
+
+// The current production landing, kept intact as the "original" baseline so it
+// can be compared side-by-side against the redesign variants.
+export default function OriginalLanding() {
+  return (
+    <div className="mk-root font-mk-sans min-h-screen overflow-x-clip">
+      <MarketingHeader />
+      <main>
+        <Hero />
+        <Stats />
+        <HowPreview />
+        <FeatureRows />
+        <Sustain />
+        <Testimonial />
+        <FinalCTA />
+      </main>
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/avatar-cluster.tsx
+++ b/apps/web/src/components/marketing/variants/playful/avatar-cluster.tsx
@@ -1,0 +1,83 @@
+import type { CommunityAvatar } from "@/components/marketing/variants/use-landing-data";
+
+const AVATAR_COLORS = [
+  "var(--mk-violet-400)",
+  "var(--mk-green-500)",
+  "var(--mk-pink-400)",
+  "var(--mk-violet-600)",
+] as const;
+
+// Decorative fallback members shown while the community query is loading or
+// empty. Not real people — purely visual placeholders (aria-hidden anyway).
+const FALLBACK: Array<[string, string]> = [
+  ["MI", "var(--mk-violet-400)"],
+  ["TK", "var(--mk-green-500)"],
+  ["LV", "var(--mk-pink-400)"],
+  ["RJ", "var(--mk-violet-600)"],
+];
+
+// Overlapping circular avatar cluster. Fully decorative (aria-hidden) — the
+// meaning lives in the adjacent live-count text.
+export function AvatarCluster({
+  avatars,
+  size = 38,
+}: {
+  avatars: CommunityAvatar[] | undefined;
+  size?: number;
+}) {
+  const hasLive = avatars != null && avatars.length >= 1;
+  const items = hasLive ? avatars : FALLBACK;
+  return (
+    <div aria-hidden="true" className="flex">
+      {items.map((item, i) => {
+        const overlap = i ? -Math.round(size * 0.29) : 0;
+        if (hasLive) {
+          const member = item as CommunityAvatar;
+          return member.image != null ? (
+            <span
+              key={i}
+              className="rounded-full inline-flex items-center justify-center border-2 border-mk-card overflow-hidden bg-mk-muted"
+              style={{ width: size, height: size, marginLeft: overlap }}
+            >
+              <img
+                src={member.image}
+                alt=""
+                className="w-full h-full rounded-full object-cover"
+              />
+            </span>
+          ) : (
+            <span
+              key={i}
+              className="rounded-full text-white font-mk-heading font-semibold inline-flex items-center justify-center border-2 border-mk-card"
+              style={{
+                width: size,
+                height: size,
+                marginLeft: overlap,
+                fontSize: Math.round(size * 0.34),
+                background: AVATAR_COLORS[i % AVATAR_COLORS.length],
+              }}
+            >
+              {member.initials}
+            </span>
+          );
+        }
+        const [txt, bg] = item as [string, string];
+        return (
+          <span
+            key={txt}
+            className="rounded-full text-white font-mk-heading font-semibold inline-flex items-center justify-center border-2 border-mk-card"
+            style={{
+              width: size,
+              height: size,
+              marginLeft: overlap,
+              fontSize: Math.round(size * 0.34),
+              background: bg,
+            }}
+          >
+            {txt}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/count-up.tsx
+++ b/apps/web/src/components/marketing/variants/playful/count-up.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+// Animated number that tweens 0 → value when `active` flips true. Honors
+// reduced-motion (renders the final value instantly) and renders the final
+// value statically on the server / before activation so no-JS users see a real
+// number, never 0. Uses tabular-nums so the width stays stable while counting.
+export function CountUp({
+  value,
+  active,
+  duration = 900,
+  format,
+  className,
+}: {
+  value: number;
+  active: boolean;
+  duration?: number;
+  format?: (n: number) => string;
+  className?: string;
+}) {
+  const [display, setDisplay] = React.useState(value);
+  const startedRef = React.useRef(false);
+  const fmt = format ?? ((n: number) => String(n));
+
+  React.useEffect(() => {
+    if (!active || startedRef.current) return;
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setDisplay(value);
+      startedRef.current = true;
+      return;
+    }
+    startedRef.current = true;
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      setDisplay(Math.round(eased * value));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    setDisplay(0);
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, value, duration]);
+
+  // Keep in sync if the live value resolves after activation.
+  React.useEffect(() => {
+    if (startedRef.current) setDisplay(value);
+  }, [value]);
+
+  return (
+    <span className={className} style={{ fontVariantNumeric: "tabular-nums" }}>
+      {fmt(display)}
+    </span>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/custody-spotlight.tsx
+++ b/apps/web/src/components/marketing/variants/playful/custody-spotlight.tsx
@@ -1,0 +1,146 @@
+import { Container } from "@/components/marketing/container";
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow, Section } from "@/components/marketing/section";
+import { Package, RotateCcw, User } from "lucide-react";
+import * as React from "react";
+
+// Calm box → person → back-to-you custody diagram. Decorative (aria-hidden);
+// the meaning is in the heading + body. Curved connectors are inline SVG.
+function Node({ children, tint }: { children: React.ReactNode; tint: string }) {
+  return (
+    <div
+      className="relative z-[1] flex flex-col items-center justify-center rounded-[var(--v-radius-card)] bg-mk-card border border-mk-border shadow-mk-sm"
+      style={{
+        width: "clamp(74px,18vw,96px)",
+        height: "clamp(74px,18vw,96px)",
+      }}
+    >
+      <div
+        className="flex items-center justify-center rounded-[14px]"
+        style={{
+          width: 40,
+          height: 40,
+          background: tint,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function CustodyDiagram() {
+  return (
+    <div aria-hidden="true" className="relative w-full">
+      {/* Desktop / tablet: horizontal row with curved connectors. */}
+      <div className="relative flex items-center justify-center gap-[clamp(20px,4vw,44px)] max-[540px]:hidden">
+        <Node tint="color-mix(in oklab, var(--mk-violet-400) 16%, var(--mk-card))">
+          <Package size={22} className="text-mk-violet-600" />
+        </Node>
+        <Connector />
+        <Node tint="color-mix(in oklab, var(--mk-green-400) 18%, var(--mk-card))">
+          <User size={22} className="text-mk-green-600" />
+        </Node>
+        <Connector back />
+        <Node tint="color-mix(in oklab, var(--mk-pink-400) 16%, var(--mk-card))">
+          <RotateCcw size={22} className="text-mk-pink-500" />
+        </Node>
+        {/* soft floating pieces */}
+        <PieceMotif
+          size={26}
+          color="color-mix(in oklab, var(--mk-violet-200) 70%, transparent)"
+          rotate={-16}
+          style={{ position: "absolute", top: -18, right: 8 }}
+        />
+        <PieceMotif
+          size={20}
+          color="color-mix(in oklab, var(--mk-green-200) 70%, transparent)"
+          rotate={22}
+          style={{ position: "absolute", bottom: -16, left: 4 }}
+        />
+      </div>
+
+      {/* 320px: collapse to a vertical box → person → you sequence. */}
+      <div className="hidden max-[540px]:flex flex-col items-center gap-3">
+        <Node tint="color-mix(in oklab, var(--mk-violet-400) 16%, var(--mk-card))">
+          <Package size={22} className="text-mk-violet-600" />
+        </Node>
+        <span className="text-mk-border text-lg leading-none">↓</span>
+        <Node tint="color-mix(in oklab, var(--mk-green-400) 18%, var(--mk-card))">
+          <User size={22} className="text-mk-green-600" />
+        </Node>
+        <span className="text-mk-border text-lg leading-none">↓</span>
+        <Node tint="color-mix(in oklab, var(--mk-pink-400) 16%, var(--mk-card))">
+          <RotateCcw size={22} className="text-mk-pink-500" />
+        </Node>
+      </div>
+    </div>
+  );
+}
+
+function Connector({ back = false }: { back?: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 56 40"
+      aria-hidden="true"
+      className="shrink-0"
+      style={{ width: "clamp(28px,6vw,56px)", height: 40, overflow: "visible" }}
+    >
+      <path
+        d={back ? "M 4 14 Q 28 38 52 14" : "M 4 26 Q 28 2 52 26"}
+        fill="none"
+        stroke="var(--mk-border)"
+        strokeWidth={2}
+        strokeDasharray="4 5"
+        strokeLinecap="round"
+      />
+      <path
+        d={back ? "M 49 18 L 52 14 L 56 17" : "M 49 23 L 52 26 L 56 22"}
+        fill="none"
+        stroke="var(--mk-violet-400)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function CustodySpotlight() {
+  return (
+    <Section tint>
+      <Container>
+        <div className="grid items-center gap-[clamp(32px,4vw,64px)] grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)] max-[860px]:grid-cols-1">
+          <Reveal>
+            <div className="max-w-[520px]">
+              <Eyebrow>Peace of mind</Eyebrow>
+              <h2 className="font-mk-heading font-bold tracking-tight text-mk-text-strong text-[clamp(26px,3.6vw,38px)] leading-[1.1] mt-3.5">
+                Always know who has your box.
+              </h2>
+              <p className="mt-4 text-[clamp(15px,1.3vw,17px)] leading-relaxed text-mk-text-muted text-pretty">
+                Lending something you love shouldn&apos;t feel risky. Every box
+                you send out stays on your shelf as &ldquo;lent&rdquo; — so you
+                always see who has it, and when it&apos;s due back.
+              </p>
+              <p className="mt-5 inline-flex items-center gap-2 text-[15px] font-semibold text-mk-text-strong">
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ background: "var(--mk-green-500)" }}
+                  aria-hidden="true"
+                />
+                Lend freely. Nothing gets lost.
+              </p>
+            </div>
+          </Reveal>
+
+          <Reveal delay={80}>
+            <div className="rounded-[var(--v-radius-card)] bg-mk-card border border-mk-border shadow-mk-sm p-[clamp(24px,4vw,40px)]">
+              <CustodyDiagram />
+            </div>
+          </Reveal>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/draggable-piece.tsx
+++ b/apps/web/src/components/marketing/variants/playful/draggable-piece.tsx
@@ -1,0 +1,321 @@
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import * as React from "react";
+
+// The signature jigsaw path, mirrored from PieceMotif so we can render it at an
+// arbitrary box size (filled for the snapped piece, stroked for the notch).
+const PIECE_PATH = [
+  "M 28 22",
+  "H 42",
+  "A 11 11 0 1 1 58 22",
+  "H 72",
+  "Q 78 22 78 28",
+  "V 42",
+  "A 11 11 0 1 1 78 58",
+  "V 72",
+  "Q 78 78 72 78",
+  "H 58",
+  "A 11 11 0 1 0 42 78",
+  "H 28",
+  "Q 22 78 22 72",
+  "V 28",
+  "Q 22 22 28 22",
+  "Z",
+].join(" ");
+
+// Square SVG that fills its (notch-sized) container.
+function PieceSquare({
+  fill,
+  stroke,
+  dashed = false,
+}: {
+  fill: string;
+  stroke?: string;
+  dashed?: boolean;
+}) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      aria-hidden="true"
+      width="100%"
+      height="100%"
+      style={{ display: "block", overflow: "visible" }}
+    >
+      <path
+        d={PIECE_PATH}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={dashed ? 4 : 0}
+        strokeDasharray={dashed ? "7 6" : undefined}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+type Confetti = {
+  id: number;
+  color: string;
+  vx: number;
+  vy: number;
+  vr: string;
+};
+
+const CONFETTI_COLORS = [
+  "var(--mk-violet-400)",
+  "var(--mk-green-400)",
+  "var(--mk-pink-400)",
+  "var(--mk-violet-600)",
+];
+
+function makeConfetti(): Confetti[] {
+  // 3–4 minis popping outward ~40–60px in an upward fan.
+  const spread = [-118, -54, 28, 96];
+  return spread.map((deg, i) => {
+    const angle = (deg * Math.PI) / 180;
+    const dist = 44 + Math.random() * 16;
+    return {
+      id: i,
+      color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+      vx: Math.cos(angle) * dist,
+      vy: Math.sin(angle) * dist,
+      vr: `${i % 2 === 0 ? "" : "-"}${120 + i * 30}deg`,
+    };
+  });
+}
+
+type PieceState = {
+  interactive: boolean;
+  placed: boolean;
+  dragging: boolean;
+  animateSnap: boolean;
+  confetti: Confetti[];
+  showToast: boolean;
+  targetRef: React.RefObject<HTMLSpanElement | null>;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+};
+
+// All the delight-moment state. Shared between the inline notch (lives in the
+// <h1>) and the tray/caption/toast (a block under the headline) so the headline
+// text flow stays clean.
+function usePieceState(onPlaced?: () => void): PieceState {
+  // Server + first client paint: pre-snapped, no tray (the safe, legible
+  // fallback). After hydration, if motion is allowed, flip to interactive.
+  const [interactive, setInteractive] = React.useState(false);
+  const [placed, setPlaced] = React.useState(true);
+  const [dragging, setDragging] = React.useState(false);
+  const [confetti, setConfetti] = React.useState<Confetti[]>([]);
+  const [showToast, setShowToast] = React.useState(false);
+  const [animateSnap, setAnimateSnap] = React.useState(false);
+  const targetRef = React.useRef<HTMLSpanElement | null>(null);
+  const firedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    const reduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    if (!reduced) {
+      setInteractive(true);
+      setPlaced(false);
+    }
+  }, []);
+
+  const place = React.useCallback(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    setAnimateSnap(true);
+    setPlaced(true);
+    setDragging(false);
+    setConfetti(makeConfetti());
+    setShowToast(true);
+    onPlaced?.();
+    window.setTimeout(() => setConfetti([]), 900);
+    window.setTimeout(() => setShowToast(false), 2100);
+  }, [onPlaced]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (placed) return;
+    (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    setDragging(true);
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (placed || !dragging) return;
+    const target = targetRef.current?.getBoundingClientRect();
+    if (target) {
+      const cx = target.left + target.width / 2;
+      const cy = target.top + target.height / 2;
+      const dist = Math.hypot(e.clientX - cx, e.clientY - cy);
+      if (dist < 160) {
+        place();
+        return;
+      }
+    }
+    setDragging(false); // bounce back to the tray
+  };
+  const onPointerCancel = () => setDragging(false);
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      place();
+    }
+  };
+
+  return {
+    interactive,
+    placed,
+    dragging,
+    animateSnap,
+    confetti,
+    showToast,
+    targetRef,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onKeyDown,
+  };
+}
+
+/**
+ * The headline word "puzzles" with the piece-shaped notch in the "z" slot.
+ * Inline — drop it inside the <h1>. Screen readers read the intact word via a
+ * visually-hidden copy; the visible glyphs render "pu␣zles" around the piece.
+ */
+function HeadlineNotch({ state }: { state: PieceState }) {
+  const { placed, dragging, animateSnap, confetti, targetRef } = state;
+  return (
+    <span className="v-notch-word">
+      <span className="sr-only">puzzles</span>
+      <span aria-hidden="true">pu</span>
+      <span
+        ref={targetRef}
+        aria-hidden="true"
+        className="v-notch-target"
+        data-dragging={dragging ? "true" : "false"}
+        style={{
+          position: "relative",
+          display: "inline-block",
+          width: "var(--v-notch)",
+          height: "var(--v-notch)",
+          top: "auto",
+          transform: "translateY(0.1em)",
+          verticalAlign: "baseline",
+          margin: "0 0.04em",
+        }}
+      >
+        {placed ? (
+          <span
+            className="v-notch-fill"
+            data-animate={animateSnap ? "true" : "false"}
+            style={{
+              position: "absolute",
+              inset: 0,
+              top: "auto",
+              transform: "none",
+            }}
+          >
+            <PieceSquare fill="var(--mk-violet-400)" />
+          </span>
+        ) : (
+          <PieceSquare
+            fill="color-mix(in oklab, var(--mk-violet-200) 35%, transparent)"
+            stroke="var(--mk-violet-300)"
+            dashed
+          />
+        )}
+        {/* Confetti — fully contained, decorative. */}
+        {confetti.map((c) => (
+          <span
+            key={c.id}
+            className="v-confetti-piece"
+            aria-hidden="true"
+            style={
+              {
+                "--vx": `${c.vx}px`,
+                "--vy": `${c.vy}px`,
+                "--vr": c.vr,
+              } as React.CSSProperties
+            }
+          >
+            <PieceMotif size={16} color={c.color} />
+          </span>
+        ))}
+      </span>
+      <span aria-hidden="true">zles</span>
+    </span>
+  );
+}
+
+/**
+ * The tray (draggable / keyboard button) + drag hint + success toast. Render
+ * this as a block UNDER the headline so it never disrupts the h1 text flow.
+ * Reserves a small min-height so the layout doesn't shift when it disappears.
+ */
+function PieceTray({ state }: { state: PieceState }) {
+  const {
+    interactive,
+    placed,
+    dragging,
+    showToast,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onKeyDown,
+  } = state;
+
+  // Nothing to show once the moment is complete or in the static fallback.
+  if (!interactive) return null;
+
+  return (
+    <div className="mt-4 flex min-h-[48px] flex-wrap items-center gap-2">
+      {!placed && (
+        <>
+          <button
+            type="button"
+            className="v-tray-piece"
+            data-dragging={dragging ? "true" : "false"}
+            aria-label="Place the last puzzle piece"
+            onPointerDown={onPointerDown}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerCancel}
+            onKeyDown={onKeyDown}
+            style={{ minWidth: 44, minHeight: 44 }}
+          >
+            <span className="v-tray-piece-art">
+              <PieceMotif size={30} color="var(--mk-violet-400)" />
+            </span>
+          </button>
+          <span className="text-[13px] font-medium text-mk-text-muted select-none">
+            Pop the last piece in →
+          </span>
+        </>
+      )}
+      {showToast && (
+        <span
+          role="status"
+          className="v-success-toast text-[14px] font-semibold text-mk-violet-600"
+        >
+          Nice — that&apos;s the spirit 🧩
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The entire hero delight moment. Returns the two render slots — `notch` (drop
+ * inside the <h1>) and `tray` (drop directly under the <h1>) — plus shares the
+ * one-time `onPlaced` tick. Reduced-motion / no-JS degrade to the piece already
+ * snapped in place: no tray, no caption, no confetti, headline fully legible.
+ */
+export function useDraggablePiece(onPlaced?: () => void): {
+  notch: React.ReactNode;
+  tray: React.ReactNode;
+} {
+  const state = usePieceState(onPlaced);
+  return {
+    notch: <HeadlineNotch state={state} />,
+    tray: <PieceTray state={state} />,
+  };
+}

--- a/apps/web/src/components/marketing/variants/playful/final-cta.tsx
+++ b/apps/web/src/components/marketing/variants/playful/final-cta.tsx
@@ -1,0 +1,55 @@
+import { Link } from "@/compat/link";
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow, Section } from "@/components/marketing/section";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+
+export function FinalCta() {
+  const startHref = useStartHref();
+  return (
+    <Section className="relative overflow-x-clip">
+      {/* The only other brand glow besides the hero. */}
+      <div className="v-glow" aria-hidden="true" />
+      <Container narrow className="relative z-[1]">
+        <Reveal>
+          <div className="text-center">
+            <div className="flex justify-center">
+              <Eyebrow center>Ready when you are</Eyebrow>
+            </div>
+            <h2 className="font-mk-heading font-bold tracking-tight text-mk-text-strong text-[clamp(28px,4vw,44px)] leading-[1.08] mt-3.5 text-balance">
+              Start your shelf today.
+            </h2>
+            <p className="mt-4 mx-auto max-w-[520px] text-[clamp(16px,1.4vw,18px)] leading-relaxed text-mk-text-muted text-pretty">
+              It&apos;s free to start — add your first box and let the swapping
+              begin.
+            </p>
+            <div className="mt-8 flex justify-center gap-3 flex-wrap max-[860px]:flex-col max-[860px]:items-stretch">
+              <Button
+                variant="brand"
+                className="h-11 px-6 text-[15px] max-[860px]:w-full"
+                asChild
+              >
+                <Link href={startHref}>
+                  Start your shelf
+                  <ArrowRight size={17} />
+                </Link>
+              </Button>
+              <Button
+                variant="outline"
+                className="h-11 px-6 text-[15px] bg-mk-card border-mk-border text-mk-text-strong hover:bg-mk-muted max-[860px]:w-full"
+                asChild
+              >
+                <Link href="/how-it-works">See how it works</Link>
+              </Button>
+            </div>
+            <p className="mt-5 text-[13px] text-mk-text-muted">
+              Free to start. No card needed.
+            </p>
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/founders.tsx
+++ b/apps/web/src/components/marketing/variants/playful/founders.tsx
@@ -1,0 +1,31 @@
+import { Container } from "@/components/marketing/container";
+import { Reveal } from "@/components/marketing/reveal";
+import { Section } from "@/components/marketing/section";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import { AvatarCluster } from "./avatar-cluster";
+
+export function Founders({ data }: { data: LandingData }) {
+  return (
+    <Section tint>
+      <Container>
+        <Reveal>
+          <figure className="mx-auto max-w-[760px] bg-mk-card border border-mk-border shadow-mk-md rounded-[var(--v-radius-card)] p-[clamp(28px,4vw,48px)] text-center">
+            <h2 className="sr-only">A note from the founders</h2>
+            <blockquote className="font-mk-heading font-semibold text-mk-text-strong text-[clamp(18px,2.4vw,28px)] leading-[1.3] text-balance">
+              &ldquo;We built JigSwap because our finished puzzles deserved
+              better than the attic — and because puzzling is more fun when you
+              share it.&rdquo;
+            </blockquote>
+            <figcaption className="mt-6 flex flex-col items-center gap-3">
+              <AvatarCluster avatars={data.communityAvatars} size={34} />
+              <span className="text-[14.5px] text-mk-text-muted">
+                The family behind JigSwap, puzzling at the kitchen table since
+                2025.
+              </span>
+            </figcaption>
+          </figure>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/hero.tsx
+++ b/apps/web/src/components/marketing/variants/playful/hero.tsx
@@ -1,0 +1,167 @@
+import { Link } from "@/compat/link";
+import { type PlankBox } from "@/components/marketing/plank";
+import { JigPlank3D } from "@/components/marketing/plank-3d";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow } from "@/components/marketing/section";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import * as React from "react";
+import { useFormatter } from "use-intl";
+import { AvatarCluster } from "./avatar-cluster";
+import { useDraggablePiece } from "./draggable-piece";
+
+// Round-robin colours for the dialed-back plank fallback boxes.
+const COLOR_PAIRS: Array<[string, string]> = [
+  ["var(--mk-violet-400)", "var(--mk-violet-600)"],
+  ["var(--mk-green-400)", "var(--mk-green-600)"],
+  ["var(--mk-pink-400)", "var(--mk-pink-500)"],
+  ["var(--mk-violet-300)", "var(--mk-violet-700)"],
+];
+const WIDTHS = [100, 116, 96, 108, 90, 104] as const;
+
+// Calm Dutch placeholder boxes used while the live catalog loads or is sparse.
+const FALLBACK_BOXES: PlankBox[] = [
+  { series: "Natuur", title: "Boslicht", pieceCount: 1000 },
+  { series: "Steden", title: "Amsterdam", pieceCount: 1500 },
+  { series: "Kunst", title: "De Nachtwacht", pieceCount: 2000 },
+  { series: "Natuur", title: "Waddenzee", pieceCount: 500 },
+  { series: "Steden", title: "Utrecht", pieceCount: 750 },
+  { series: "Kunst", title: "Delfts Blauw", pieceCount: 1000 },
+].map((b, i) => {
+  const [c1, c2] = COLOR_PAIRS[i % COLOR_PAIRS.length];
+  return { ...b, c1, c2, width: WIDTHS[i % WIDTHS.length] };
+});
+
+// Two soft shelf rows for the calmer supporting prop.
+const SHELF_ROWS = 2;
+function toRows(boxes: PlankBox[]): PlankBox[][] {
+  const rows: PlankBox[][] = Array.from({ length: SHELF_ROWS }, () => []);
+  boxes.forEach((b, i) => rows[i % SHELF_ROWS].push(b));
+  return rows;
+}
+
+export function Hero({ data }: { data: LandingData }) {
+  const { stats, communityAvatars, plankPuzzles } = data;
+  const startHref = useStartHref();
+  const format = useFormatter();
+
+  // One-time visual stat tick driven by the delight moment. Never mutates real
+  // data — it's a +1 flourish layered on top of the live value.
+  const [bumped, setBumped] = React.useState(false);
+  const piece = useDraggablePiece(() => setBumped(true));
+
+  const rows = React.useMemo(() => {
+    const boxes: PlankBox[] =
+      plankPuzzles && plankPuzzles.length >= 3
+        ? plankPuzzles.map((p, i) => {
+            const [c1, c2] = COLOR_PAIRS[i % COLOR_PAIRS.length];
+            return {
+              title: p.title,
+              pieceCount: p.pieceCount,
+              series: p.brand,
+              cover: p.image ?? undefined,
+              width: WIDTHS[i % WIDTHS.length],
+              c1,
+              c2,
+            };
+          })
+        : FALLBACK_BOXES;
+    return toRows(boxes);
+  }, [plankPuzzles]);
+
+  const liveCount =
+    stats != null ? format.number(stats.totalUsers + (bumped ? 1 : 0)) : null;
+
+  return (
+    <div className="relative overflow-x-clip">
+      <div className="v-glow" aria-hidden="true" />
+
+      <div className="relative z-[1] w-full max-w-[1200px] mx-auto px-6">
+        <div className="grid items-center gap-[clamp(32px,5vw,72px)] pt-[clamp(48px,7vw,96px)] pb-[clamp(56px,8vw,104px)] min-[861px]:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+          {/* Left column — text lockup */}
+          <Reveal>
+            <div className="max-w-[620px]">
+              <Eyebrow>The friendly home for your puzzles</Eyebrow>
+
+              <h1 className="font-mk-heading font-bold text-mk-text-strong mt-4 text-[clamp(30px,5.2vw,56px)] leading-[1.05] tracking-[-0.01em] text-balance">
+                Your {piece.notch}, but make them social.
+              </h1>
+
+              {/* Tray + caption + success toast live under the headline so the
+                  h1 text flow stays clean. */}
+              {piece.tray}
+
+              <p className="mt-[clamp(18px,2.2vw,28px)] text-[clamp(16px,1.4vw,19px)] leading-relaxed text-mk-text-muted max-w-[520px] text-pretty">
+                Shelve every box, lend to fellow puzzlers, and always see
+                who&apos;s got it. Free to start.
+              </p>
+
+              {/* CTA row */}
+              <div className="mt-[clamp(20px,2.4vw,32px)] flex flex-wrap gap-3 max-[860px]:flex-col">
+                <Button
+                  variant="brand"
+                  className="h-11 px-6 text-[15px] max-[860px]:w-full"
+                  asChild
+                >
+                  <Link href={startHref}>
+                    Start your shelf
+                    <ArrowRight size={17} />
+                  </Link>
+                </Button>
+                <Button
+                  variant="outline"
+                  className="h-11 px-6 text-[15px] bg-mk-card border-mk-border text-mk-text-strong hover:bg-mk-muted max-[860px]:w-full"
+                  asChild
+                >
+                  <Link href="/how-it-works">See how it works</Link>
+                </Button>
+              </div>
+
+              {/* Live trust row */}
+              <div className="mt-[clamp(22px,2.6vw,32px)] flex items-center gap-3.5 flex-wrap">
+                <AvatarCluster avatars={communityAvatars} />
+                <div className="text-[14.5px] text-mk-text-muted leading-snug">
+                  {liveCount != null ? (
+                    <>
+                      <span className="font-semibold text-mk-text-strong tabular-nums">
+                        {liveCount}
+                      </span>{" "}
+                      puzzlers are already swapping
+                    </>
+                  ) : (
+                    "Join the community"
+                  )}
+                </div>
+              </div>
+            </div>
+          </Reveal>
+
+          {/* Right column — dialed-back plank supporting prop */}
+          <div
+            aria-hidden="true"
+            className="relative justify-self-center max-[860px]:order-last max-[540px]:hidden"
+            style={{
+              width: "clamp(280px, 34vw, 440px)",
+              height: "clamp(280px, 34vw, 440px)",
+            }}
+          >
+            {/* low-intensity radial behind the plank */}
+            <div
+              className="absolute inset-[-12%] rounded-full"
+              style={{
+                background:
+                  "radial-gradient(closest-side, var(--v-glow-violet), transparent 72%)",
+                filter: "blur(6px)",
+              }}
+            />
+            <div className="absolute inset-0">
+              <JigPlank3D rows={rows} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/how-steps.tsx
+++ b/apps/web/src/components/marketing/variants/playful/how-steps.tsx
@@ -1,0 +1,128 @@
+import { Container } from "@/components/marketing/container";
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import { Reveal } from "@/components/marketing/reveal";
+import { Section, SectionHead } from "@/components/marketing/section";
+import * as React from "react";
+
+type Step = {
+  num: string;
+  title: string;
+  body: string;
+  active?: boolean;
+  motif: React.ReactNode;
+};
+
+// Small playful piece arrangement per card (decorative).
+function StepMotif({
+  pieces,
+}: {
+  pieces: Array<[string, number, number, number]>;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative mb-5"
+      style={{ width: 76, height: 64 }}
+    >
+      {pieces.map(([color, size, x, y], i) => (
+        <PieceMotif
+          key={i}
+          size={size}
+          color={color}
+          rotate={i * 18 - 18}
+          style={{ position: "absolute", left: x, top: y }}
+        />
+      ))}
+    </div>
+  );
+}
+
+const STEPS: Step[] = [
+  {
+    num: "01",
+    title: "Fill your shelf",
+    body: "Add every box you own to your personal puzzle library — covers, piece counts and all.",
+    active: true,
+    motif: (
+      <StepMotif
+        pieces={[
+          ["var(--mk-violet-400)", 44, 0, 8],
+          ["var(--mk-violet-200)", 30, 36, 24],
+        ]}
+      />
+    ),
+  },
+  {
+    num: "02",
+    title: "Discover & request",
+    body: "Browse what the community's sharing and ask to borrow or swap.",
+    motif: (
+      <StepMotif
+        pieces={[
+          ["var(--mk-green-400)", 42, 2, 6],
+          ["var(--mk-green-200)", 30, 38, 26],
+        ]}
+      />
+    ),
+  },
+  {
+    num: "03",
+    title: "Lend & track",
+    body: "Hand a puzzle on and always see who's got it and when it's coming back.",
+    motif: (
+      <StepMotif
+        pieces={[
+          ["var(--mk-violet-400)", 40, 4, 8],
+          ["var(--mk-pink-400)", 28, 38, 24],
+        ]}
+      />
+    ),
+  },
+];
+
+function StepCard({ step, delay }: { step: Step; delay: number }) {
+  return (
+    <Reveal delay={delay}>
+      <article className="v-lift h-full bg-mk-card border border-mk-border shadow-mk-sm rounded-[var(--v-radius-card)] p-[clamp(20px,3vw,32px)]">
+        <div
+          className="inline-flex items-center justify-center font-mk-heading font-bold text-[15px] w-10 h-10 rounded-[var(--v-radius-chip)] mb-4"
+          style={{
+            background: step.active
+              ? "color-mix(in oklab, var(--mk-pink-400) 16%, var(--mk-card))"
+              : "var(--mk-muted)",
+            color: step.active ? "var(--mk-pink-500)" : "var(--mk-text-strong)",
+          }}
+        >
+          {step.num}
+        </div>
+        {step.motif}
+        <h3 className="font-mk-heading font-bold text-mk-text-strong text-[clamp(19px,2vw,22px)] leading-tight">
+          {step.title}
+        </h3>
+        <p className="mt-2 text-[15px] leading-relaxed text-mk-text-muted text-pretty">
+          {step.body}
+        </p>
+      </article>
+    </Reveal>
+  );
+}
+
+export function HowSteps() {
+  return (
+    <Section>
+      <Container>
+        <SectionHead
+          align="center"
+          eyebrow="How it works"
+          title="Three steps and you're swapping."
+          lead="Build your shelf, find your next puzzle, and keep track of every box you lend out."
+        />
+        <div className="mt-[clamp(36px,5vw,56px)] grid gap-[clamp(20px,2.5vw,32px)] grid-cols-3 max-[860px]:grid-cols-1">
+          {STEPS.map((step, i) => (
+            <StepCard key={step.num} step={step} delay={i * 90} />
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/index.tsx
+++ b/apps/web/src/components/marketing/variants/playful/index.tsx
@@ -1,0 +1,13 @@
+import "./playful.css";
+
+// PLACEHOLDER — replaced by the Frontend Developer building the Playful-Premium
+// variant. Root must keep the `v-playful` scope class and import `./playful.css`.
+export default function PlayfulLanding() {
+  return (
+    <div className="v-playful font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
+      <p className="text-mk-text-muted text-sm">
+        Playful-Premium variant — under construction.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/index.tsx
+++ b/apps/web/src/components/marketing/variants/playful/index.tsx
@@ -1,13 +1,37 @@
+import { MarketingFooter } from "@/components/marketing/footer";
+import { MarketingHeader } from "@/components/marketing/header";
+import { useLandingData } from "@/components/marketing/variants/use-landing-data";
 import "./playful.css";
 
-// PLACEHOLDER — replaced by the Frontend Developer building the Playful-Premium
-// variant. Root must keep the `v-playful` scope class and import `./playful.css`.
+import { CustodySpotlight } from "./custody-spotlight";
+import { FinalCta } from "./final-cta";
+import { Founders } from "./founders";
+import { Hero } from "./hero";
+import { HowSteps } from "./how-steps";
+import { StatPills } from "./stat-pills";
+import { SustainBand } from "./sustain-band";
+
+// Variant 1 — "Playful-Premium". Friendly puzzle-piece personality on a clean,
+// whitespace-rich structure, spending its entire "delight budget" on a single
+// draggable-piece moment in the hero. The page re-skins purely via the
+// `.v-playful` scope in playful.css; every component still reads `--mk-*`.
 export default function PlayfulLanding() {
+  // Single source of truth for real platform numbers / avatars / shelf covers.
+  const data = useLandingData({ avatarLimit: 4, plankLimit: 12 });
+
   return (
-    <div className="v-playful font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
-      <p className="text-mk-text-muted text-sm">
-        Playful-Premium variant — under construction.
-      </p>
+    <div className="v-playful font-mk-sans min-h-screen overflow-x-clip">
+      <MarketingHeader />
+      <main>
+        <Hero data={data} />
+        <StatPills data={data} />
+        <HowSteps />
+        <CustodySpotlight />
+        <SustainBand />
+        <Founders data={data} />
+        <FinalCta />
+      </main>
+      <MarketingFooter />
     </div>
   );
 }

--- a/apps/web/src/components/marketing/variants/playful/playful.css
+++ b/apps/web/src/components/marketing/variants/playful/playful.css
@@ -1,8 +1,225 @@
-/* Playful-Premium variant — scoped styles.
- * All overrides live under `.v-playful` so they never leak into other variants
- * or the global token system. Redeclare `--mk-*` / add `--v-*` custom
- * properties here to give this variant its own palette, type and motion.
- * Replaced/expanded by the Frontend Developer building this variant. */
+/* apps/web/src/components/marketing/variants/playful/playful.css
+   Playful-Premium: the real brand seeds, a touch more air + bounce, a rounded
+   display, larger radii. Additive — inherits the global .dark flip for grounds.
+
+   No font @import: Baloo 2 is already loaded in __root.tsx. Reuse it. */
+
 .v-playful {
-  /* scope marker — variant styles go here */
+  /* ---- Display font: reuse the already-loaded rounded face ---- */
+  --v-font-display: "Baloo 2", ui-rounded, "Segoe UI", system-ui, sans-serif;
+  --font-mk-heading: var(--v-font-display);
+
+  /* ---- Keep focus visible + on-brand ---- */
+  --mk-ring: var(--mk-seed-primary);
+
+  /* ---- Radii (larger, friendlier; variant-private) ---- */
+  --v-radius-card: 22px;
+  --v-radius-pill: 999px;
+  --v-radius-chip: 14px;
+
+  /* ---- Motion (springier defaults for the hero moment) ---- */
+  --v-ease-snap: var(--ease-mk-spring);
+  --v-snap-dur: 420ms;
+  --v-bob-dur: 2400ms;
+  --v-confetti-dur: 600ms;
+
+  /* ---- Hero / CTA glow (variant-private, low intensity for "calm premium") ---- */
+  --v-glow-violet: color-mix(in oklab, var(--mk-seed-primary) 20%, transparent);
+  --v-glow-pink: color-mix(in oklab, var(--mk-seed-accent) 14%, transparent);
+  --v-glow-green: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 12%,
+    transparent
+  );
+
+  /* ---- Hero piece-notch sizing ---- */
+  --v-notch: 0.78em; /* ~cap-height of the headline */
+
+  /* ---- Slightly warmer brand shadow for hover lifts (premium, not flat) ---- */
+  --shadow-mk-brand: 0 10px 28px -8px rgb(96 72 232 / 0.34);
+}
+
+/* Dark: grounds/text inherit the global .dark flip. Only re-tune variant glow
+   so it reads on the dark ground without washing out. */
+.dark .v-playful {
+  --v-glow-violet: color-mix(in oklab, var(--mk-seed-primary) 28%, transparent);
+  --v-glow-pink: color-mix(in oklab, var(--mk-seed-accent) 20%, transparent);
+  --v-glow-green: color-mix(
+    in oklab,
+    var(--mk-seed-secondary) 18%,
+    transparent
+  );
+  --shadow-mk-brand: 0 12px 32px -10px rgb(120 96 255 / 0.42);
+}
+
+/* --------------------------------------------------------------------------
+   Soft CSS radial glow — used in exactly two places (hero + final CTA).
+   ------------------------------------------------------------------------ */
+.v-playful .v-glow {
+  position: absolute;
+  inset: -10% -10% auto -10%;
+  height: 540px;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(60% 70% at 18% 8%, var(--v-glow-violet), transparent 70%),
+    radial-gradient(50% 60% at 88% 0%, var(--v-glow-pink), transparent 70%),
+    radial-gradient(60% 80% at 60% 30%, var(--v-glow-green), transparent 72%);
+}
+
+/* --------------------------------------------------------------------------
+   Hero delight moment: notch, tray piece, bob, confetti.
+   ------------------------------------------------------------------------ */
+
+/* The word that carries the missing-piece notch. */
+.v-playful .v-notch-word {
+  position: relative;
+  display: inline-block;
+  white-space: nowrap;
+}
+
+/* The dashed piece-outline drop target sitting in the glyph slot. */
+.v-playful .v-notch-target {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: var(--v-notch);
+  height: var(--v-notch);
+  pointer-events: none;
+  transition: filter 0.18s var(--ease-mk-out);
+}
+.v-playful .v-notch-target[data-dragging="true"] {
+  filter: brightness(1.25) saturate(1.2);
+}
+
+/* The pre-snapped / snapped filled piece sitting in the notch. */
+.v-playful .v-notch-fill {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%) scale(1);
+  width: var(--v-notch);
+  height: var(--v-notch);
+  pointer-events: none;
+}
+
+/* Spring snap-in animation for the filled piece. */
+@keyframes v-snap-in {
+  0% {
+    transform: translateY(-50%) scale(0.4) rotate(-18deg);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(-50%) scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+.v-playful .v-notch-fill[data-animate="true"] {
+  animation: v-snap-in var(--v-snap-dur) var(--v-ease-snap) both;
+}
+
+/* The draggable tray piece (real <button>). */
+.v-playful .v-tray-piece {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: 0;
+  background: transparent;
+  padding: 6px;
+  border-radius: var(--v-radius-chip);
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.v-playful .v-tray-piece:active {
+  cursor: grabbing;
+}
+.v-playful .v-tray-piece:focus-visible {
+  outline: 2px solid var(--mk-ring);
+  outline-offset: 3px;
+}
+
+/* Gentle idle bob on the tray piece. */
+@keyframes v-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+.v-playful .v-tray-piece-art {
+  animation: v-bob var(--v-bob-dur) var(--ease-mk-out) infinite;
+  filter: drop-shadow(0 6px 10px rgb(96 72 232 / 0.28));
+}
+.v-playful .v-tray-piece[data-dragging="true"] .v-tray-piece-art {
+  animation: none;
+}
+
+/* Confetti minis: pop outward + fade. Each gets its own custom-property vector. */
+@keyframes v-confetti {
+  0% {
+    transform: translate(0, 0) scale(0.5) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--vx), var(--vy)) scale(1) rotate(var(--vr));
+    opacity: 0;
+  }
+}
+.v-playful .v-confetti-piece {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  pointer-events: none;
+  animation: v-confetti var(--v-confetti-dur) var(--ease-mk-out) both;
+}
+
+/* Success microcopy fade. */
+@keyframes v-pop-fade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px) scale(0.96);
+  }
+  18% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  82% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-2px) scale(0.98);
+  }
+}
+.v-playful .v-success-toast {
+  animation: v-pop-fade 2s var(--ease-mk-out) both;
+}
+
+/* --------------------------------------------------------------------------
+   Card hover lift (how-it-works steps).
+   ------------------------------------------------------------------------ */
+.v-playful .v-lift {
+  transition:
+    transform 0.18s var(--ease-mk-out),
+    box-shadow 0.18s var(--ease-mk-out);
+}
+.v-playful .v-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-mk-md);
+}
+
+/* --------------------------------------------------------------------------
+   Reduced-motion: kill all bespoke hero motion; static legible end-state.
+   ------------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .v-playful *,
+  .v-playful *::before,
+  .v-playful *::after {
+    animation: none !important;
+    transition: none !important;
+  }
 }

--- a/apps/web/src/components/marketing/variants/playful/playful.css
+++ b/apps/web/src/components/marketing/variants/playful/playful.css
@@ -1,0 +1,8 @@
+/* Playful-Premium variant — scoped styles.
+ * All overrides live under `.v-playful` so they never leak into other variants
+ * or the global token system. Redeclare `--mk-*` / add `--v-*` custom
+ * properties here to give this variant its own palette, type and motion.
+ * Replaced/expanded by the Frontend Developer building this variant. */
+.v-playful {
+  /* scope marker — variant styles go here */
+}

--- a/apps/web/src/components/marketing/variants/playful/stat-pills.tsx
+++ b/apps/web/src/components/marketing/variants/playful/stat-pills.tsx
@@ -1,0 +1,93 @@
+import { Reveal } from "@/components/marketing/reveal";
+import { Section } from "@/components/marketing/section";
+import type { LandingData } from "@/components/marketing/variants/use-landing-data";
+import * as React from "react";
+import { useFormatter } from "use-intl";
+import { CountUp } from "./count-up";
+
+type Pill = { value: number | undefined; label: string };
+
+function StatPill({ pill, delay }: { pill: Pill; delay: number }) {
+  const format = useFormatter();
+  const [active, setActive] = React.useState(false);
+
+  return (
+    <Reveal
+      delay={delay}
+      className="max-[860px]:w-full max-[860px]:max-w-[360px]"
+    >
+      {/* Trigger the count-up once the pill scrolls into view. */}
+      <InView onEnter={() => setActive(true)}>
+        <div className="v-lift inline-flex w-full flex-col items-center bg-mk-card border border-mk-border shadow-mk-sm px-[clamp(24px,3vw,36px)] py-[clamp(20px,2.4vw,28px)] rounded-[var(--v-radius-pill)] text-center">
+          <span className="font-mk-heading font-bold text-mk-text-strong leading-none text-[clamp(30px,4vw,44px)] tabular-nums">
+            {pill.value != null ? (
+              <CountUp
+                value={pill.value}
+                active={active}
+                format={(n) => format.number(n)}
+              />
+            ) : (
+              "—"
+            )}
+          </span>
+          <span className="mt-2 text-[14px] font-medium text-mk-text-muted">
+            {pill.label}
+          </span>
+        </div>
+      </InView>
+    </Reveal>
+  );
+}
+
+// Tiny intersection trigger so the count-up only fires when seen (and only
+// once). Reveal handles the fade; this handles the number tween activation.
+function InView({
+  onEnter,
+  children,
+}: {
+  onEnter: () => void;
+  children: React.ReactNode;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            onEnter();
+            io.disconnect();
+          }
+        }
+      },
+      { threshold: 0.3 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div ref={ref}>{children}</div>;
+}
+
+export function StatPills({ data }: { data: LandingData }) {
+  const { stats } = data;
+  const pills: Pill[] = [
+    { value: stats?.totalUsers, label: "puzzlers signed up" },
+    { value: stats?.totalPuzzles, label: "puzzles in the catalog" },
+    { value: stats?.totalOwnedPuzzles, label: "puzzles on shelves right now" },
+  ];
+
+  return (
+    <Section>
+      <div className="w-full max-w-[1200px] mx-auto px-6">
+        <h2 className="sr-only">JigSwap by the numbers</h2>
+        <div className="flex flex-wrap justify-center items-center gap-[clamp(16px,2vw,28px)] max-[860px]:flex-col">
+          {pills.map((pill, i) => (
+            <StatPill key={pill.label} pill={pill} delay={i * 90} />
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/playful/sustain-band.tsx
+++ b/apps/web/src/components/marketing/variants/playful/sustain-band.tsx
@@ -1,0 +1,43 @@
+import { Container } from "@/components/marketing/container";
+import { PieceMotif } from "@/components/marketing/piece-motif";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow, Section } from "@/components/marketing/section";
+
+export function SustainBand() {
+  return (
+    <Section className="relative overflow-x-clip">
+      {/* very faint green-tinted glow, top-right */}
+      <div
+        aria-hidden="true"
+        className="absolute top-0 right-0 w-[460px] h-[360px] pointer-events-none"
+        style={{
+          background:
+            "radial-gradient(60% 70% at 80% 10%, color-mix(in oklab, var(--mk-seed-secondary) 14%, transparent), transparent 72%)",
+        }}
+      />
+      <Container narrow className="relative">
+        <Reveal>
+          <div className="text-center">
+            <div className="flex justify-center">
+              <Eyebrow center>Why it matters</Eyebrow>
+            </div>
+            <h2 className="font-mk-heading font-bold tracking-tight text-mk-text-strong text-[clamp(26px,3.6vw,38px)] leading-[1.1] mt-3.5">
+              Give every puzzle a second life.
+            </h2>
+            <p className="mt-4 mx-auto max-w-[600px] text-[clamp(16px,1.4vw,18px)] leading-relaxed text-mk-text-muted text-pretty">
+              A finished puzzle deserves better than the attic. Pass it on, and
+              it gets a second, third, fourth afternoon with someone new.
+            </p>
+            <div className="mt-7 flex justify-center" aria-hidden="true">
+              <PieceMotif
+                size={40}
+                color="color-mix(in oklab, var(--mk-green-400) 70%, transparent)"
+                rotate={-8}
+              />
+            </div>
+          </div>
+        </Reveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/registry.ts
+++ b/apps/web/src/components/marketing/variants/registry.ts
@@ -1,0 +1,70 @@
+// Landing-page variant registry.
+//
+// Four experimental redesigns of the marketing landing page plus the existing
+// "original" layout, all switchable at runtime via the floating tweaks panel
+// (see ./switcher.tsx). The selected variant is driven by the `?v=` search
+// param on the home route so it is SSR-safe and shareable as a preview URL.
+
+export const VARIANT_IDS = [
+  "original",
+  "playful",
+  "editorial",
+  "cozy",
+  "retro",
+] as const;
+
+export type VariantId = (typeof VARIANT_IDS)[number];
+
+// The variant a fresh visit lands on when no `?v=` param is present. Defaults
+// to a redesigned variant (not "original") so reviewers see new work first and
+// can switch back to "original" to compare.
+export const DEFAULT_VARIANT: VariantId = "playful";
+
+export type VariantMeta = {
+  id: VariantId;
+  label: string;
+  /** One-line personality summary shown in the switcher. */
+  tagline: string;
+};
+
+export const VARIANTS: VariantMeta[] = [
+  {
+    id: "original",
+    label: "Original",
+    tagline: "The current production landing — baseline for comparison.",
+  },
+  {
+    id: "playful",
+    label: "Playful-Premium",
+    tagline:
+      "Illustrated puzzle motifs on clean whitespace, one delightful hero moment.",
+  },
+  {
+    id: "editorial",
+    label: "Bold / Editorial",
+    tagline:
+      "Big expressive type, asymmetric magazine layouts, high personality.",
+  },
+  {
+    id: "cozy",
+    label: "Cozy / Hygge",
+    tagline: "Warm, lifestyle-led, the feeling of a rainy-day puzzle table.",
+  },
+  {
+    id: "retro",
+    label: "Retro / Tactile",
+    tagline: "Paper texture, nostalgic palette, board-game-box analog warmth.",
+  },
+];
+
+export function isVariantId(value: unknown): value is VariantId {
+  return (
+    typeof value === "string" &&
+    (VARIANT_IDS as readonly string[]).includes(value)
+  );
+}
+
+/** Coerce an unknown search-param value into a valid variant id. */
+export function coerceVariant(value: unknown): VariantId {
+  return isVariantId(value) ? value : DEFAULT_VARIANT;
+}

--- a/apps/web/src/components/marketing/variants/retro/assembly-steps.tsx
+++ b/apps/web/src/components/marketing/variants/retro/assembly-steps.tsx
@@ -1,0 +1,70 @@
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow } from "@/components/marketing/section";
+
+const STEPS = [
+  {
+    n: "01",
+    title: "Shelve",
+    body: "Add your puzzles to your digital shelf, piece count and box art included.",
+  },
+  {
+    n: "02",
+    title: "Share",
+    body: "Lend or swap a box with someone in the community.",
+  },
+  {
+    n: "03",
+    title: "Track",
+    body: "Always see which box is out, and whose table it's on.",
+  },
+];
+
+// 01 / 02 / 03 assembly instructions with dashed connectors (assembly-diagram
+// feel). Horizontal connectors on desktop, a vertical gutter rule on mobile.
+export function AssemblySteps() {
+  return (
+    <div className="mx-auto w-full max-w-[1200px] px-6">
+      <Eyebrow>Assembly</Eyebrow>
+      <h2 className="font-mk-heading text-mk-text-strong mt-3.5 text-[clamp(28px,4vw,40px)] leading-[1.1] font-bold tracking-tight">
+        Three steps to get going
+      </h2>
+
+      <ol className="mt-10 grid grid-cols-3 gap-8 max-[860px]:grid-cols-1 max-[860px]:gap-0">
+        {STEPS.map((step, i) => (
+          <Reveal key={step.n} delay={i * 110}>
+            <li className="relative max-[860px]:pl-10">
+              {/* Mobile vertical connector */}
+              {i < STEPS.length - 1 && (
+                <span
+                  aria-hidden="true"
+                  className="v-connector-v absolute top-2 bottom-[-28px] left-[14px] hidden max-[860px]:block"
+                />
+              )}
+              {/* Desktop horizontal connector */}
+              {i < STEPS.length - 1 && (
+                <span
+                  aria-hidden="true"
+                  className="v-connector-h absolute top-[clamp(20px,4vw,42px)] right-[-22px] hidden w-[44px] min-[861px]:block"
+                />
+              )}
+
+              <span
+                aria-hidden="true"
+                className="font-mk-heading v-offset block text-[clamp(40px,8vw,84px)] leading-none font-extrabold max-[860px]:text-[clamp(36px,12vw,56px)]"
+                style={{ color: "var(--mk-seed-primary)" }}
+              >
+                {step.n}
+              </span>
+              <h3 className="font-mk-heading text-mk-text-strong mt-3 text-[20px] font-bold tracking-tight">
+                {step.title}
+              </h3>
+              <p className="text-mk-text-body mt-2 max-w-[34ch] text-[15px] leading-relaxed text-pretty max-[860px]:pb-8">
+                {step.body}
+              </p>
+            </li>
+          </Reveal>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/avatars.tsx
+++ b/apps/web/src/components/marketing/variants/retro/avatars.tsx
@@ -1,0 +1,55 @@
+import type { CommunityAvatar } from "@/components/marketing/variants/use-landing-data";
+import { cn } from "@/lib/utils";
+
+// Decorative overlapping member chips (real initials/photos from Convex, with a
+// stable placeholder set while loading). aria-hidden — the live count line and
+// copy carry the meaning.
+const PLACEHOLDER = ["AvB", "MK", "JdW", "St"];
+
+export function CommunityChips({
+  avatars,
+  size = 38,
+  className,
+}: {
+  avatars: CommunityAvatar[] | undefined;
+  size?: number;
+  className?: string;
+}) {
+  const loading = avatars === undefined;
+  const items =
+    avatars && avatars.length > 0
+      ? avatars
+      : PLACEHOLDER.map((initials) => ({ initials, image: null }));
+
+  return (
+    <div aria-hidden="true" className={cn("flex items-center", className)}>
+      {items.slice(0, 4).map((a, i) => (
+        <span
+          key={i}
+          className={cn(
+            "border-mk-card bg-mk-muted text-mk-text-strong relative inline-flex items-center justify-center overflow-hidden rounded-full border-2 font-mono text-[11px] font-bold",
+            loading && "animate-pulse",
+          )}
+          style={{
+            width: size,
+            height: size,
+            marginLeft: i === 0 ? 0 : -size * 0.32,
+            zIndex: items.length - i,
+          }}
+        >
+          {a.image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={a.image}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            a.initials
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/barcode.tsx
+++ b/apps/web/src/components/marketing/variants/retro/barcode.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+// CSS barcode (repeating-linear-gradient bars) — decorative colophon mark.
+export function Barcode({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "v-barcode h-12 w-full max-w-[220px] rounded-[2px]",
+        className,
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/box-lid.tsx
+++ b/apps/web/src/components/marketing/variants/retro/box-lid.tsx
@@ -43,7 +43,7 @@ export function BoxLid({
                   className="mb-6 inline-flex flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-[var(--v-radius-chip)] px-4 py-2 font-mono text-[11px] font-bold tracking-[0.14em] uppercase"
                   style={{
                     background: "var(--v-band-teal)",
-                    color: "#fbf3df",
+                    color: "var(--v-on-band)",
                   }}
                 >
                   <span>Ages 6–106</span>

--- a/apps/web/src/components/marketing/variants/retro/box-lid.tsx
+++ b/apps/web/src/components/marketing/variants/retro/box-lid.tsx
@@ -1,0 +1,124 @@
+import { Link } from "@/compat/link";
+import { Reveal } from "@/components/marketing/reveal";
+import type {
+  CommunityAvatar,
+  LandingStats,
+} from "@/components/marketing/variants/use-landing-data";
+import { Button } from "@/components/ui/button";
+import { CommunityChips } from "./avatars";
+import { CornerStamp } from "./corner-stamp";
+
+// The hero: a flat, printed box LID. Warmth from layered print craft (offset
+// ink, die-cut edge, paper grain, corner stamp), not 3D/heavy JS.
+export function BoxLid({
+  startHref,
+  stats,
+  avatars,
+}: {
+  startHref: string;
+  stats: LandingStats | undefined;
+  avatars: CommunityAvatar[] | undefined;
+}) {
+  const count = stats?.totalUsers;
+
+  return (
+    <section
+      id="top"
+      className="relative w-full overflow-x-clip py-[clamp(48px,7vw,88px)]"
+      style={{ background: "var(--v-lid-ground)" }}
+    >
+      <div className="mx-auto w-full max-w-[1200px] px-6">
+        <Reveal>
+          <div className="relative mx-auto max-w-[980px]">
+            {/* Corner stamp — clipped inside the lid via the card overflow */}
+            <div className="paper v-box v-lid-settle relative overflow-hidden border-[3px] border-[var(--mk-text-strong)] px-[clamp(20px,5vw,64px)] py-[clamp(36px,6vw,64px)]">
+              <CornerStamp
+                size={116}
+                className="v-stamp-down pointer-events-none absolute -top-1 right-2 origin-center [transform:rotate(8deg)] max-[860px]:w-[clamp(56px,16vw,84px)]"
+              />
+
+              <div className="mx-auto max-w-[760px] text-center">
+                {/* Spec banner */}
+                <div
+                  className="mb-6 inline-flex flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-[var(--v-radius-chip)] px-4 py-2 font-mono text-[11px] font-bold tracking-[0.14em] uppercase"
+                  style={{
+                    background: "var(--v-band-teal)",
+                    color: "#fbf3df",
+                  }}
+                >
+                  <span>Ages 6–106</span>
+                  <Dot />
+                  <span>500–2000 Pieces</span>
+                  <Dot />
+                  <span>1 Shelf, Many Hands</span>
+                </div>
+
+                <p className="text-mk-text-muted mb-4 font-mono text-[11px] font-semibold tracking-[0.22em] uppercase">
+                  The Puzzle Library · No. 2025
+                </p>
+
+                <h1 className="font-mk-heading v-offset-hero text-mk-text-strong text-[clamp(34px,7vw,76px)] leading-[1.02] font-extrabold tracking-tight text-balance">
+                  A digital shelf for an analog joy.
+                </h1>
+
+                <p className="text-mk-text-body mx-auto mt-5 max-w-[58ch] text-[clamp(16px,2.2vw,19px)] leading-relaxed text-pretty">
+                  Shelve every jigsaw, lend and swap with fellow puzzlers, and
+                  always know which box is on whose table. Screen-free fun —
+                  finally organised.
+                </p>
+
+                <div className="mt-7 flex flex-wrap items-center justify-center gap-3 max-[540px]:flex-col">
+                  <Button
+                    variant="brand"
+                    size="lg"
+                    className="h-12 px-7 text-[15px] max-[540px]:w-full"
+                    asChild
+                  >
+                    <Link href={startHref}>Open the box</Link>
+                  </Button>
+                  <Button
+                    size="lg"
+                    className="bg-mk-card text-mk-text-strong border-mk-text-strong hover:bg-mk-muted focus-visible:ring-mk-ring h-12 border-2 px-7 text-[15px] font-semibold shadow-[var(--shadow-mk-sm)] transition-colors focus-visible:ring-2 focus-visible:outline-none max-[540px]:w-full"
+                    asChild
+                  >
+                    <Link href="#contents">See what&apos;s inside</Link>
+                  </Button>
+                </div>
+
+                {/* Live trust row */}
+                <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+                  <CommunityChips avatars={avatars} size={36} />
+                  <p
+                    className="text-mk-text-body text-[14.5px] font-medium"
+                    aria-live="polite"
+                  >
+                    {count === undefined ? (
+                      <span className="text-mk-text-muted">
+                        Counting the puzzlers…
+                      </span>
+                    ) : (
+                      <>
+                        <strong className="text-mk-text-strong font-bold">
+                          {count.toLocaleString()}
+                        </strong>{" "}
+                        puzzlers have already opened the box.
+                      </>
+                    )}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+function Dot() {
+  return (
+    <span aria-hidden="true" className="opacity-60">
+      ·
+    </span>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/chrome.tsx
+++ b/apps/web/src/components/marketing/variants/retro/chrome.tsx
@@ -1,0 +1,83 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { clearIntlCache, type Locale, setLocale } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
+import { useRouter } from "@tanstack/react-router";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useLocale, useTranslations } from "use-intl";
+
+// Shared nav destinations — identical to the production marketing header so the
+// retro chrome keeps the same routes.
+export const RETRO_NAV = [
+  { href: "/how-it-works", key: "howItWorks" },
+  { href: "/features", key: "features" },
+  { href: "/about", key: "about" },
+  { href: "/docs", key: "docs" },
+  { href: "/contact", key: "contact" },
+] as const;
+
+const LANGUAGES = [
+  { code: "en", name: "English", flag: "🇺🇸" },
+  { code: "nl", name: "Nederlands", flag: "🇳🇱" },
+] as const satisfies readonly { code: Locale; name: string; flag: string }[];
+
+// Language picker — square ink-bordered chip to match the printed chrome.
+export function LangToggle() {
+  const t = useTranslations("marketing.nav");
+  const locale = useLocale();
+  const router = useRouter();
+  const change = async (next: Locale) => {
+    if (next === locale) return;
+    await setLocale({ data: next });
+    clearIntlCache();
+    await router.invalidate();
+  };
+  const current =
+    LANGUAGES.find((lang) => lang.code === locale) ?? LANGUAGES[0];
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={t("switchLanguage")}
+          className="text-mk-text-body bg-mk-card border-mk-border focus-visible:ring-mk-ring inline-flex h-11 w-11 items-center justify-center rounded-[var(--v-radius-chip)] border-2 text-[18px] leading-none focus-visible:ring-2 focus-visible:outline-none"
+        >
+          {current.flag}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {LANGUAGES.map((language) => (
+          <DropdownMenuItem
+            key={language.code}
+            onClick={() => change(language.code)}
+            className={cn(locale === language.code && "bg-accent")}
+          >
+            <span className="mr-2">{language.flag}</span>
+            {language.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// Light/dark toggle — square chip variant.
+export function ModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      aria-label="Toggle dark mode"
+      className="text-mk-text-body bg-mk-card border-mk-border focus-visible:ring-mk-ring inline-flex h-11 w-11 items-center justify-center rounded-[var(--v-radius-chip)] border-2 focus-visible:ring-2 focus-visible:outline-none"
+    >
+      <Sun size={18} className="hidden dark:block" />
+      <Moon size={18} className="dark:hidden" />
+    </button>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/contents-list.tsx
+++ b/apps/web/src/components/marketing/variants/retro/contents-list.tsx
@@ -1,0 +1,135 @@
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow } from "@/components/marketing/section";
+import type { PlankPuzzle } from "@/components/marketing/variants/use-landing-data";
+import { cn } from "@/lib/utils";
+
+const ITEMS = [
+  {
+    title: "Your whole shelf, catalogued",
+    gloss: "every box in one tidy place, piece counts and all.",
+  },
+  {
+    title: "Lending & swapping",
+    gloss: "pass finished puzzles to people who'll actually do them.",
+  },
+  {
+    title: "Custody tracking",
+    gloss: "see who currently holds each box you've lent out.",
+  },
+  {
+    title: "A real community",
+    gloss: "Dutch puzzlers, growing since 2025.",
+  },
+  {
+    title: "A second life for every puzzle",
+    gloss: "out of the attic, back on a table.",
+  },
+];
+
+// Themed Dutch fallback covers (per research §0) when no real plank data.
+const FALLBACK: PlankPuzzle[] = [
+  { title: "Boslicht", pieceCount: 1000, image: null },
+  { title: "Amsterdam", pieceCount: 1500, image: null },
+  { title: "De Nachtwacht", pieceCount: 2000, image: null },
+  { title: "Zandsculpturen", pieceCount: 500, image: null },
+];
+
+export function ContentsList({
+  puzzles,
+}: {
+  puzzles: PlankPuzzle[] | undefined;
+}) {
+  const covers = (puzzles && puzzles.length > 0 ? puzzles : FALLBACK).slice(
+    0,
+    4,
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-[1200px] px-6">
+      <Eyebrow>Contents</Eyebrow>
+      <h2 className="font-mk-heading text-mk-text-strong mt-3.5 text-[clamp(28px,4vw,40px)] leading-[1.1] font-bold tracking-tight">
+        What&apos;s in the box
+      </h2>
+
+      <div className="mt-10 grid grid-cols-[58%_42%] gap-12 max-[860px]:grid-cols-1 max-[860px]:gap-10">
+        {/* Checklist */}
+        <ul className="flex flex-col">
+          {ITEMS.map((item, i) => (
+            <Reveal key={item.title} delay={i * 70}>
+              <li className="flex items-baseline gap-3 py-3.5">
+                <span
+                  aria-hidden="true"
+                  className="text-mk-seed-secondary translate-y-[2px] text-[18px] leading-none"
+                  style={{ color: "var(--mk-seed-secondary)" }}
+                >
+                  ▣
+                </span>
+                <span className="flex flex-1 flex-wrap items-baseline">
+                  <span className="text-mk-text-strong font-mk-heading text-[17px] font-bold">
+                    {item.title}
+                  </span>
+                  <span className="v-leader mx-2 min-w-6 flex-1 translate-y-[-3px]" />
+                  <span className="text-mk-text-body text-[14.5px] leading-snug">
+                    {item.gloss}
+                  </span>
+                </span>
+              </li>
+            </Reveal>
+          ))}
+        </ul>
+
+        {/* Parts bag */}
+        <Reveal delay={120}>
+          <div className="paper v-box border-mk-text-strong relative overflow-hidden border-[3px] p-5 [transform:rotate(1.5deg)] max-[860px]:[transform:none]">
+            <p
+              aria-hidden="true"
+              className="text-mk-text-muted mb-3 text-center font-mono text-[10.5px] font-bold tracking-[0.16em] uppercase"
+            >
+              Real boxes from the catalogue
+            </p>
+            <div className="grid grid-cols-2 gap-3" aria-hidden="true">
+              {covers.map((p, i) => (
+                <PartCover key={i} puzzle={p} />
+              ))}
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </div>
+  );
+}
+
+function PartCover({ puzzle }: { puzzle: PlankPuzzle }) {
+  return (
+    <div
+      className={cn(
+        "border-mk-border bg-mk-muted relative aspect-[4/3] overflow-hidden rounded-[var(--v-radius-chip)] border-2",
+      )}
+    >
+      {puzzle.image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={puzzle.image}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div
+          className="flex h-full w-full flex-col items-center justify-center p-2 text-center"
+          style={{
+            background:
+              "linear-gradient(135deg, color-mix(in oklab, var(--mk-seed-accent) 35%, var(--mk-muted)), var(--mk-muted))",
+          }}
+        >
+          <span className="text-mk-text-strong font-mk-heading text-[13px] leading-tight font-bold">
+            {puzzle.title}
+          </span>
+          <span className="text-mk-text-muted mt-1 font-mono text-[9.5px] font-semibold tracking-wide uppercase">
+            {puzzle.pieceCount} pcs
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/corner-stamp.tsx
+++ b/apps/web/src/components/marketing/variants/retro/corner-stamp.tsx
@@ -1,0 +1,82 @@
+// Rotated circular "approval" stamp — decorative ink seal. Text runs around the
+// ring via SVG textPath; centre carries a star + year. aria-hidden: the headline
+// carries all meaning.
+export function CornerStamp({
+  size = 116,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      aria-hidden="true"
+      className={className}
+      style={{ color: "var(--mk-seed-primary)" }}
+    >
+      <defs>
+        <path
+          id="v-stamp-ring"
+          d="M 60 60 m -42 0 a 42 42 0 1 1 84 0 a 42 42 0 1 1 -84 0"
+          fill="none"
+        />
+      </defs>
+      <circle
+        cx="60"
+        cy="60"
+        r="56"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+      <circle
+        cx="60"
+        cy="60"
+        r="48"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="2 3"
+      />
+      <text
+        fill="currentColor"
+        style={{
+          fontFamily: "var(--v-font-display)",
+          fontSize: "11px",
+          fontWeight: 700,
+          letterSpacing: "2.5px",
+        }}
+      >
+        <textPath href="#v-stamp-ring" startOffset="2%">
+          APPROVED · EST. 2025 · NETHERLANDS ·
+        </textPath>
+      </text>
+      <text
+        x="60"
+        y="50"
+        textAnchor="middle"
+        fill="currentColor"
+        style={{ fontSize: "20px" }}
+      >
+        ✶
+      </text>
+      <text
+        x="60"
+        y="74"
+        textAnchor="middle"
+        fill="currentColor"
+        style={{
+          fontFamily: "var(--v-font-display)",
+          fontSize: "16px",
+          fontWeight: 800,
+          letterSpacing: "1px",
+        }}
+      >
+        NO. 2025
+      </text>
+    </svg>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/footer.tsx
+++ b/apps/web/src/components/marketing/variants/retro/footer.tsx
@@ -1,0 +1,103 @@
+import { Link } from "@/compat/link";
+import type { CommunityAvatar } from "@/components/marketing/variants/use-landing-data";
+import { Wordmark } from "@/components/marketing/wordmark";
+import { useTranslations } from "use-intl";
+import { CommunityChips } from "./avatars";
+import { Barcode } from "./barcode";
+import { LangToggle, ModeToggle } from "./chrome";
+
+// Retro footer — the box BOTTOM: CSS barcode + colophon left, nav columns +
+// toggles + contributors right. Keeps the <footer> landmark, all nav routes,
+// and both toggles.
+export function RetroFooter({
+  avatars,
+}: {
+  avatars: CommunityAvatar[] | undefined;
+}) {
+  const t = useTranslations("marketing.nav");
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="paper v-double-rule border-mk-border border-t-2">
+      <div className="mx-auto w-full max-w-[1200px] px-6 pt-16 pb-10">
+        <div className="grid grid-cols-[1.5fr_1fr_1fr] gap-12 max-[860px]:grid-cols-2 max-[860px]:gap-8 max-[540px]:grid-cols-1">
+          {/* Colophon */}
+          <div className="max-[540px]:order-1">
+            <Wordmark />
+            <Barcode className="mt-5" />
+            <p className="text-mk-text-muted mt-4 font-mono text-[11.5px] leading-relaxed font-semibold tracking-[0.1em] uppercase">
+              JIGSWAP · NL · MMXXV
+              <br />
+              Printed at a kitchen table
+              <br />1 Shelf · Many Hands
+            </p>
+          </div>
+
+          {/* Nav columns */}
+          <FooterCol
+            title={t("howItWorks")}
+            links={[
+              { href: "/how-it-works", label: t("howItWorks") },
+              { href: "/features", label: t("features") },
+              { href: "/docs", label: t("docs") },
+              { href: "/sign-up", label: t("startTrading") },
+            ]}
+          />
+          <div className="flex flex-col gap-3">
+            <FooterCol
+              title={t("about")}
+              links={[
+                { href: "/about", label: t("about") },
+                { href: "/contact", label: t("contact") },
+                { href: "/privacy", label: "Privacy" },
+                { href: "/terms", label: "Terms" },
+              ]}
+            />
+            <div className="mt-4 flex items-center gap-2.5">
+              <LangToggle />
+              <ModeToggle />
+            </div>
+          </div>
+        </div>
+
+        {/* Contributors + sign-off */}
+        <div className="border-mk-border mt-12 flex flex-wrap items-center justify-between gap-4 border-t pt-6">
+          <span className="text-mk-text-muted font-mono text-[12px] tracking-[0.08em] uppercase">
+            © {year} JigSwap · Made at a Dutch kitchen table
+          </span>
+          <div className="flex items-center gap-3">
+            <CommunityChips avatars={avatars} size={32} />
+            <span className="text-mk-text-muted font-mono text-[11px] font-semibold tracking-[0.12em] uppercase">
+              Made with fellow puzzlers
+            </span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterCol({
+  title,
+  links,
+}: {
+  title: string;
+  links: { href: string; label: string }[];
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="font-mk-heading text-mk-text-strong text-sm font-bold tracking-wide uppercase">
+        {title}
+      </div>
+      {links.map((lk) => (
+        <Link
+          key={lk.href + lk.label}
+          href={lk.href}
+          className="text-mk-text-body hover:text-mk-violet-600 focus-visible:ring-mk-ring w-fit rounded-[4px] text-[14.5px] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        >
+          {lk.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/header.tsx
+++ b/apps/web/src/components/marketing/variants/retro/header.tsx
@@ -1,0 +1,129 @@
+import { Link } from "@/compat/link";
+import { Wordmark } from "@/components/marketing/wordmark";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useLocation } from "@tanstack/react-router";
+import { Authenticated, Unauthenticated } from "convex/react";
+import { Menu, X } from "lucide-react";
+import * as React from "react";
+import { useTranslations } from "use-intl";
+import { LangToggle, ModeToggle, RETRO_NAV } from "./chrome";
+
+// Retro header — a printed "box top edge" strip. Same NAV destinations, auth
+// actions, and theme/lang toggles as the production header; bottom border reads
+// as a die-cut box edge (double rule).
+export function RetroHeader() {
+  const t = useTranslations("marketing.nav");
+  const { pathname } = useLocation();
+  const [open, setOpen] = React.useState(false);
+
+  const navLink = (item: (typeof RETRO_NAV)[number], mobile = false) => (
+    <Link
+      key={item.href}
+      href={item.href}
+      onClick={() => setOpen(false)}
+      className={cn(
+        "focus-visible:ring-mk-ring rounded-[4px] focus-visible:ring-2 focus-visible:outline-none",
+        mobile
+          ? "text-mk-text-strong border-mk-border border-b px-1 py-3 text-[17px] font-semibold"
+          : "hover:text-mk-violet-600 py-1.5 text-[15px] font-semibold tracking-tight transition-colors",
+        !mobile &&
+          (pathname === item.href ? "text-mk-violet-600" : "text-mk-text-body"),
+      )}
+    >
+      {t(item.key)}
+    </Link>
+  );
+
+  return (
+    <header className="paper v-double-rule sticky top-0 z-50">
+      <div className="mx-auto flex h-[70px] w-full max-w-[1200px] items-center gap-4 px-6">
+        <Link
+          href="/"
+          aria-label="JigSwap"
+          className="focus-visible:ring-mk-ring rounded-[6px] focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <Wordmark />
+        </Link>
+
+        <span
+          aria-hidden="true"
+          className="text-mk-text-muted border-mk-border mx-2 hidden border-l-2 pl-4 font-mono text-[10.5px] font-semibold tracking-[0.16em] uppercase min-[1040px]:inline"
+        >
+          Est. 2025 · Dutch Kitchen Table
+        </span>
+
+        <nav className="ml-2 hidden items-center gap-[22px] min-[861px]:flex">
+          {RETRO_NAV.map((item) => navLink(item))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-2.5">
+          <LangToggle />
+          <ModeToggle />
+          <Unauthenticated>
+            <Link
+              href="/sign-in"
+              className="text-mk-text-body hover:text-mk-violet-600 focus-visible:ring-mk-ring hidden rounded-[4px] px-1 py-1.5 text-[15px] font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none min-[861px]:inline-flex"
+            >
+              {t("login")}
+            </Link>
+            <Button
+              variant="brand"
+              className="hidden min-[861px]:inline-flex"
+              asChild
+            >
+              <Link href="/sign-up">{t("startTrading")}</Link>
+            </Button>
+          </Unauthenticated>
+          <Authenticated>
+            <Button
+              variant="brand"
+              className="hidden min-[861px]:inline-flex"
+              asChild
+            >
+              <Link href="/dashboard">{t("dashboard")}</Link>
+            </Button>
+          </Authenticated>
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            aria-label={open ? t("closeMenu") : t("openMenu")}
+            aria-expanded={open}
+            className="text-mk-text-body bg-mk-card border-mk-border focus-visible:ring-mk-ring inline-flex h-11 w-11 items-center justify-center rounded-[var(--v-radius-chip)] border-2 focus-visible:ring-2 focus-visible:outline-none min-[861px]:hidden"
+          >
+            {open ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <div className="paper border-mk-border border-t min-[861px]:hidden">
+          <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-1 px-6 pt-3 pb-[18px]">
+            {RETRO_NAV.map((item) => navLink(item, true))}
+            <Unauthenticated>
+              <Link
+                href="/sign-in"
+                onClick={() => setOpen(false)}
+                className="text-mk-text-strong border-mk-border border-b px-1 py-3 text-[17px] font-semibold"
+              >
+                {t("login")}
+              </Link>
+              <Button variant="brand" className="mt-3 w-full" asChild>
+                <Link href="/sign-up" onClick={() => setOpen(false)}>
+                  {t("startTrading")}
+                </Link>
+              </Button>
+            </Unauthenticated>
+            <Authenticated>
+              <Button variant="brand" className="mt-3 w-full" asChild>
+                <Link href="/dashboard" onClick={() => setOpen(false)}>
+                  {t("dashboard")}
+                </Link>
+              </Button>
+            </Authenticated>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/index.tsx
+++ b/apps/web/src/components/marketing/variants/retro/index.tsx
@@ -1,13 +1,129 @@
 import "./retro.css";
 
-// PLACEHOLDER — replaced by the Frontend Developer building the Retro/Tactile
-// variant. Root must keep the `v-retro` scope class and import its CSS.
+import { Link } from "@/compat/link";
+import { Reveal } from "@/components/marketing/reveal";
+import { Eyebrow, Section } from "@/components/marketing/section";
+import { useStartHref } from "@/components/marketing/use-start-href";
+import { useLandingData } from "@/components/marketing/variants/use-landing-data";
+import { Button } from "@/components/ui/button";
+import { AssemblySteps } from "./assembly-steps";
+import { BoxLid } from "./box-lid";
+import { ContentsList } from "./contents-list";
+import { RetroFooter } from "./footer";
+import { RetroHeader } from "./header";
+import { InsertCard } from "./insert-card";
+import { KeepCard } from "./keep-card";
+import { NumbersBand } from "./numbers-band";
+
+// Retro / Tactile landing — "A digital shelf for an analog joy." The page IS a
+// vintage board-game box: lid → contents → assembly → keep-card → stamped
+// numbers → second-life slug → founders' insert → final CTA → box-bottom
+// colophon. One display font (Rokkitt slab), paper grain, offset-print craft —
+// all pure CSS/SVG. Re-skins shared components by re-pointing --mk-* in retro.css.
 export default function RetroLanding() {
+  const startHref = useStartHref();
+  const { stats, communityAvatars, plankPuzzles } = useLandingData({
+    avatarLimit: 4,
+    plankLimit: 4,
+  });
+
   return (
-    <div className="v-retro font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
-      <p className="text-mk-text-muted text-sm">
-        Retro/Tactile variant — under construction.
-      </p>
+    <div className="v-retro font-mk-sans bg-mk-bg text-mk-text-body min-h-screen overflow-x-clip">
+      <RetroHeader />
+
+      <main>
+        {/* 1 — Hero box lid */}
+        <BoxLid
+          startHref={startHref}
+          stats={stats}
+          avatars={communityAvatars}
+        />
+
+        {/* 2 — Contents */}
+        <Section id="contents">
+          <ContentsList puzzles={plankPuzzles} />
+        </Section>
+
+        {/* 3 — Assembly */}
+        <Section id="assembly" tint>
+          <AssemblySteps />
+        </Section>
+
+        {/* 4 — Custody / keep-this card */}
+        <Section id="custody">
+          <Reveal>
+            <KeepCard />
+          </Reveal>
+        </Section>
+
+        {/* 5 — By the numbers (real Convex stats) */}
+        <div id="numbers">
+          <NumbersBand stats={stats} />
+        </div>
+
+        {/* 6 — Second life slug */}
+        <Section id="secondlife">
+          <Reveal>
+            <div className="mx-auto max-w-[760px] px-6 text-center">
+              <Eyebrow center>Why</Eyebrow>
+              <h2 className="font-mk-heading text-mk-text-strong mx-auto mt-3.5 max-w-[18ch] text-[clamp(26px,3.6vw,38px)] leading-[1.12] font-bold tracking-tight">
+                <span
+                  aria-hidden="true"
+                  className="mr-2 inline-block translate-y-[2px] text-[0.8em]"
+                  style={{ color: "var(--mk-seed-secondary)" }}
+                >
+                  ▷
+                </span>
+                Give every puzzle another life.
+              </h2>
+              <p className="text-mk-text-body mx-auto mt-4 max-w-[56ch] text-[clamp(15px,2vw,18px)] leading-relaxed text-pretty">
+                A finished puzzle deserves better than the attic. Pass it on,
+                and let it be someone else&apos;s slow, satisfying afternoon —
+                second life, third, fourth.
+              </p>
+            </div>
+          </Reveal>
+        </Section>
+
+        {/* 7 — Founders' insert */}
+        <Section id="insert" tint>
+          <Reveal>
+            <InsertCard />
+          </Reveal>
+        </Section>
+
+        {/* 8 — Final CTA */}
+        <section
+          id="open"
+          className="w-full overflow-x-clip py-[clamp(56px,8vw,104px)]"
+          style={{ background: "var(--v-lid-ground)" }}
+        >
+          <div className="mx-auto max-w-[680px] px-6 text-center">
+            <h2 className="font-mk-heading v-offset text-mk-text-strong text-[clamp(28px,4.6vw,46px)] leading-[1.06] font-extrabold tracking-tight text-balance">
+              Lift the lid. Start your shelf.
+            </h2>
+            <div className="mt-7 flex flex-wrap items-center justify-center gap-3 max-[540px]:flex-col">
+              <Button
+                variant="brand"
+                size="lg"
+                className="h-12 px-7 text-[15px] max-[540px]:w-full"
+                asChild
+              >
+                <Link href={startHref}>Open the box</Link>
+              </Button>
+              <Button
+                size="lg"
+                className="bg-mk-card text-mk-text-strong border-mk-text-strong hover:bg-mk-muted focus-visible:ring-mk-ring h-12 border-2 px-7 text-[15px] font-semibold shadow-[var(--shadow-mk-sm)] transition-colors focus-visible:ring-2 focus-visible:outline-none max-[540px]:w-full"
+                asChild
+              >
+                <Link href="#contents">See what&apos;s inside</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <RetroFooter avatars={communityAvatars} />
     </div>
   );
 }

--- a/apps/web/src/components/marketing/variants/retro/index.tsx
+++ b/apps/web/src/components/marketing/variants/retro/index.tsx
@@ -1,0 +1,13 @@
+import "./retro.css";
+
+// PLACEHOLDER — replaced by the Frontend Developer building the Retro/Tactile
+// variant. Root must keep the `v-retro` scope class and import its CSS.
+export default function RetroLanding() {
+  return (
+    <div className="v-retro font-mk-sans flex min-h-screen items-center justify-center overflow-x-clip">
+      <p className="text-mk-text-muted text-sm">
+        Retro/Tactile variant — under construction.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/insert-card.tsx
+++ b/apps/web/src/components/marketing/variants/retro/insert-card.tsx
@@ -1,0 +1,23 @@
+// Founders' quote as a printed insert / leaflet: cream stock, heavier grain, a
+// dashed perforation edge, and a slight tilt (desktop only).
+export function InsertCard() {
+  return (
+    <div className="mx-auto w-full max-w-[760px] px-6">
+      <figure className="paper-heavy v-perf border-mk-border relative overflow-hidden rounded-[var(--v-radius-box)] border-2 px-[clamp(22px,5vw,52px)] py-[clamp(32px,5vw,52px)] shadow-[var(--shadow-mk-md)] [transform:rotate(-1.2deg)] max-[860px]:[transform:none]">
+        <p
+          aria-hidden="true"
+          className="text-mk-text-muted mb-5 font-mono text-[10.5px] font-bold tracking-[0.18em] uppercase"
+        >
+          A note from inside the box
+        </p>
+        <blockquote className="font-mk-heading text-mk-text-strong text-[clamp(20px,3vw,28px)] leading-[1.32] font-medium text-balance italic">
+          “We built JigSwap because our finished puzzles deserved better than
+          the attic — and because puzzling is more fun when you share it.”
+        </blockquote>
+        <figcaption className="font-mk-heading text-mk-text-body mt-5 text-[14px] font-semibold tracking-[0.04em] uppercase">
+          — The family behind JigSwap, puzzling at the kitchen table since 2025.
+        </figcaption>
+      </figure>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/keep-card.tsx
+++ b/apps/web/src/components/marketing/variants/retro/keep-card.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+// "Keep this card" — a detachable warranty/registration card. Brick-tinted
+// inset, perforated dashed top edge, a small KEEP THIS stamp, and a tiny
+// box → person → box typographic diagram.
+export function KeepCard() {
+  return (
+    <div className="mx-auto w-full max-w-[760px] px-6">
+      <div
+        className="v-perf paper relative overflow-hidden rounded-[var(--v-radius-box)] px-[clamp(20px,5vw,48px)] pt-9 pb-[clamp(28px,4vw,40px)] shadow-[var(--shadow-mk-md)]"
+        style={{
+          backgroundColor:
+            "color-mix(in oklab, var(--mk-seed-primary) 9%, var(--mk-card))",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="absolute top-4 right-4 inline-flex rotate-[-4deg] items-center gap-1 rounded-[var(--v-radius-chip)] px-2.5 py-1 font-mono text-[10px] font-bold tracking-[0.14em] uppercase"
+          style={{ background: "var(--v-band-teal)", color: "#fbf3df" }}
+        >
+          ✶ Keep this
+        </span>
+
+        <h2 className="font-mk-heading text-mk-text-strong max-w-[16ch] text-[clamp(24px,3.4vw,34px)] leading-[1.1] font-bold tracking-tight">
+          Never lose a box again.
+        </h2>
+        <p className="text-mk-text-body mt-4 max-w-[56ch] text-[clamp(15px,2vw,17px)] leading-relaxed text-pretty">
+          Lend a puzzle out and JigSwap remembers exactly who has it. No
+          guesswork, no “didn&apos;t I lend that to someone?” — just box →
+          person → back to your shelf.
+        </p>
+
+        <div
+          aria-hidden="true"
+          className="text-mk-text-strong mt-6 flex flex-wrap items-center gap-2 font-mono text-[12px] font-bold tracking-[0.08em] uppercase"
+        >
+          <Chip>📦 Your box</Chip>
+          <Arrow />
+          <Chip>🧑 A puzzler</Chip>
+          <Arrow />
+          <Chip>📦 Back to you</Chip>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="border-mk-border bg-mk-card inline-flex items-center rounded-[var(--v-radius-chip)] border-2 px-3 py-1.5">
+      {children}
+    </span>
+  );
+}
+
+function Arrow() {
+  return <span className="text-mk-text-muted text-[16px] leading-none">→</span>;
+}

--- a/apps/web/src/components/marketing/variants/retro/keep-card.tsx
+++ b/apps/web/src/components/marketing/variants/retro/keep-card.tsx
@@ -16,7 +16,10 @@ export function KeepCard() {
         <span
           aria-hidden="true"
           className="absolute top-4 right-4 inline-flex rotate-[-4deg] items-center gap-1 rounded-[var(--v-radius-chip)] px-2.5 py-1 font-mono text-[10px] font-bold tracking-[0.14em] uppercase"
-          style={{ background: "var(--v-band-teal)", color: "#fbf3df" }}
+          style={{
+            background: "var(--v-band-teal)",
+            color: "var(--v-on-band)",
+          }}
         >
           ✶ Keep this
         </span>

--- a/apps/web/src/components/marketing/variants/retro/numbers-band.tsx
+++ b/apps/web/src/components/marketing/variants/retro/numbers-band.tsx
@@ -13,17 +13,17 @@ export function NumbersBand({ stats }: { stats: LandingStats | undefined }) {
       <div className="mx-auto w-full max-w-[1200px] px-6 text-center">
         <div
           className="inline-flex items-center gap-2 font-mono text-xs font-semibold tracking-[0.14em] uppercase"
-          style={{ color: "#fbf3df" }}
+          style={{ color: "var(--v-on-band)" }}
         >
           <span
             className="h-0.5 w-[18px] rounded-xs"
-            style={{ background: "#fbf3df" }}
+            style={{ background: "var(--v-on-band)" }}
           />
           By the numbers
         </div>
         <h2
           className="font-mk-heading mx-auto mt-3.5 max-w-[20ch] text-[clamp(28px,4vw,40px)] leading-[1.1] font-bold tracking-tight"
-          style={{ color: "#fbf3df" }}
+          style={{ color: "var(--v-on-band)" }}
         >
           A growing box of puzzlers
         </h2>

--- a/apps/web/src/components/marketing/variants/retro/numbers-band.tsx
+++ b/apps/web/src/components/marketing/variants/retro/numbers-band.tsx
@@ -1,0 +1,57 @@
+import { Reveal } from "@/components/marketing/reveal";
+import type { LandingStats } from "@/components/marketing/variants/use-landing-data";
+import { StampStat } from "./stamp-stat";
+
+// Full-bleed teal "by the numbers" band — three REAL Convex totals rendered as
+// rubber-stamp figures. Real totals only; never fabricated.
+export function NumbersBand({ stats }: { stats: LandingStats | undefined }) {
+  return (
+    <section
+      className="w-full overflow-x-clip py-[clamp(56px,8vw,104px)]"
+      style={{ background: "var(--v-band-teal)" }}
+    >
+      <div className="mx-auto w-full max-w-[1200px] px-6 text-center">
+        <div
+          className="inline-flex items-center gap-2 font-mono text-xs font-semibold tracking-[0.14em] uppercase"
+          style={{ color: "#fbf3df" }}
+        >
+          <span
+            className="h-0.5 w-[18px] rounded-xs"
+            style={{ background: "#fbf3df" }}
+          />
+          By the numbers
+        </div>
+        <h2
+          className="font-mk-heading mx-auto mt-3.5 max-w-[20ch] text-[clamp(28px,4vw,40px)] leading-[1.1] font-bold tracking-tight"
+          style={{ color: "#fbf3df" }}
+        >
+          A growing box of puzzlers
+        </h2>
+
+        <div className="mt-12 flex flex-wrap items-center justify-center gap-[clamp(20px,4vw,56px)]">
+          <Reveal delay={0}>
+            <StampStat
+              value={stats?.totalUsers}
+              caption="Puzzlers"
+              rotate="-2deg"
+            />
+          </Reveal>
+          <Reveal delay={120}>
+            <StampStat
+              value={stats?.totalPuzzles}
+              caption="Puzzles catalogued"
+              rotate="1.5deg"
+            />
+          </Reveal>
+          <Reveal delay={240}>
+            <StampStat
+              value={stats?.totalOwnedPuzzles}
+              caption="On shelves"
+              rotate="-1deg"
+            />
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/retro.css
+++ b/apps/web/src/components/marketing/variants/retro/retro.css
@@ -1,0 +1,6 @@
+/* Retro/Tactile variant — scoped styles under `.v-retro`.
+ * Paper texture, nostalgic palette, board-game-box feel. Redeclare `--mk-*` /
+ * add `--v-*` custom properties here. Replaced/expanded by the Frontend Developer. */
+.v-retro {
+  /* scope marker — variant styles go here */
+}

--- a/apps/web/src/components/marketing/variants/retro/retro.css
+++ b/apps/web/src/components/marketing/variants/retro/retro.css
@@ -1,6 +1,249 @@
-/* Retro/Tactile variant — scoped styles under `.v-retro`.
- * Paper texture, nostalgic palette, board-game-box feel. Redeclare `--mk-*` /
- * add `--v-*` custom properties here. Replaced/expanded by the Frontend Developer. */
+/* apps/web/src/components/marketing/variants/retro/retro.css
+   Retro / Tactile: vintage board-game box. Muted mustard/teal/brick/cream,
+   slab display type, paper grain. Re-points --mk-* so shared Button/Section/
+   cards/header turn retro with no component edits; adds --v-* for box craft. */
+
+@import url("https://fonts.googleapis.com/css2?family=Rokkitt:wght@500;600;700;800&display=swap");
+
 .v-retro {
-  /* scope marker — variant styles go here */
+  /* --- Board-game seeds (literal, deliberately off the violet brand) --- */
+  --mk-seed-primary: #c64f33; /* brick — "brand"/primary ink */
+  --mk-seed-secondary: #1f7a6f; /* teal — "go"/secondary ink */
+  --mk-seed-accent: #d9a32a; /* mustard — highlight/stamp */
+
+  /* --- Paper grounds (literal cream / off-white print stock) --- */
+  --v-paper: #f3e6cb; /* warm cream page */
+  --v-paper-card: #fbf3df; /* lighter card stock */
+  --v-paper-deep: #e8d6b0; /* muted band / contents bag */
+  --v-lid-ground: #d9a32a; /* mustard hero/CTA band */
+  --v-band-teal: #1f7a6f; /* numbers band ground */
+
+  --mk-bg: var(--v-paper);
+  --mk-card: var(--v-paper-card);
+  --mk-muted: var(--v-paper-deep);
+
+  /* --- Ink (AA on cream + on mustard) --- */
+  --mk-text-strong: #241a10; /* near-black brown ink */
+  --mk-text-body: #3d2f1d; /* 8.9:1 on cream */
+  --mk-text-muted: #6f5a3c; /* ~4.6:1 on cream */
+
+  --mk-border: #b89a64; /* warm print rule */
+  --mk-input-border: #a98a56;
+  --mk-ring: #1f7a6f; /* teal focus — ≥3:1 on cream + mustard */
+
+  /* Shared violet/green utility tokens used by reused components — re-point so
+     Eyebrow/SectionHead/links stop reading violet and turn retro ink/teal. */
+  --mk-violet-200: color-mix(in oklab, var(--mk-seed-secondary) 30%, #e8d6b0);
+  --mk-violet-400: color-mix(in oklab, var(--mk-seed-secondary) 60%, #c9b489);
+  --mk-violet-600: #1a5f57; /* teal-ink, AA on cream for eyebrow/links */
+  --mk-green-600: #c64f33; /* brick — wordmark "Swap" reads as ink */
+
+  /* --- Letterpress shadows (warm, low, inky) --- */
+  --shadow-mk-xs: 0 1px 0 rgb(60 40 16 / 0.18);
+  --shadow-mk-sm: 0 2px 0 rgb(60 40 16 / 0.16);
+  --shadow-mk-md:
+    0 3px 0 rgb(60 40 16 / 0.2), 0 8px 18px -8px rgb(60 40 16 / 0.3);
+  --shadow-mk-lg:
+    0 5px 0 rgb(60 40 16 / 0.22), 0 18px 34px -10px rgb(60 40 16 / 0.32);
+  --shadow-mk-brand: 0 4px 0 #8a3724, 0 12px 26px -8px rgb(140 56 36 / 0.4);
+
+  /* --- Display font wired into shared headings --- */
+  --v-font-display: "Rokkitt", "Rockwell", "Courier New", Georgia, serif;
+  --font-mk-heading: var(--v-font-display);
+
+  /* --- Variant-only box-craft tokens --- */
+  --v-radius-box: 10px; /* die-cut box corner */
+  --v-radius-chip: 6px;
+  --v-grain-light: 0.05; /* paper grain opacity, light */
+  --v-grain-dark: 0.08;
+  --v-rule: 1px dashed var(--mk-border);
+  --v-shadow-die:
+    0 0 0 3px var(--mk-text-strong),
+    /* ink keyline */ 6px 7px 0 rgb(36 26 16 / 0.18),
+    /* offset drop = "box thickness" */ 0 22px 40px -14px rgb(36 26 16 / 0.34);
+  --v-press-drift: 1px; /* offset-print ghost breathe distance */
+  --v-grain: var(--v-grain-light);
+}
+
+/* --- Dark retro: dim the paper to a tobacco/board ground, KEEP the grain --- */
+.dark .v-retro {
+  --v-paper: #221a10;
+  --v-paper-card: #2b2114;
+  --v-paper-deep: #1c150c;
+  --v-lid-ground: #8f6c17; /* dimmer mustard so cream ink stays AA */
+  --v-band-teal: #12433d;
+
+  --mk-bg: var(--v-paper);
+  --mk-card: var(--v-paper-card);
+  --mk-muted: var(--v-paper-deep);
+
+  --mk-text-strong: #f5e9cf; /* cream ink */
+  --mk-text-body: #e6d4ac;
+  --mk-text-muted: #b89a64; /* ≥4.5:1 on tobacco */
+
+  --mk-border: #5a472a;
+  --mk-ring: #5bb7a9; /* brighter teal for dark focus visibility */
+
+  --mk-violet-200: color-mix(in oklab, var(--mk-seed-secondary) 30%, #2b2114);
+  --mk-violet-400: color-mix(in oklab, var(--mk-seed-secondary) 55%, #3a2c18);
+  --mk-violet-600: #6fcabb; /* teal-ink readable on tobacco */
+  --mk-green-600: #e7895f; /* warm brick on dark */
+
+  --v-grain: var(--v-grain-dark);
+  --v-shadow-die:
+    0 0 0 3px #0d0a05, 6px 7px 0 rgb(0 0 0 / 0.5),
+    0 22px 40px -14px rgb(0 0 0 / 0.55);
+}
+
+/* ============================================================ *
+ *  Textures & box craft                                        *
+ * ============================================================ */
+
+/* Paper grain — inline feTurbulence multiplied over the surface. The grain is
+   a low-opacity overlay so it never drags body text below AA. */
+.v-retro .paper {
+  background-color: var(--mk-card);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/></svg>");
+  background-blend-mode: multiply;
+}
+.dark .v-retro .paper {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.09'/></svg>");
+}
+
+/* Heavier grain stock for the founders' insert. */
+.v-retro .paper-heavy {
+  background-color: var(--mk-card);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='m'><feTurbulence type='fractalNoise' baseFrequency='0.55' numOctaves='3'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23m)' opacity='0.07'/></svg>");
+  background-blend-mode: multiply;
+}
+
+/* Double-rule = die-cut box edge. */
+.v-retro .v-double-rule {
+  border-bottom: 2px solid var(--mk-border);
+  box-shadow: 0 3px 0 var(--mk-border);
+}
+
+/* Die-cut box card (lid + parts bag). */
+.v-retro .v-box {
+  border-radius: var(--v-radius-box);
+  box-shadow: var(--v-shadow-die);
+}
+
+/* Offset-print misregistration ghost behind ink type (the signature look). */
+.v-retro .v-offset {
+  text-shadow: 1.5px 1.5px 0
+    color-mix(in oklab, var(--mk-seed-secondary) 50%, transparent);
+}
+
+/* Hero h1: a slightly stronger teal ghost + a barely-perceptible drift. */
+.v-retro .v-offset-hero {
+  text-shadow: 1.5px 1.5px 0
+    color-mix(in oklab, var(--mk-seed-secondary) 55%, transparent);
+  animation: v-press-drift 6s ease-in-out infinite alternate;
+}
+@keyframes v-press-drift {
+  from {
+    text-shadow: 1.5px 1.5px 0
+      color-mix(in oklab, var(--mk-seed-secondary) 55%, transparent);
+  }
+  to {
+    text-shadow: 2.5px 2.5px 0
+      color-mix(in oklab, var(--mk-seed-secondary) 55%, transparent);
+  }
+}
+
+/* Dotted contents-list leader. */
+.v-retro .v-leader {
+  border-bottom: 1px dotted var(--mk-border);
+}
+
+/* Dashed perforation rule. */
+.v-retro .v-perf {
+  border-top: 2px dashed var(--mk-border);
+}
+
+/* Barcode — pure CSS bars. */
+.v-retro .v-barcode {
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--mk-text-strong) 0 2px,
+    transparent 2px 4px,
+    var(--mk-text-strong) 4px 7px,
+    transparent 7px 10px,
+    var(--mk-text-strong) 10px 11px,
+    transparent 11px 14px
+  );
+}
+
+/* Rubber-stamp circle (numbers band). */
+.v-retro .v-stamp {
+  border: 2.5px solid currentColor;
+  border-radius: 999px;
+}
+
+/* Lid settle entrance. */
+.v-retro .v-lid-settle {
+  animation: v-lid-settle 0.42s var(--ease-mk-out) both;
+}
+@keyframes v-lid-settle {
+  from {
+    transform: translateY(8px);
+    box-shadow:
+      0 0 0 3px var(--mk-text-strong),
+      2px 3px 0 rgb(36 26 16 / 0.12),
+      0 8px 16px -10px rgb(36 26 16 / 0.2);
+  }
+  to {
+    transform: translateY(0);
+    box-shadow: var(--v-shadow-die);
+  }
+}
+
+/* Corner stamp stamp-down. */
+.v-retro .v-stamp-down {
+  animation: v-stamp-down 0.45s var(--ease-mk-spring) both;
+}
+@keyframes v-stamp-down {
+  0% {
+    transform: rotate(8deg) scale(0.9);
+    opacity: 0;
+  }
+  60% {
+    transform: rotate(11deg) scale(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: rotate(8deg) scale(1);
+    opacity: 1;
+  }
+}
+
+/* Dashed assembly connectors. */
+.v-retro .v-connector-h {
+  border-top: 2px dashed var(--mk-border);
+}
+.v-retro .v-connector-v {
+  border-left: 2px dashed var(--mk-border);
+}
+
+/* ============================================================ *
+ *  Reduced motion — everything resolves to its final state.    *
+ * ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .v-retro .v-lid-settle,
+  .v-retro .v-stamp-down,
+  .v-retro .v-offset-hero {
+    animation: none !important;
+  }
+  .v-retro .v-lid-settle {
+    box-shadow: var(--v-shadow-die);
+  }
+  .v-retro .v-stamp-down {
+    transform: rotate(8deg) scale(1);
+    opacity: 1;
+  }
+  .v-retro .v-offset-hero {
+    text-shadow: 1.5px 1.5px 0
+      color-mix(in oklab, var(--mk-seed-secondary) 55%, transparent);
+  }
 }

--- a/apps/web/src/components/marketing/variants/retro/retro.css
+++ b/apps/web/src/components/marketing/variants/retro/retro.css
@@ -1,55 +1,35 @@
 /* apps/web/src/components/marketing/variants/retro/retro.css
-   Retro / Tactile: vintage board-game box. Muted mustard/teal/brick/cream,
-   slab display type, paper grain. Re-points --mk-* so shared Button/Section/
-   cards/header turn retro with no component edits; adds --v-* for box craft. */
+   Retro / Tactile: vintage board-game box. Keeps JigSwap's ORIGINAL brand
+   palette — surfaces, text, ramps and ring all inherit the global brand
+   --mk-*. Only the LAYOUT/craft changes: slab display type, paper grain,
+   die-cut box shadows, letterpress buttons, stamps and perforations. The
+   "box lid" / "numbers" bands are recoloured to the signature brand violet
+   (white ink on them is AA-safe). All scoped under .v-retro. */
 
 @import url("https://fonts.googleapis.com/css2?family=Rokkitt:wght@500;600;700;800&display=swap");
 
 .v-retro {
-  /* --- Board-game seeds (literal, deliberately off the violet brand) --- */
-  --mk-seed-primary: #c64f33; /* brick — "brand"/primary ink */
-  --mk-seed-secondary: #1f7a6f; /* teal — "go"/secondary ink */
-  --mk-seed-accent: #d9a32a; /* mustard — highlight/stamp */
-
-  /* --- Paper grounds (literal cream / off-white print stock) --- */
-  --v-paper: #f3e6cb; /* warm cream page */
-  --v-paper-card: #fbf3df; /* lighter card stock */
-  --v-paper-deep: #e8d6b0; /* muted band / contents bag */
-  --v-lid-ground: #d9a32a; /* mustard hero/CTA band */
-  --v-band-teal: #1f7a6f; /* numbers band ground */
-
-  --mk-bg: var(--v-paper);
-  --mk-card: var(--v-paper-card);
-  --mk-muted: var(--v-paper-deep);
-
-  /* --- Ink (AA on cream + on mustard) --- */
-  --mk-text-strong: #241a10; /* near-black brown ink */
-  --mk-text-body: #3d2f1d; /* 8.9:1 on cream */
-  --mk-text-muted: #6f5a3c; /* ~4.6:1 on cream */
-
-  --mk-border: #b89a64; /* warm print rule */
-  --mk-input-border: #a98a56;
-  --mk-ring: #1f7a6f; /* teal focus — ≥3:1 on cream + mustard */
-
-  /* Shared violet/green utility tokens used by reused components — re-point so
-     Eyebrow/SectionHead/links stop reading violet and turn retro ink/teal. */
-  --mk-violet-200: color-mix(in oklab, var(--mk-seed-secondary) 30%, #e8d6b0);
-  --mk-violet-400: color-mix(in oklab, var(--mk-seed-secondary) 60%, #c9b489);
-  --mk-violet-600: #1a5f57; /* teal-ink, AA on cream for eyebrow/links */
-  --mk-green-600: #c64f33; /* brick — wordmark "Swap" reads as ink */
-
-  /* --- Letterpress shadows (warm, low, inky) --- */
-  --shadow-mk-xs: 0 1px 0 rgb(60 40 16 / 0.18);
-  --shadow-mk-sm: 0 2px 0 rgb(60 40 16 / 0.16);
-  --shadow-mk-md:
-    0 3px 0 rgb(60 40 16 / 0.2), 0 8px 18px -8px rgb(60 40 16 / 0.3);
-  --shadow-mk-lg:
-    0 5px 0 rgb(60 40 16 / 0.22), 0 18px 34px -10px rgb(60 40 16 / 0.32);
-  --shadow-mk-brand: 0 4px 0 #8a3724, 0 12px 26px -8px rgb(140 56 36 / 0.4);
+  /* --- Colored box-craft bands, re-based on the BRAND violet --- */
+  --v-lid-ground: var(--mk-seed-primary); /* hero "box lid" band (#6048e8) */
+  --v-band-teal: var(
+    --mk-violet-700
+  ); /* numbers band + chips (deeper violet) */
+  --v-on-band: #ffffff; /* "ink" printed on the violet bands (AA on both) */
 
   /* --- Display font wired into shared headings --- */
   --v-font-display: "Rokkitt", "Rockwell", "Courier New", Georgia, serif;
   --font-mk-heading: var(--v-font-display);
+
+  /* --- Letterpress shadows: hard offsets in brand-neutral ink --- */
+  --shadow-mk-xs: 0 1px 0 rgb(31 27 46 / 0.18);
+  --shadow-mk-sm: 0 2px 0 rgb(31 27 46 / 0.16);
+  --shadow-mk-md:
+    0 3px 0 rgb(31 27 46 / 0.2), 0 8px 18px -8px rgb(31 27 46 / 0.3);
+  --shadow-mk-lg:
+    0 5px 0 rgb(31 27 46 / 0.22), 0 18px 34px -10px rgb(31 27 46 / 0.32);
+  /* Chunky letterpress brand button: hard violet offset + soft brand glow. */
+  --shadow-mk-brand:
+    0 4px 0 var(--mk-violet-700), 0 12px 26px -8px rgb(96 72 232 / 0.4);
 
   /* --- Variant-only box-craft tokens --- */
   --v-radius-box: 10px; /* die-cut box corner */
@@ -59,36 +39,16 @@
   --v-rule: 1px dashed var(--mk-border);
   --v-shadow-die:
     0 0 0 3px var(--mk-text-strong),
-    /* ink keyline */ 6px 7px 0 rgb(36 26 16 / 0.18),
-    /* offset drop = "box thickness" */ 0 22px 40px -14px rgb(36 26 16 / 0.34);
+    /* ink keyline */ 6px 7px 0 rgb(31 27 46 / 0.18),
+    /* offset drop = "box thickness" */ 0 22px 40px -14px rgb(31 27 46 / 0.34);
   --v-press-drift: 1px; /* offset-print ghost breathe distance */
   --v-grain: var(--v-grain-light);
 }
 
-/* --- Dark retro: dim the paper to a tobacco/board ground, KEEP the grain --- */
+/* Dark retro inherits the global brand .dark surfaces/text/ramps; keep the
+   grain heavier and the die-cut drop deeper. The violet bands + white ink
+   still read in dark. */
 .dark .v-retro {
-  --v-paper: #221a10;
-  --v-paper-card: #2b2114;
-  --v-paper-deep: #1c150c;
-  --v-lid-ground: #8f6c17; /* dimmer mustard so cream ink stays AA */
-  --v-band-teal: #12433d;
-
-  --mk-bg: var(--v-paper);
-  --mk-card: var(--v-paper-card);
-  --mk-muted: var(--v-paper-deep);
-
-  --mk-text-strong: #f5e9cf; /* cream ink */
-  --mk-text-body: #e6d4ac;
-  --mk-text-muted: #b89a64; /* ≥4.5:1 on tobacco */
-
-  --mk-border: #5a472a;
-  --mk-ring: #5bb7a9; /* brighter teal for dark focus visibility */
-
-  --mk-violet-200: color-mix(in oklab, var(--mk-seed-secondary) 30%, #2b2114);
-  --mk-violet-400: color-mix(in oklab, var(--mk-seed-secondary) 55%, #3a2c18);
-  --mk-violet-600: #6fcabb; /* teal-ink readable on tobacco */
-  --mk-green-600: #e7895f; /* warm brick on dark */
-
   --v-grain: var(--v-grain-dark);
   --v-shadow-die:
     0 0 0 3px #0d0a05, 6px 7px 0 rgb(0 0 0 / 0.5),
@@ -129,13 +89,14 @@
   box-shadow: var(--v-shadow-die);
 }
 
-/* Offset-print misregistration ghost behind ink type (the signature look). */
+/* Offset-print misregistration ghost behind ink type (the signature look),
+   tinted with the brand green seed. */
 .v-retro .v-offset {
   text-shadow: 1.5px 1.5px 0
     color-mix(in oklab, var(--mk-seed-secondary) 50%, transparent);
 }
 
-/* Hero h1: a slightly stronger teal ghost + a barely-perceptible drift. */
+/* Hero h1: a slightly stronger ghost + a barely-perceptible drift. */
 .v-retro .v-offset-hero {
   text-shadow: 1.5px 1.5px 0
     color-mix(in oklab, var(--mk-seed-secondary) 55%, transparent);
@@ -190,8 +151,8 @@
     transform: translateY(8px);
     box-shadow:
       0 0 0 3px var(--mk-text-strong),
-      2px 3px 0 rgb(36 26 16 / 0.12),
-      0 8px 16px -10px rgb(36 26 16 / 0.2);
+      2px 3px 0 rgb(31 27 46 / 0.12),
+      0 8px 16px -10px rgb(31 27 46 / 0.2);
   }
   to {
     transform: translateY(0);

--- a/apps/web/src/components/marketing/variants/retro/stamp-stat.tsx
+++ b/apps/web/src/components/marketing/variants/retro/stamp-stat.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+// A single rubber-stamp stat: cream ink-stamp on the teal band, big slab
+// numeral + one-word caption. Accessible loading: a pulsing placeholder, the
+// caption visible, and NO fabricated zero announced.
+export function StampStat({
+  value,
+  caption,
+  rotate,
+}: {
+  value: number | undefined;
+  caption: string;
+  rotate: string;
+}) {
+  const loading = value === undefined;
+
+  return (
+    <div
+      className="v-stamp flex aspect-square w-[clamp(150px,22vw,196px)] flex-col items-center justify-center rounded-full p-4 text-center max-[860px]:[transform:rotate(var(--v-stamp-rot-sm))]"
+      style={
+        {
+          color: "#fbf3df",
+          transform: `rotate(${rotate})`,
+          ["--v-stamp-rot-sm" as string]: rotate.startsWith("-")
+            ? "-1deg"
+            : "1deg",
+        } as React.CSSProperties
+      }
+    >
+      {loading ? (
+        <span
+          aria-hidden="true"
+          className="h-9 w-20 animate-pulse rounded-[4px] bg-[#fbf3df]/40"
+        />
+      ) : (
+        <span className="font-mk-heading text-[clamp(34px,5vw,52px)] leading-none font-extrabold tabular-nums">
+          {value.toLocaleString()}
+        </span>
+      )}
+      <span
+        className={cn(
+          "mt-2 max-w-[12ch] font-mono text-[11px] font-bold tracking-[0.12em] uppercase",
+        )}
+      >
+        {caption}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/retro/stamp-stat.tsx
+++ b/apps/web/src/components/marketing/variants/retro/stamp-stat.tsx
@@ -20,7 +20,7 @@ export function StampStat({
       className="v-stamp flex aspect-square w-[clamp(150px,22vw,196px)] flex-col items-center justify-center rounded-full p-4 text-center max-[860px]:[transform:rotate(var(--v-stamp-rot-sm))]"
       style={
         {
-          color: "#fbf3df",
+          color: "var(--v-on-band)",
           transform: `rotate(${rotate})`,
           ["--v-stamp-rot-sm" as string]: rotate.startsWith("-")
             ? "-1deg"
@@ -31,7 +31,7 @@ export function StampStat({
       {loading ? (
         <span
           aria-hidden="true"
-          className="h-9 w-20 animate-pulse rounded-[4px] bg-[#fbf3df]/40"
+          className="h-9 w-20 animate-pulse rounded-[4px] bg-white/40"
         />
       ) : (
         <span className="font-mk-heading text-[clamp(34px,5vw,52px)] leading-none font-extrabold tabular-nums">

--- a/apps/web/src/components/marketing/variants/switcher.tsx
+++ b/apps/web/src/components/marketing/variants/switcher.tsx
@@ -1,0 +1,115 @@
+import { Check, Moon, Palette, Sun, X } from "lucide-react";
+import { useTheme } from "next-themes";
+import * as React from "react";
+
+import { VARIANTS, type VariantId } from "./registry";
+
+// Floating "tweaks" panel for reviewing landing-page variants.
+//
+// Sits fixed in the bottom-right so it never pushes page layout around. Lets a
+// reviewer flip between the four redesigns + the original baseline and toggle
+// dark mode, all without leaving the page. This is a review-only control — it
+// is not part of any shipped variant and would be removed once a winner is
+// picked.
+
+export function VariantSwitcher({
+  current,
+  onChange,
+}: {
+  current: VariantId;
+  onChange: (id: VariantId) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  const isDark = mounted && resolvedTheme === "dark";
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[9999] font-mk-sans print:hidden">
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Landing variant switcher"
+          className="w-[280px] rounded-2xl border border-black/10 bg-white/85 p-3 text-[#1f1b2e] shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-[#1b1d24]/90 dark:text-[#f6f2ed]"
+        >
+          <div className="mb-2 flex items-center justify-between px-1">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide opacity-70">
+              <Palette size={14} />
+              Variant
+            </div>
+            <button
+              type="button"
+              aria-label="Close switcher"
+              onClick={() => setOpen(false)}
+              className="rounded-md p-1 opacity-60 transition-opacity hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          <ul className="flex flex-col gap-1">
+            {VARIANTS.map((v) => {
+              const active = v.id === current;
+              return (
+                <li key={v.id}>
+                  <button
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => onChange(v.id)}
+                    className={[
+                      "flex w-full items-start gap-2 rounded-xl px-2.5 py-2 text-left transition-colors",
+                      active
+                        ? "bg-[#6048e8]/12 ring-1 ring-[#6048e8]/40"
+                        : "hover:bg-black/5 dark:hover:bg-white/5",
+                    ].join(" ")}
+                  >
+                    <span className="mt-0.5 w-4 shrink-0">
+                      {active ? (
+                        <Check size={16} className="text-[#6048e8]" />
+                      ) : null}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block text-sm font-semibold">
+                        {v.label}
+                      </span>
+                      <span className="block text-[11px] leading-snug opacity-60">
+                        {v.tagline}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="mt-2 flex items-center justify-between border-t border-black/10 px-1 pt-2 dark:border-white/10">
+            <span className="text-xs opacity-70">Appearance</span>
+            <button
+              type="button"
+              aria-label={
+                isDark ? "Switch to light mode" : "Switch to dark mode"
+              }
+              onClick={() => setTheme(isDark ? "light" : "dark")}
+              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium hover:bg-black/5 focus-visible:outline-2 focus-visible:outline-offset-2 dark:hover:bg-white/5"
+            >
+              {isDark ? <Moon size={14} /> : <Sun size={14} />}
+              {isDark ? "Dark" : "Light"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          aria-label="Open landing variant switcher"
+          onClick={() => setOpen(true)}
+          className="flex items-center gap-2 rounded-full border border-black/10 bg-white/85 px-4 py-2.5 text-sm font-semibold text-[#1f1b2e] shadow-xl backdrop-blur-xl transition-transform hover:scale-[1.03] dark:border-white/10 dark:bg-[#1b1d24]/90 dark:text-[#f6f2ed]"
+        >
+          <Palette size={16} className="text-[#6048e8]" />
+          {VARIANTS.find((v) => v.id === current)?.label ?? "Variant"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/marketing/variants/use-landing-data.ts
+++ b/apps/web/src/components/marketing/variants/use-landing-data.ts
@@ -1,0 +1,63 @@
+import { gateway } from "@/gateway";
+import { useQuery } from "convex/react";
+import * as React from "react";
+
+// Shared marketing data hook so every landing variant pulls the same real
+// platform numbers without re-implementing the Convex wiring. Mirrors the
+// query usage in the original hero/stats components.
+//
+// SSR-safe: the seed-dependent queries are skipped until a client-side seed is
+// generated after mount, so the server render is deterministic.
+
+export type LandingStats = {
+  totalUsers: number;
+  totalPuzzles: number;
+  totalOwnedPuzzles: number;
+};
+
+export type CommunityAvatar = { initials: string; image: string | null };
+
+export type PlankPuzzle = {
+  title: string;
+  pieceCount: number;
+  brand?: string;
+  image: string | null;
+};
+
+export type LandingData = {
+  /** Global platform counters; `undefined` while loading. */
+  stats: LandingStats | undefined;
+  /** Up to `avatarLimit` real community members; `undefined` while loading. */
+  communityAvatars: CommunityAvatar[] | undefined;
+  /** Up to `plankLimit` recent catalog puzzles for shelf/plank visuals. */
+  plankPuzzles: PlankPuzzle[] | undefined;
+};
+
+export function useLandingData(options?: {
+  avatarLimit?: number;
+  plankLimit?: number;
+}): LandingData {
+  const avatarLimit = options?.avatarLimit ?? 4;
+  const plankLimit = options?.plankLimit ?? 12;
+
+  const stats = useQuery(gateway.insights.globalStats, {}) as
+    | LandingStats
+    | undefined;
+
+  // Stable per-visit seed generated client-side after mount (SSR-safe). The
+  // seeded queries stay skipped until it is ready.
+  const [seed, setSeed] = React.useState<number | null>(null);
+  React.useEffect(() => setSeed(Math.floor(Math.random() * 0xffffffff)), []);
+
+  const communityAvatars = useQuery(
+    gateway.insights.communityAvatars,
+    seed === null ? "skip" : { limit: avatarLimit, seed },
+  ) as CommunityAvatar[] | undefined;
+
+  const plankPuzzles = useQuery(
+    gateway.insights.plankPuzzles,
+    seed === null ? "skip" : { limit: plankLimit, seed },
+  ) as PlankPuzzle[] | undefined;
+
+  return { stats, communityAvatars, plankPuzzles };
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,41 +1,67 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import * as React from "react";
 
 import { pageTitle } from "@/lib/page-title";
 
-import { MarketingFooter } from "@/components/marketing/footer";
-import { MarketingHeader } from "@/components/marketing/header";
-import { FeatureRows } from "@/components/marketing/home/feature-rows";
-import { FinalCTA } from "@/components/marketing/home/final-cta";
-import { Hero } from "@/components/marketing/home/hero";
-import { HowPreview } from "@/components/marketing/home/how-preview";
-import { Stats } from "@/components/marketing/home/stats";
-import { Sustain } from "@/components/marketing/home/sustain";
-import { Testimonial } from "@/components/marketing/home/testimonial";
+import { Landing } from "@/components/marketing/variants/landing";
+import {
+  DEFAULT_VARIANT,
+  isVariantId,
+  type VariantId,
+} from "@/components/marketing/variants/registry";
+
+// Persisted variant choice, so a reviewer's pick survives reloads even without
+// the `?v=` param in the URL.
+const STORAGE_KEY = "jigswap.landing.variant";
+
+type HomeSearch = { v?: VariantId };
 
 export const Route = createFileRoute("/")({
+  // Keep `?v=` as a known, validated search param (anything else is dropped) so
+  // the active landing variant is SSR-safe and shareable as a preview URL.
+  validateSearch: (search: Record<string, unknown>): HomeSearch =>
+    isVariantId(search.v) ? { v: search.v } : {},
   head: ({ match }) => ({
     meta: [{ title: pageTitle(match.context, "home") }],
   }),
   component: Home,
 });
 
-// Marketing landing — the design handoff's "plank" hero variant followed by
-// stats (real platform numbers), how-it-works teaser, feature rows,
-// sustainability band, founders' quote and the closing CTA.
+// Marketing landing. Ships several drastically different design variants behind
+// a floating switcher (review-only) so the team can compare them live and keep
+// the winner. The URL `?v=` param wins; otherwise we fall back to the reviewer's
+// last stored choice, then the default variant.
 function Home() {
-  return (
-    <div className="mk-root font-mk-sans min-h-screen overflow-x-clip">
-      <MarketingHeader />
-      <main>
-        <Hero />
-        <Stats />
-        <HowPreview />
-        <FeatureRows />
-        <Sustain />
-        <Testimonial />
-        <FinalCTA />
-      </main>
-      <MarketingFooter />
-    </div>
+  const navigate = useNavigate();
+  const { v } = Route.useSearch();
+
+  // Client-only stored fallback, read after mount so the first (SSR-matching)
+  // render stays deterministic and never mismatches hydration.
+  const [stored, setStored] = React.useState<VariantId | null>(null);
+  React.useEffect(() => {
+    if (v) return;
+    try {
+      const saved = window.localStorage.getItem(STORAGE_KEY);
+      if (isVariantId(saved)) setStored(saved);
+    } catch {
+      /* localStorage unavailable — fall through to the default */
+    }
+  }, [v]);
+
+  const variant: VariantId = v ?? stored ?? DEFAULT_VARIANT;
+
+  const onVariantChange = React.useCallback(
+    (id: VariantId) => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, id);
+      } catch {
+        /* ignore — URL param still drives the selection */
+      }
+      setStored(id);
+      navigate({ to: "/", search: { v: id }, replace: true });
+    },
+    [navigate],
   );
+
+  return <Landing variant={variant} onVariantChange={onVariantChange} />;
 }


### PR DESCRIPTION
## What

The current landing page reads like a generic SaaS template. This PR adds **four drastically different landing-page redesigns** plus the original baseline, all switchable **live in one page** via a floating "tweaks" panel — so we can compare them in the browser and keep the winner.

Pick a variant in the bottom-right switcher, or deep-link it: `/?v=playful` · `/?v=editorial` · `/?v=cozy` · `/?v=retro` · `/?v=original`. Your choice persists across reloads (localStorage) and the dark-mode toggle lives in the same panel.

## The four directions

| Variant | Personality | Signature moves |
|---|---|---|
| **Playful-Premium** (`playful`, default) | Friendly + premium, Duolingo/Notion energy | A single **draggable puzzle piece** that snaps into the headline (spring + confetti + one stat tick); calm whitespace everywhere else; friendly stat pills; custody spotlight. Reuses Baloo 2. |
| **Bold / Editorial** (`editorial`) | Design-magazine cover | Oversized stacked `LEND. / SWAP. / SHARE.`, bespoke masthead + colophon, enormous editorial stat figures, manifesto pull-quote, numbered spreads, the 3D plank bleeding off the cover. **Fraunces** display. |
| **Cozy / Hygge** (`cozy`) | Rainy-day warmth | Warm terracotta re-seed, cream surfaces, sustainability promoted to hero weight, humanised stats. No 3D plank. *(No real lifestyle photos exist — photographic slots are marked `[PHOTO PLACEHOLDER]` and backed by a pure-CSS warm-gradient + grain + duotone fallback so it ships looking intentional.)* |
| **Retro / Tactile** (`retro`) | Board-game-box nostalgia | Vintage box-lid hero, paper grain via inline SVG (no binary assets), assembly-step loop, stamped "by the numbers" band. **Rokkitt** slab display. |

## How it's built

- **Theme by scope, never by edit.** Each variant lives in `apps/web/src/components/marketing/variants/<id>/`, is wrapped in a `.v-<id>` class, and re-skins the shared `--mk-*`-based components purely by redeclaring tokens in its own scoped CSS. **No changes to `marketing.css`, `globals.css`, or `__root.tsx`.**
- **SSR-safe selection** via a validated `?v=` search param (route-owned) + localStorage fallback; the `original` variant renders the current production landing untouched.
- Variants reuse the shared `useLandingData()` (real Convex stats), `useStartHref()`, and `Reveal`; display fonts load per-variant (no extra bytes on other pages).
- Accessibility: one `<h1>`, ordered landmarks, AA contrast, ≥44px targets, and every bespoke hero animation degrades under `prefers-reduced-motion`.
- Design rationale lives in `variants/_briefs/` (UX research + theming architecture).

This was produced with subagents — UX Researcher + UX Architect for the briefs/foundation, then a UI Designer → Frontend Developer pipeline per variant.

## Verification

- ✅ `pnpm type-check` (whole app) — clean
- ✅ `eslint` — 0 errors (4 pre-existing-style `<img>` warnings, matching the current `home/hero.tsx`)
- ✅ `prettier --check` — clean
- ✅ SSR returns **200** with correct distinctive content on all five variants

> ⚠️ No browser/visual QA in this environment (no Chrome; no real Convex/Clerk creds — SSR was checked with a dummy Convex URL in Clerk keyless mode). Please click through the variants in light + dark, desktop + mobile, before deciding.

## Switcher is review-only

The floating panel is a comparison tool, not shipping chrome. Once you pick a winner, the follow-up is: set it as the landing, delete the other variant folders + the switcher/registry, drop the `?v=` plumbing, and remove `_briefs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
