### PR TITLE
fix(web): enable adding a legacy catalog puzzle to the library

### DIFF
--- a/apps/web/src/components/add-puzzle/add-puzzle-mappers.test.ts
+++ b/apps/web/src/components/add-puzzle/add-puzzle-mappers.test.ts
@@ -2,7 +2,24 @@ import { describe, expect, it } from "vitest";
 import {
   availabilityToSharing,
   hasAnyAvailability,
+  resolveDefinitionId,
 } from "./add-puzzle-mappers";
+
+describe("resolveDefinitionId", () => {
+  it("prefers the domain aggregateId when present", () => {
+    expect(resolveDefinitionId("agg-1", "convex-id-1")).toBe("agg-1");
+  });
+
+  it("falls back to the raw Convex id for legacy puzzles without an aggregateId", () => {
+    expect(resolveDefinitionId(undefined, "convex-id-1")).toBe("convex-id-1");
+    expect(resolveDefinitionId(null, "convex-id-1")).toBe("convex-id-1");
+  });
+
+  it("returns null when neither id is available", () => {
+    expect(resolveDefinitionId(undefined, undefined)).toBeNull();
+    expect(resolveDefinitionId(null, null)).toBeNull();
+  });
+});
 
 describe("availabilityToSharing", () => {
   it("maps availability flags to an updateSharing arg object with visibility visible", () => {

--- a/apps/web/src/components/add-puzzle/add-puzzle-mappers.ts
+++ b/apps/web/src/components/add-puzzle/add-puzzle-mappers.ts
@@ -7,6 +7,16 @@ export interface Availability {
 export const hasAnyAvailability = (a: Availability): boolean =>
   a.forTrade || a.forLend || a.forSale;
 
+// The catalog id used to acquire a copy. Domain-written puzzles carry an `aggregateId`;
+// legacy/seeded rows predate it (it is optional in the schema) and must fall back to the raw
+// Convex `_id`, which the acquireCopy backend resolves via its by-_id fallback. Without this
+// fallback a legacy puzzle leaves `selectedDefinitionId` null — Save stays disabled and, worse,
+// a submit would mint a duplicate catalog definition instead of reusing the existing one.
+export const resolveDefinitionId = (
+  aggregateId: string | null | undefined,
+  fallbackId: string | null | undefined,
+): string | null => aggregateId ?? fallbackId ?? null;
+
 // Shape matches gateway.library.updateSharing args.
 export const availabilityToSharing = (copyId: string, a: Availability) => ({
   copyId,

--- a/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
@@ -16,6 +16,7 @@ import {
   MatchConfirm,
   PieceCountField,
   ReadinessChecklist,
+  resolveDefinitionId,
   SectionDivider,
   SegmentedPills,
   TagInput,
@@ -140,7 +141,9 @@ function AddPuzzlePage() {
     if (!puzzleIdFromUrl || !specificPuzzle) return;
     // Only pre-fill once (when selectedDefinitionId is still null)
     if (selectedDefinitionId) return;
-    setSelectedDefinitionId(specificPuzzle.aggregateId ?? null);
+    setSelectedDefinitionId(
+      resolveDefinitionId(specificPuzzle.aggregateId, specificPuzzle._id),
+    );
     setForm((f) => ({
       ...f,
       title: specificPuzzle.title,
@@ -532,7 +535,12 @@ function AddPuzzlePage() {
         <MatchConfirm
           match={pendingMatch}
           onUse={() => {
-            setSelectedDefinitionId(pendingMatch.aggregateId ?? null);
+            setSelectedDefinitionId(
+              resolveDefinitionId(
+                pendingMatch.aggregateId,
+                pendingMatch.puzzleId,
+              ),
+            );
             setForm((f) => ({
               ...f,
               title: pendingMatch.title,

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as catalog_adapters_ogieRawProductPage from "../catalog/adapters/o
 import type * as catalog_adapters_ogieStorePageFetcher from "../catalog/adapters/ogieStorePageFetcher.js";
 import type * as catalog_adapters_systemClock from "../catalog/adapters/systemClock.js";
 import type * as catalog_approvePuzzleDefinition from "../catalog/approvePuzzleDefinition.js";
+import type * as catalog_backfill from "../catalog/backfill.js";
 import type * as catalog_createCatalogCategory from "../catalog/createCatalogCategory.js";
 import type * as catalog_errors from "../catalog/errors.js";
 import type * as catalog_extractFromUrl from "../catalog/extractFromUrl.js";
@@ -269,6 +270,7 @@ declare const fullApi: ApiFromModules<{
   "catalog/adapters/ogieStorePageFetcher": typeof catalog_adapters_ogieStorePageFetcher;
   "catalog/adapters/systemClock": typeof catalog_adapters_systemClock;
   "catalog/approvePuzzleDefinition": typeof catalog_approvePuzzleDefinition;
+  "catalog/backfill": typeof catalog_backfill;
   "catalog/createCatalogCategory": typeof catalog_createCatalogCategory;
   "catalog/errors": typeof catalog_errors;
   "catalog/extractFromUrl": typeof catalog_extractFromUrl;

--- a/packages/backend/convex/catalog/backfill.ts
+++ b/packages/backend/convex/catalog/backfill.ts
@@ -1,0 +1,30 @@
+import { internalMutation } from "../_generated/server";
+
+// One-shot, idempotent migration: puzzles created before the domain catalog path never received
+// an aggregateId, so the copy-acquisition flow (which resolves a definition by aggregateId)
+// cannot reach them — in the add-to-library form their Save button stays disabled. library's
+// backfill only stamps puzzles reachable through an existing copy, so never-acquired catalog
+// rows stay unstamped; this sweep covers them.
+//
+// We use the row's own Convex _id as the aggregateId rather than a fresh UUID: the domain
+// PuzzleDefinitionId does no runtime format validation, and every existing _id reference (legacy
+// copies, plus copies acquired through the add/new _id fallback) then satisfies
+// puzzleDefinitionId === aggregateId, so ownership and grouping stay consistent with no copy
+// rewrite. Re-runnable: rows that already carry an aggregateId are skipped, never overwritten.
+export const backfillPuzzleAggregateIds = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const puzzles = await ctx.db.query("puzzles").collect();
+
+    let patched = 0;
+    for (const puzzle of puzzles) {
+      if (puzzle.aggregateId) continue;
+      await ctx.db.patch(puzzle._id, {
+        aggregateId: puzzle._id as unknown as string,
+      });
+      patched++;
+    }
+
+    return { patched };
+  },
+});

--- a/packages/backend/convex/catalogBackfill.test.ts
+++ b/packages/backend/convex/catalogBackfill.test.ts
@@ -1,0 +1,102 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seedSubmitter = (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    return ctx.db.insert("users", {
+      clerkId: "clerk_alice",
+      email: "alice@example.com",
+      name: "Alice",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+const insertPuzzle = (
+  t: ReturnType<typeof convexTest>,
+  submittedBy: Id<"users">,
+  fields: { title: string; aggregateId?: string },
+) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    return ctx.db.insert("puzzles", {
+      title: fields.title,
+      pieceCount: 1000,
+      searchableText: fields.title,
+      status: "approved",
+      submittedBy,
+      createdAt: now,
+      updatedAt: now,
+      ...(fields.aggregateId ? { aggregateId: fields.aggregateId } : {}),
+    });
+  });
+
+const puzzleById = (t: ReturnType<typeof convexTest>, id: Id<"puzzles">) =>
+  t.run(async (ctx) => ctx.db.get(id));
+
+const puzzleByAggregateId = (
+  t: ReturnType<typeof convexTest>,
+  aggregateId: string,
+) =>
+  t.run(async (ctx) =>
+    ctx.db
+      .query("puzzles")
+      .withIndex("by_aggregate_id", (q) => q.eq("aggregateId", aggregateId))
+      .unique(),
+  );
+
+describe("catalog.backfillPuzzleAggregateIds", () => {
+  test("stamps each legacy puzzle's _id as its aggregateId and leaves stamped rows alone", async () => {
+    const t = convexTest(schema, modules);
+    const submitter = await seedSubmitter(t);
+    const legacyA = await insertPuzzle(t, submitter, { title: "Legacy A" });
+    const legacyB = await insertPuzzle(t, submitter, { title: "Legacy B" });
+    const alreadyStamped = await insertPuzzle(t, submitter, {
+      title: "Domain Puzzle",
+      aggregateId: "existing-uuid",
+    });
+
+    const result = await t.mutation(
+      internal.catalog.backfill.backfillPuzzleAggregateIds,
+      {},
+    );
+    expect(result.patched).toBe(2);
+
+    // Legacy rows now carry their own _id as the aggregateId...
+    expect((await puzzleById(t, legacyA))?.aggregateId).toBe(legacyA);
+    expect((await puzzleById(t, legacyB))?.aggregateId).toBe(legacyB);
+    // ...so they are now resolvable through the by_aggregate_id index the copy flow uses.
+    expect((await puzzleByAggregateId(t, legacyA))?._id).toBe(legacyA);
+
+    // A row that already had an aggregateId is untouched.
+    expect((await puzzleById(t, alreadyStamped))?.aggregateId).toBe(
+      "existing-uuid",
+    );
+  });
+
+  test("is idempotent — a second run stamps nothing", async () => {
+    const t = convexTest(schema, modules);
+    const submitter = await seedSubmitter(t);
+    await insertPuzzle(t, submitter, { title: "Legacy A" });
+
+    const first = await t.mutation(
+      internal.catalog.backfill.backfillPuzzleAggregateIds,
+      {},
+    );
+    expect(first.patched).toBe(1);
+
+    const second = await t.mutation(
+      internal.catalog.backfill.backfillPuzzleAggregateIds,
+      {},
+    );
+    expect(second.patched).toBe(0);
+  });
+});

--- a/packages/backend/convex/libraryMutations.test.ts
+++ b/packages/backend/convex/libraryMutations.test.ts
@@ -160,6 +160,40 @@ describe("library.acquireCopy", () => {
     });
   });
 
+  test("acquires a legacy puzzle that has no aggregateId by its raw Convex _id", async () => {
+    const t = convexTest(schema, modules);
+    const { alice } = await seed(t);
+    // A legacy/seeded catalog row that predates aggregateId — the add/new copy flow reaches
+    // these by their raw _id, which the snapshot provider resolves via its by-_id fallback.
+    const legacyId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("puzzles", {
+        title: "Legacy Lighthouse",
+        brand: "Schmidt",
+        pieceCount: 750,
+        searchableText: "Legacy Lighthouse Schmidt",
+        status: "approved",
+        submittedBy: alice,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const copyId = (await asAlice(t).mutation(
+      api.library.acquireCopy.acquireCopy,
+      { puzzleDefinitionId: legacyId, condition: "good" },
+    )) as string;
+
+    const row = await copyRow(t, copyId);
+    expect(row?.puzzleDefinitionId).toBe(legacyId);
+    expect(row?.snapshot).toEqual({
+      title: "Legacy Lighthouse",
+      brand: "Schmidt",
+      pieceCount: 750,
+      thumbnail: undefined,
+    });
+  });
+
   test("an unknown puzzle definition => PuzzleNotFound", async () => {
     const t = convexTest(schema, modules);
     await seed(t);


### PR DESCRIPTION
## Problem

Picking an existing catalog puzzle to add to your library (copy mode, reached via `?puzzleId=`) left the **Save button disabled** — and, had it been submittable, would have **minted a duplicate catalog definition** instead of reusing the puzzle you picked.

## Root cause

Catalog puzzles store `aggregateId` as **optional** (`schema.ts` — legacy/seeded rows don't have one). The add-to-library form (`my-puzzles/add/new.tsx`) read *only* `specificPuzzle.aggregateId`, so for those rows `selectedDefinitionId` stayed `null`:

- `isReady` is false → Save disabled.
- `handleAdd` would fall into its `if (!definitionId)` branch → `createPuzzle` mints a new definition.

The backend's `acquireCopy` snapshot provider already resolves by `aggregateId` **and falls back to the raw Convex `_id`** — the frontend just never passed it.

## Fix

- New pure helper `resolveDefinitionId(aggregateId, fallbackId)` — prefers `aggregateId`, falls back to the raw `_id`, else `null`.
- Used in both call sites in `new.tsx`: the copy-mode pre-fill effect (`specificPuzzle._id`) and the import-match "Use" handler (`pendingMatch.puzzleId`).

Now picking an existing puzzle sets `selectedDefinitionId`, Save enables immediately, and the copy is acquired against the existing definition — no duplicate.

## Tests
- `resolveDefinitionId` unit test (written red → green).
- Backend regression test: `acquireCopy` resolves a legacy puzzle with no `aggregateId` by its raw `_id`.
- Full web suite 65/65, backend `libraryMutations` 27/27, `tsc` clean, ESLint + Prettier clean.

## How to verify
Open an existing catalog puzzle → "Add to library". The Save button should be enabled without entering a name, and saving should not create a second catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: durable backfill (legacy puzzles)

The frontend `_id` fallback above makes the form *resilient*, but the root data issue is that puzzles created before the domain catalog path have no `aggregateId` — and `library/backfill.ts` only stamps puzzles reachable via an existing copy, so never-acquired catalog rows stay unstamped (exactly the "browse → add a fresh one" case).

Added `catalog/backfill.ts` — an idempotent `internalMutation` that stamps each unstamped puzzle's own Convex `_id` as its `aggregateId`. Using `_id` (not a fresh UUID) keeps it consistent with every existing `_id` reference (legacy copies + copies acquired via the `_id` fallback), so `puzzleDefinitionId === aggregateId` holds with **no copy rewrite**. The domain `PuzzleDefinitionId` does no runtime format validation, so an `_id` string is valid.

**⚠️ Run once per deployment after merge:**
```
npx convex run catalog/backfill:backfillPuzzleAggregateIds
```
Re-runnable; rows that already have an `aggregateId` are skipped.
