### PR TITLE
docs(web): real ToS + privacy policy (EN/NL) — for owner review

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -898,7 +898,7 @@
     "title": "Privacy Policy",
     "lastUpdated": "Last Updated",
     "effectiveDate": "2 July 2026",
-    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by [OWNER TO CONFIRM: legal name of the operator], who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
+    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by Sander Verkuil, who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
     "informationWeCollect": {
       "title": "Information We Collect",
       "description": "We collect information you give us directly, plus a limited amount of information collected automatically while you use JigSwap.",
@@ -916,7 +916,7 @@
       "automaticallyCollected": {
         "title": "Collected automatically",
         "items": [
-          "Product analytics events, such as pages visited and features used (via PostHog)",
+          "Product analytics events, such as pages visited and features used (via PostHog, only after you accept the cookie notice)",
           "Error reports and operational logs used to keep the service running",
           "Your language preference and cookie-notice choice, stored in cookies",
           "A push notification subscription — only if you turn push notifications on"
@@ -948,14 +948,18 @@
     },
     "dataStorage": {
       "title": "Where Your Data Lives",
-      "description": "JigSwap does not run its own servers. Your data is stored with a small number of service providers:",
+      "description": "JigSwap does not run its own servers. Your data is stored in the European Union with a small number of service providers:",
       "convex": {
         "title": "Convex",
-        "description": "Our database and file storage. Your library, exchanges, messages, and uploaded photos are stored in Convex."
+        "description": "Our database and file storage, on Convex's EU hosting. Your library, exchanges, messages, and uploaded photos are stored in the European Union."
       },
       "clerk": {
         "title": "Clerk",
-        "description": "Our authentication provider. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+        "description": "Our authentication provider, with EU data residency. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+      },
+      "vercel": {
+        "title": "Vercel",
+        "description": "Our hosting provider. The JigSwap web application is served through Vercel's global edge network. Vercel delivers the site to your browser; your personal data itself lives in the EU-hosted services above."
       }
     },
     "photos": {
@@ -972,7 +976,7 @@
       "description": "We use analytics to understand how JigSwap is used and to catch errors before they spoil the fun.",
       "posthog": {
         "title": "PostHog",
-        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. This data is used only to improve JigSwap."
+        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. PostHog only starts after you accept the cookie notice — if you decline, it is never loaded. This data is used only to improve JigSwap."
       },
       "noAdvertising": "We do not show ads, we do not use your data for advertising, and we never sell your data."
     },
@@ -982,7 +986,7 @@
       "noSale": "We do not sell, rent, or trade your personal data. Ever.",
       "limitedSharing": "Data is shared only in these cases:",
       "circumstances": [
-        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
+        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), Vercel (hosting), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
         "With other members, to the extent you choose — your profile and the parts of your library you share are visible according to your settings",
         "When the law requires it, or to protect the service and its members against fraud or abuse",
         "For anything else: only with your explicit consent"
@@ -1017,9 +1021,9 @@
         "Sign-in cookies from Clerk that keep you logged in (strictly necessary)",
         "A language cookie that remembers your English/Dutch preference",
         "A cookie that remembers that you have seen the cookie notice",
-        "Analytics identifiers from PostHog, stored in cookies and local storage, to tell visits apart"
+        "Analytics identifiers from PostHog, stored in cookies and local storage — only after you accept the cookie notice"
       ],
-      "control": "You can block or delete cookies in your browser settings. JigSwap keeps working, though you will need to sign in again and your preferences may reset."
+      "control": "Analytics is opt-in: it only runs after you accept the cookie notice, and declining means it is never loaded. You can also block or delete cookies in your browser settings; JigSwap keeps working, though you will need to sign in again and your preferences may reset."
     },
     "cookieConsent": {
       "title": "We use cookies",
@@ -1035,7 +1039,7 @@
     },
     "international": {
       "title": "International Data Transfers",
-      "description": "We prefer EU-hosted providers where we can: PostHog and Axiom process data in the European Union. Convex and Clerk are US-based companies, so some data may be processed outside the EU/EEA. Where that happens, transfers take place under the safeguards those providers offer for GDPR compliance, such as the EU standard contractual clauses."
+      "description": "Your personal data is stored in the European Union: we use the EU-hosted variants of Convex, Clerk, PostHog, and Axiom. Our hosting provider Vercel serves the website through a global edge network, so requests may pass through servers outside the EU on their way to you, but the personal data itself stays stored in the EU. Where a provider processes limited data outside the EU/EEA, transfers take place under GDPR safeguards such as the EU standard contractual clauses."
     },
     "changes": {
       "title": "Changes to This Policy",
@@ -1043,16 +1047,17 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Questions about privacy or your data? The easiest way to reach us is the",
-      "linkLabel": "contact form",
-      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
+      "description": "Questions about privacy or your data? Email us at",
+      "emailAddress": "privacy@jigswap.site",
+      "formNote": "You can also use the",
+      "linkLabel": "contact form"
     }
   },
   "terms": {
     "title": "Terms of Service",
     "lastUpdated": "Last Updated",
     "effectiveDate": "2 July 2026",
-    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by [OWNER TO CONFIRM: legal name of the operator]. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
+    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by Sander Verkuil. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
     "acceptance": {
       "title": "Acceptance of Terms",
       "description": "By accessing or using JigSwap you agree to be bound by these Terms. If you do not agree with any part of them, please do not use the service."
@@ -1144,9 +1149,10 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Questions about these Terms? The easiest way to reach us is the",
-      "linkLabel": "contact form",
-      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
+      "description": "Questions about these Terms? Email us at",
+      "emailAddress": "legal@jigswap.site",
+      "formNote": "You can also use the",
+      "linkLabel": "contact form"
     }
   },
   "about": {

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -897,108 +897,129 @@
   "privacy": {
     "title": "Privacy Policy",
     "lastUpdated": "Last Updated",
-    "introduction": "This Privacy Policy describes how JigSwap ('we', 'our', or 'us') collects, uses, and protects your personal information when you use our jigsaw puzzle trading platform.",
-    "effectiveDate": "July 20, 2025",
+    "effectiveDate": "2 July 2026",
+    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by [OWNER TO CONFIRM: legal name of the operator], who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
     "informationWeCollect": {
       "title": "Information We Collect",
-      "description": "We collect information you provide directly to us and information we collect automatically when you use our service.",
+      "description": "We collect information you give us directly, plus a limited amount of information collected automatically while you use JigSwap.",
       "personalInformation": {
-        "title": "Personal Information",
+        "title": "Information you provide",
         "items": [
-          "Account information (name, email address, username)",
-          "Profile information (bio, location, interests)",
-          "Puzzle collection data and photos",
-          "Exchange history and communications",
-          "Reviews and ratings you provide"
+          "Account details via Clerk, our sign-in provider: name, email address, username, and avatar",
+          "Your profile: display name, bio, and other details you choose to share",
+          "Your puzzle library: the copies you own, their condition, photos you upload, completions, and collections",
+          "Exchange activity: swap, sale, and loan requests, the messages you send to arrange them, and reviews",
+          "Community activity: the circles you belong to, members you follow, and comments you post",
+          "Messages you send through the contact form: your name, email address, and message"
         ]
       },
       "automaticallyCollected": {
-        "title": "Automatically Collected Information",
+        "title": "Collected automatically",
         "items": [
-          "Device information (IP address, browser type, operating system)",
-          "Usage data (pages visited, features used, time spent)",
-          "Analytics data (interaction patterns, preferences)",
-          "Technical logs and error reports"
+          "Product analytics events, such as pages visited and features used (via PostHog)",
+          "Error reports and operational logs used to keep the service running",
+          "Your language preference and cookie-notice choice, stored in cookies",
+          "A push notification subscription — only if you turn push notifications on"
         ]
       }
     },
     "howWeUseInformation": {
       "title": "How We Use Your Information",
-      "description": "We use the information we collect to provide, improve, and secure our services.",
+      "description": "We use your data to run JigSwap — nothing more:",
       "purposes": [
-        "Provide and maintain our puzzle trading platform",
-        "Process trades and facilitate exchanges between users",
-        "Personalize your experience and show relevant content",
-        "Send important service updates and notifications",
-        "Analyze usage patterns to improve our service",
-        "Prevent fraud and ensure platform security",
-        "Respond to your questions and support requests"
-      ]
-    },
-    "dataStorage": {
-      "title": "Data Storage and Hosting",
-      "description": "Your data is securely stored and managed by trusted third-party services:",
-      "convex": {
-        "title": "Convex",
-        "description": "Our primary database and backend services are hosted by Convex. They handle data storage, user authentication, and real-time features."
-      },
-      "vercel": {
-        "title": "Vercel",
-        "description": "Our web application is hosted on Vercel's infrastructure, which provides fast, reliable, and secure hosting services."
+        "Provide your library, completions, collections, and insights",
+        "Facilitate exchanges between members, including messaging and loan tracking",
+        "Show your profile and puzzles to the members you have chosen to share them with",
+        "Send you notifications about activity that concerns you",
+        "Keep the service secure and prevent abuse, including automated screening of uploaded photos",
+        "Understand how JigSwap is used so we can improve it",
+        "Respond when you contact us"
+      ],
+      "lawfulBasis": {
+        "title": "Our lawful basis, in plain terms",
+        "description": "Under the GDPR we need a legal reason for each use of your data. Ours are:",
+        "items": [
+          "Performing our agreement with you: everything needed to run the service you signed up for — your account, library, exchanges, and messages",
+          "Legitimate interests: keeping JigSwap secure, preventing abuse, screening uploaded photos, operational logging, and understanding usage so we can improve the service",
+          "Consent: where we ask you first, such as browser push notifications",
+          "Legal obligations: the rare cases where we must keep or share data because the law requires it"
+        ]
       }
     },
-    "analytics": {
-      "title": "Analytics and Tracking",
-      "description": "We use analytics to understand how our service is used and improve user experience.",
-      "posthog": {
-        "title": "PostHog Analytics",
-        "description": "We use PostHog to collect anonymous usage analytics. This helps us understand user behavior and improve our platform. PostHog data is used solely for service improvement and is not sold to third parties."
+    "dataStorage": {
+      "title": "Where Your Data Lives",
+      "description": "JigSwap does not run its own servers. Your data is stored with a small number of service providers:",
+      "convex": {
+        "title": "Convex",
+        "description": "Our database and file storage. Your library, exchanges, messages, and uploaded photos are stored in Convex."
       },
-      "noAdvertising": "We do not use your data for advertising purposes. Your information will never be sold to advertisers or third parties for marketing purposes."
+      "clerk": {
+        "title": "Clerk",
+        "description": "Our authentication provider. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+      }
+    },
+    "photos": {
+      "title": "Photos You Upload",
+      "description": "Photos you add to your library go through an automatic pipeline before other members can see them:",
+      "steps": [
+        "The image is re-encoded, which strips hidden metadata such as EXIF data — including any embedded location",
+        "An automated content-safety check screens the image; for this we currently use a model hosted by Hugging Face, which processes the image for this purpose only",
+        "Until this finishes, the photo is visible only to you"
+      ]
+    },
+    "analytics": {
+      "title": "Analytics and Error Reporting",
+      "description": "We use analytics to understand how JigSwap is used and to catch errors before they spoil the fun.",
+      "posthog": {
+        "title": "PostHog",
+        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. This data is used only to improve JigSwap."
+      },
+      "noAdvertising": "We do not show ads, we do not use your data for advertising, and we never sell your data."
     },
     "dataSharing": {
-      "title": "Data Sharing and Third Parties",
-      "description": "We are committed to protecting your privacy and do not sell your personal information.",
-      "noSale": "We do not sell, rent, or trade your personal information to third parties for advertising or marketing purposes.",
-      "limitedSharing": "We may share your information only in these limited circumstances:",
+      "title": "Data Sharing",
+      "description": "We share personal data only with the providers that run JigSwap, and only what they need to do their job.",
+      "noSale": "We do not sell, rent, or trade your personal data. Ever.",
+      "limitedSharing": "Data is shared only in these cases:",
       "circumstances": [
-        "With your explicit consent",
-        "To comply with legal obligations",
-        "To protect our rights and prevent fraud",
-        "With service providers who assist in platform operations (under strict confidentiality agreements)"
+        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
+        "With other members, to the extent you choose — your profile and the parts of your library you share are visible according to your settings",
+        "When the law requires it, or to protect the service and its members against fraud or abuse",
+        "For anything else: only with your explicit consent"
       ]
     },
     "dataSecurity": {
       "title": "Data Security",
-      "description": "We implement appropriate security measures to protect your personal information:",
+      "description": "We take reasonable measures to protect your data:",
       "measures": [
-        "Encryption of data in transit and at rest",
-        "Regular security audits and updates",
-        "Access controls and authentication",
-        "Secure hosting infrastructure"
+        "All traffic between your browser and JigSwap is encrypted (TLS)",
+        "Every read and write is checked on the server: members only see what the visibility rules allow",
+        "Uploaded photos are stripped of hidden metadata and screened before they become visible to others",
+        "Access to production data is limited to what is needed to run the service"
       ]
     },
     "yourRights": {
-      "title": "Your Rights and Choices",
-      "description": "You have control over your personal information:",
+      "title": "Your Rights",
+      "description": "Under the GDPR you have the following rights, and JigSwap has built-in tools for most of them:",
       "rights": [
-        "Access and review your personal data",
-        "Update or correct your information",
-        "Delete your account and associated data",
-        "Opt out of certain data collection",
-        "Export your data in a portable format",
-        "Contact us with privacy concerns"
+        "Access: see the data we hold about you — most of it is directly visible in the app",
+        "Portability: download your data as a file via the export on your Insights page",
+        "Rectification: correct your profile and library yourself at any time, or ask us to fix something",
+        "Erasure: delete your account, which removes your account record — and ask us to remove any remaining content tied to it",
+        "Objection and restriction: object to processing we base on our legitimate interests",
+        "Complaint: lodge a complaint with your data protection authority — in the Netherlands, the Autoriteit Persoonsgegevens"
       ]
     },
     "cookies": {
-      "title": "Cookies and Tracking",
-      "description": "We use cookies and similar technologies to enhance your experience:",
+      "title": "Cookies",
+      "description": "JigSwap uses a small number of cookies and similar technologies:",
       "types": [
-        "Essential cookies for platform functionality",
-        "Analytics cookies to understand usage patterns",
-        "Preference cookies to remember your settings"
+        "Sign-in cookies from Clerk that keep you logged in (strictly necessary)",
+        "A language cookie that remembers your English/Dutch preference",
+        "A cookie that remembers that you have seen the cookie notice",
+        "Analytics identifiers from PostHog, stored in cookies and local storage, to tell visits apart"
       ],
-      "control": "You can control cookie settings through your browser preferences."
+      "control": "You can block or delete cookies in your browser settings. JigSwap keeps working, though you will need to sign in again and your preferences may reset."
     },
     "cookieConsent": {
       "title": "We use cookies",
@@ -1009,114 +1030,123 @@
       "acceptanceText": "By clicking \"Accept\", you agree to our use of cookies."
     },
     "children": {
-      "title": "Children's Privacy",
-      "description": "Our service is not intended for children under 13. We do not knowingly collect personal information from children under 13."
+      "title": "Children",
+      "description": "JigSwap is not intended for children under 16, and we do not knowingly collect personal data from them. If you believe a child under 16 has an account, please contact us."
     },
     "international": {
       "title": "International Data Transfers",
-      "description": "Your data may be processed in countries other than your own. We ensure appropriate safeguards are in place to protect your information."
+      "description": "We prefer EU-hosted providers where we can: PostHog and Axiom process data in the European Union. Convex and Clerk are US-based companies, so some data may be processed outside the EU/EEA. Where that happens, transfers take place under the safeguards those providers offer for GDPR compliance, such as the EU standard contractual clauses."
     },
     "changes": {
       "title": "Changes to This Policy",
-      "description": "We may update this Privacy Policy from time to time. We will notify you of any material changes by posting the new policy on our website and updating the 'Last Updated' date."
+      "description": "We may update this policy as JigSwap evolves. Material changes are announced by posting the new policy on this page and updating the date at the top."
     },
     "contact": {
-      "title": "Contact Us",
-      "description": "If you have any questions about this Privacy Policy or our data practices, please contact us:",
-      "email": "Email",
-      "emailAddress": "privacy@jigswap.site",
-      "questions": "We're committed to transparency and will respond to your privacy inquiries promptly."
+      "title": "Contact",
+      "description": "Questions about privacy or your data? The easiest way to reach us is the",
+      "linkLabel": "contact form",
+      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
     }
   },
   "terms": {
     "title": "Terms of Service",
     "lastUpdated": "Last Updated",
-    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, our jigsaw puzzle trading platform. By using our service, you agree to these terms.",
-    "effectiveDate": "July 20, 2025",
+    "effectiveDate": "2 July 2026",
+    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by [OWNER TO CONFIRM: legal name of the operator]. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
     "acceptance": {
       "title": "Acceptance of Terms",
-      "description": "By accessing or using JigSwap, you agree to be bound by these Terms. If you disagree with any part of these terms, you may not access our service."
+      "description": "By accessing or using JigSwap you agree to be bound by these Terms. If you do not agree with any part of them, please do not use the service."
     },
     "serviceDescription": {
-      "title": "Service Description",
-      "description": "JigSwap is a platform that enables users to trade, exchange, and manage jigsaw puzzles. Our service includes:",
+      "title": "What JigSwap Is",
+      "description": "JigSwap helps jigsaw puzzle collectors keep track of their puzzles and exchange them with other members. The service includes:",
       "features": [
-        "Puzzle collection management and tracking",
-        "Trading and exchange functionality",
-        "Community features and reviews",
-        "Analytics and progress tracking"
+        "A community-maintained puzzle catalog that members can add puzzles to",
+        "A personal library to track the copies you own, their condition, and photos of them",
+        "Logging completions (when you finished a puzzle and how long it took) and organising copies into collections",
+        "Exchanges between members — swaps, sales, and loans — with messaging to arrange them",
+        "Circles (private groups of friends) for sharing part of your library, plus member profiles and follows",
+        "Personal insights and statistics about your puzzling, including a download of your own data"
       ]
     },
     "userAccounts": {
-      "title": "User Accounts",
-      "description": "To use certain features of our service, you must create an account. You are responsible for:",
+      "title": "Your Account",
+      "description": "You need an account for most features. Sign-in and account management are handled by Clerk, our authentication provider. You are responsible for:",
       "responsibilities": [
-        "Maintaining the security of your account",
-        "Providing accurate and complete information",
-        "Notifying us of any unauthorized use",
-        "Being at least 13 years old to use the service"
+        "Keeping access to your account secure",
+        "Providing accurate information in your profile and about your puzzles",
+        "Letting us know if you suspect unauthorised use of your account",
+        "Being at least 16 years old to create an account"
       ]
     },
     "userConduct": {
-      "title": "User Conduct",
-      "description": "You agree to use our service responsibly and in accordance with these terms:",
-      "prohibitedTitle": "Prohibited Activities:",
-      "expectedTitle": "Expected Behavior:",
-      "prohibited": [
-        "Violating any applicable laws or regulations",
-        "Infringing on intellectual property rights",
-        "Harassing or harming other users",
-        "Attempting to gain unauthorized access to our systems",
-        "Using the service for commercial purposes without permission"
-      ],
+      "title": "Community Conduct",
+      "description": "JigSwap runs on trust between puzzle lovers. Use the service responsibly:",
+      "expectedTitle": "What we expect:",
       "expected": [
-        "Treating other users with respect",
-        "Providing accurate information about puzzles",
-        "Honoring trade agreements and commitments",
-        "Reporting suspicious or inappropriate behavior"
+        "Treat other members with respect",
+        "Describe your puzzles honestly, including condition and missing pieces",
+        "Follow through on exchanges you agree to",
+        "Report problems or suspicious behaviour via the contact form"
+      ],
+      "prohibitedTitle": "What is not allowed:",
+      "prohibited": [
+        "Breaking the law or infringing other people's rights",
+        "Harassing, threatening, or deceiving other members",
+        "Uploading unlawful, infringing, or sexually explicit content",
+        "Spam or unsolicited commercial use of the platform",
+        "Scraping the service or attempting to gain unauthorised access to accounts or systems",
+        "Impersonating another person or member"
       ]
     },
     "trading": {
-      "title": "Trading and Exchanges",
-      "description": "Our platform facilitates puzzle trading between users. By participating in trades, you agree to:",
+      "title": "Swaps, Sales, and Loans",
+      "description": "JigSwap lets members arrange swaps, sales, and loans of puzzles with each other. Every exchange is an agreement between the two members involved — not with JigSwap. When you take part in an exchange, you agree to:",
       "agreements": [
-        "Accurately describe puzzle condition and completeness",
-        "Honor agreed-upon trade terms",
-        "Communicate promptly and honestly",
-        "Resolve disputes amicably when possible"
+        "Accurately describe the condition and completeness of your puzzles",
+        "Honour the terms you agreed on, including returning borrowed puzzles",
+        "Arrange payment and shipping between yourselves — JigSwap does not process payments",
+        "Communicate promptly and try to resolve disagreements respectfully"
       ],
-      "disclaimer": "JigSwap acts as a facilitator for trades but is not responsible for the quality, condition, or completeness of traded puzzles. Users trade at their own risk."
+      "disclaimer": "JigSwap only brings members into contact and keeps a record of the exchange. We are not a party to any exchange and are not responsible for payment, shipping, or the quality, condition, or completeness of exchanged puzzles. Exchanges are at your own risk."
     },
     "intellectualProperty": {
-      "title": "Intellectual Property",
-      "description": "Our service and its original content, features, and functionality are owned by JigSwap and are protected by international copyright, trademark, and other intellectual property laws."
+      "title": "Content and Intellectual Property",
+      "description": "Different things on JigSwap belong to different people:",
+      "yourContent": {
+        "title": "Your content",
+        "description": "Photos, reviews, comments, and other content you post remain yours. By posting, you give us a non-exclusive licence to store and display that content so the service can work — for example, showing your puzzle photos to the members you have shared them with. Puzzles you add to the shared catalog become part of the community catalog that all members can use. Uploaded photos pass through an automated safety check before other members can see them (see the Privacy Policy for details)."
+      },
+      "platform": {
+        "title": "The platform and puzzle artwork",
+        "description": "The JigSwap software is open source under the MIT licence. Puzzle images and artwork in the catalog belong to their respective publishers and rights holders and are used to identify puzzles. If you hold rights to content shown on JigSwap and want it corrected or removed, please contact us."
+      }
     },
     "privacy": {
       "title": "Privacy",
-      "description": "Your privacy is important to us. Please review our Privacy Policy, which also governs your use of the service."
+      "description": "How we handle your personal data is described in our Privacy Policy, which applies alongside these Terms."
     },
     "termination": {
-      "title": "Account Termination",
-      "description": "We may terminate or suspend your account immediately, without prior notice, for any reason, including breach of these Terms."
+      "title": "Ending Your Account",
+      "description": "You can stop using JigSwap and delete your account at any time. We may suspend or remove accounts that break these Terms — for example for scams, harassment, or unlawful content. Where reasonably possible, we will tell you why."
     },
     "disclaimer": {
-      "title": "Disclaimer of Warranties",
-      "description": "The service is provided 'as is' without warranties of any kind. We do not guarantee that the service will be uninterrupted or error-free."
+      "title": "Disclaimer",
+      "description": "JigSwap is a hobby project provided free of charge and 'as is'. We do our best to keep it running well, but we cannot promise that the service will always be available or error-free."
     },
     "limitation": {
       "title": "Limitation of Liability",
-      "description": "JigSwap shall not be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of the service."
+      "description": "To the extent permitted by applicable law, JigSwap and its operator are not liable for indirect or consequential damage arising from your use of the service or from exchanges between members. Nothing in these Terms limits liability that cannot be limited or excluded under applicable law."
     },
     "changes": {
-      "title": "Changes to Terms",
-      "description": "We reserve the right to modify these terms at any time. We will notify users of any material changes by posting the new terms on our website."
+      "title": "Changes to These Terms",
+      "description": "We may update these Terms from time to time. Material changes are announced by posting the new Terms on this page and updating the date at the top. If you keep using JigSwap after a change, the updated Terms apply."
     },
     "contact": {
-      "title": "Contact Information",
-      "description": "If you have any questions about these Terms of Service, please contact us:",
-      "email": "Email",
-      "emailAddress": "legal@jigswap.site",
-      "questions": "We're committed to transparency and will respond to your inquiries promptly."
+      "title": "Contact",
+      "description": "Questions about these Terms? The easiest way to reach us is the",
+      "linkLabel": "contact form",
+      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
     }
   },
   "about": {

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -898,7 +898,7 @@
     "title": "Privacybeleid",
     "lastUpdated": "Laatst bijgewerkt",
     "effectiveDate": "2 juli 2026",
-    "introduction": "Dit privacybeleid legt uit welke persoonsgegevens JigSwap verzamelt, waarom we dat doen en welke rechten je hebt. JigSwap wordt beheerd door [OWNER TO CONFIRM: legal name of the operator], die de verwerkingsverantwoordelijke is voor de verwerking die hier wordt beschreven. We willen zo min mogelijk verzamelen en transparant zijn over de rest.",
+    "introduction": "Dit privacybeleid legt uit welke persoonsgegevens JigSwap verzamelt, waarom we dat doen en welke rechten je hebt. JigSwap wordt beheerd door Sander Verkuil, die de verwerkingsverantwoordelijke is voor de verwerking die hier wordt beschreven. We willen zo min mogelijk verzamelen en transparant zijn over de rest.",
     "informationWeCollect": {
       "title": "Welke gegevens we verzamelen",
       "description": "We verzamelen gegevens die je ons zelf geeft, plus een beperkte hoeveelheid gegevens die automatisch wordt verzameld terwijl je JigSwap gebruikt.",
@@ -916,7 +916,7 @@
       "automaticallyCollected": {
         "title": "Automatisch verzameld",
         "items": [
-          "Productanalyse-events, zoals bezochte pagina's en gebruikte functies (via PostHog)",
+          "Productanalyse-events, zoals bezochte pagina's en gebruikte functies (via PostHog, alleen nadat je de cookiemelding hebt geaccepteerd)",
           "Foutrapportages en operationele logs om de dienst draaiend te houden",
           "Je taalvoorkeur en je keuze bij de cookiemelding, opgeslagen in cookies",
           "Een pushnotificatie-abonnement — alleen als je pushmeldingen aanzet"
@@ -948,14 +948,18 @@
     },
     "dataStorage": {
       "title": "Waar je gegevens staan",
-      "description": "JigSwap heeft geen eigen servers. Je gegevens staan bij een klein aantal dienstverleners:",
+      "description": "JigSwap heeft geen eigen servers. Je gegevens worden in de Europese Unie opgeslagen bij een klein aantal dienstverleners:",
       "convex": {
         "title": "Convex",
-        "description": "Onze database en bestandsopslag. Je bibliotheek, uitwisselingen, berichten en geüploade foto's worden opgeslagen in Convex."
+        "description": "Onze database en bestandsopslag, op de EU-hosting van Convex. Je bibliotheek, uitwisselingen, berichten en geüploade foto's worden opgeslagen in de Europese Unie."
       },
       "clerk": {
         "title": "Clerk",
-        "description": "Onze authenticatieprovider. Clerk bewaart je inloggegevens en basisaccountgegevens (naam, e-mailadres, avatar) en verzorgt het inloggen. Als je je account verwijdert, krijgen wij daar bericht van via Clerk en verwijderen we je accountrecord."
+        "description": "Onze authenticatieprovider, met EU-dataresidentie. Clerk bewaart je inloggegevens en basisaccountgegevens (naam, e-mailadres, avatar) en verzorgt het inloggen. Als je je account verwijdert, krijgen wij daar bericht van via Clerk en verwijderen we je accountrecord."
+      },
+      "vercel": {
+        "title": "Vercel",
+        "description": "Onze hostingprovider. De JigSwap-webapplicatie wordt geleverd via het wereldwijde edge-netwerk van Vercel. Vercel bezorgt de site bij je browser; je persoonsgegevens zelf staan in de EU-gehoste diensten hierboven."
       }
     },
     "photos": {
@@ -972,7 +976,7 @@
       "description": "We gebruiken analyse om te begrijpen hoe JigSwap wordt gebruikt en om fouten op te sporen voordat ze het plezier bederven.",
       "posthog": {
         "title": "PostHog",
-        "description": "We gebruiken PostHog, gehost in de Europese Unie, voor productanalyse en foutrapportage. Analyseverzoeken lopen via ons eigen domein. Deze gegevens gebruiken we alleen om JigSwap te verbeteren."
+        "description": "We gebruiken PostHog, gehost in de Europese Unie, voor productanalyse en foutrapportage. Analyseverzoeken lopen via ons eigen domein. PostHog start pas nadat je de cookiemelding hebt geaccepteerd — weiger je, dan wordt het nooit geladen. Deze gegevens gebruiken we alleen om JigSwap te verbeteren."
       },
       "noAdvertising": "We tonen geen advertenties, we gebruiken je gegevens niet voor reclame en we verkopen je gegevens nooit."
     },
@@ -982,7 +986,7 @@
       "noSale": "We verkopen, verhuren of verhandelen je persoonsgegevens niet. Nooit.",
       "limitedSharing": "Gegevens worden alleen in deze gevallen gedeeld:",
       "circumstances": [
-        "Met de dienstverleners uit dit beleid, als verwerkers namens ons: Convex (database en bestanden), Clerk (inloggen), PostHog (analyse en foutrapportage), Axiom (operationele logs, gehost in de EU) en Hugging Face (automatische fotocontrole)",
+        "Met de dienstverleners uit dit beleid, als verwerkers namens ons: Convex (database en bestanden), Clerk (inloggen), Vercel (hosting), PostHog (analyse en foutrapportage), Axiom (operationele logs, gehost in de EU) en Hugging Face (automatische fotocontrole)",
         "Met andere leden, voor zover jij dat kiest — je profiel en de delen van je bibliotheek die je deelt zijn zichtbaar volgens jouw instellingen",
         "Wanneer de wet dat vereist, of om de dienst en haar leden te beschermen tegen fraude of misbruik",
         "Voor al het andere: alleen met jouw uitdrukkelijke toestemming"
@@ -1017,9 +1021,9 @@
         "Inlogcookies van Clerk die je ingelogd houden (strikt noodzakelijk)",
         "Een taalcookie die je voorkeur voor Engels of Nederlands onthoudt",
         "Een cookie die onthoudt dat je de cookiemelding hebt gezien",
-        "Analyse-identifiers van PostHog, opgeslagen in cookies en local storage, om bezoeken uit elkaar te houden"
+        "Analyse-identifiers van PostHog, opgeslagen in cookies en local storage — alleen nadat je de cookiemelding hebt geaccepteerd"
       ],
-      "control": "Je kunt cookies blokkeren of verwijderen via je browserinstellingen. JigSwap blijft werken, al moet je dan opnieuw inloggen en kunnen je voorkeuren worden gereset."
+      "control": "Analyse is opt-in: die draait alleen nadat je de cookiemelding hebt geaccepteerd, en weiger je, dan wordt die nooit geladen. Je kunt cookies ook blokkeren of verwijderen via je browserinstellingen; JigSwap blijft werken, al moet je dan opnieuw inloggen en kunnen je voorkeuren worden gereset."
     },
     "cookieConsent": {
       "title": "We gebruiken cookies",
@@ -1035,7 +1039,7 @@
     },
     "international": {
       "title": "Internationale doorgifte van gegevens",
-      "description": "Waar mogelijk kiezen we dienstverleners die in de EU hosten: PostHog en Axiom verwerken gegevens in de Europese Unie. Convex en Clerk zijn Amerikaanse bedrijven, dus sommige gegevens kunnen buiten de EU/EER worden verwerkt. In dat geval vindt de doorgifte plaats onder de waarborgen die deze dienstverleners bieden voor AVG-naleving, zoals de EU-standaardcontractbepalingen."
+      "description": "Je persoonsgegevens worden opgeslagen in de Europese Unie: we gebruiken de EU-gehoste varianten van Convex, Clerk, PostHog en Axiom. Onze hostingprovider Vercel levert de website via een wereldwijd edge-netwerk, waardoor verzoeken onderweg servers buiten de EU kunnen passeren, maar de persoonsgegevens zelf blijven in de EU opgeslagen. Waar een dienstverlener beperkte gegevens buiten de EU/EER verwerkt, gebeurt de doorgifte onder AVG-waarborgen zoals de EU-standaardcontractbepalingen."
     },
     "changes": {
       "title": "Wijzigingen in dit beleid",
@@ -1043,16 +1047,17 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Vragen over privacy of je gegevens? Je bereikt ons het makkelijkst via het",
-      "linkLabel": "contactformulier",
-      "emailNote": "Je kunt ook mailen naar [OWNER TO CONFIRM: contact email]."
+      "description": "Vragen over privacy of je gegevens? Mail ons via",
+      "emailAddress": "privacy@jigswap.site",
+      "formNote": "Je kunt ook terecht bij het",
+      "linkLabel": "contactformulier"
     }
   },
   "terms": {
     "title": "Algemene Voorwaarden",
     "lastUpdated": "Laatst bijgewerkt",
     "effectiveDate": "2 juli 2026",
-    "introduction": "Deze algemene voorwaarden ('Voorwaarden') zijn van toepassing op je gebruik van JigSwap, een communityplatform voor legpuzzelliefhebbers, beheerd door [OWNER TO CONFIRM: legal name of the operator]. JigSwap is een hobbyproject, geen commerciële marktplaats. Door een account aan te maken of JigSwap te gebruiken ga je akkoord met deze Voorwaarden.",
+    "introduction": "Deze algemene voorwaarden ('Voorwaarden') zijn van toepassing op je gebruik van JigSwap, een communityplatform voor legpuzzelliefhebbers, beheerd door Sander Verkuil. JigSwap is een hobbyproject, geen commerciële marktplaats. Door een account aan te maken of JigSwap te gebruiken ga je akkoord met deze Voorwaarden.",
     "acceptance": {
       "title": "Akkoord met de Voorwaarden",
       "description": "Door JigSwap te bezoeken of te gebruiken ga je akkoord met deze Voorwaarden. Ben je het met een deel ervan niet eens, gebruik de dienst dan niet."
@@ -1144,9 +1149,10 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Vragen over deze Voorwaarden? Je bereikt ons het makkelijkst via het",
-      "linkLabel": "contactformulier",
-      "emailNote": "Je kunt ook mailen naar [OWNER TO CONFIRM: contact email]."
+      "description": "Vragen over deze Voorwaarden? Mail ons via",
+      "emailAddress": "legal@jigswap.site",
+      "formNote": "Je kunt ook terecht bij het",
+      "linkLabel": "contactformulier"
     }
   },
   "about": {

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -897,108 +897,129 @@
   "privacy": {
     "title": "Privacybeleid",
     "lastUpdated": "Laatst bijgewerkt",
-    "introduction": "Dit privacybeleid beschrijft hoe JigSwap ('we', 'ons' of 'onze') je persoonsgegevens verzamelt, gebruikt en beschermt wanneer je ons platform voor het ruilen van legpuzzels gebruikt.",
-    "effectiveDate": "20 juli 2025",
+    "effectiveDate": "2 juli 2026",
+    "introduction": "Dit privacybeleid legt uit welke persoonsgegevens JigSwap verzamelt, waarom we dat doen en welke rechten je hebt. JigSwap wordt beheerd door [OWNER TO CONFIRM: legal name of the operator], die de verwerkingsverantwoordelijke is voor de verwerking die hier wordt beschreven. We willen zo min mogelijk verzamelen en transparant zijn over de rest.",
     "informationWeCollect": {
       "title": "Welke gegevens we verzamelen",
-      "description": "We verzamelen gegevens die je rechtstreeks aan ons verstrekt en gegevens die we automatisch verzamelen wanneer je onze dienst gebruikt.",
+      "description": "We verzamelen gegevens die je ons zelf geeft, plus een beperkte hoeveelheid gegevens die automatisch wordt verzameld terwijl je JigSwap gebruikt.",
       "personalInformation": {
-        "title": "Persoonsgegevens",
+        "title": "Gegevens die je zelf geeft",
         "items": [
-          "Accountgegevens (naam, e-mailadres, gebruikersnaam)",
-          "Profielgegevens (bio, woonplaats, interesses)",
-          "Gegevens en foto's van je puzzelcollectie",
-          "Ruilgeschiedenis en communicatie",
-          "Beoordelingen en waarderingen die je geeft"
+          "Accountgegevens via Clerk, onze inlogprovider: naam, e-mailadres, gebruikersnaam en avatar",
+          "Je profiel: weergavenaam, bio en andere gegevens die je wilt delen",
+          "Je puzzelbibliotheek: de exemplaren die je bezit, hun staat, foto's die je uploadt, voltooiingen en collecties",
+          "Uitwisselingsactiviteit: ruil-, verkoop- en leenverzoeken, de berichten die je stuurt om ze te regelen, en beoordelingen",
+          "Community-activiteit: de kringen waar je lid van bent, leden die je volgt en reacties die je plaatst",
+          "Berichten via het contactformulier: je naam, e-mailadres en bericht"
         ]
       },
       "automaticallyCollected": {
-        "title": "Automatisch verzamelde gegevens",
+        "title": "Automatisch verzameld",
         "items": [
-          "Apparaatgegevens (IP-adres, browsertype, besturingssysteem)",
-          "Gebruiksgegevens (bezochte pagina's, gebruikte functies, bestede tijd)",
-          "Analytische gegevens (interactiepatronen, voorkeuren)",
-          "Technische logbestanden en foutrapporten"
+          "Productanalyse-events, zoals bezochte pagina's en gebruikte functies (via PostHog)",
+          "Foutrapportages en operationele logs om de dienst draaiend te houden",
+          "Je taalvoorkeur en je keuze bij de cookiemelding, opgeslagen in cookies",
+          "Een pushnotificatie-abonnement — alleen als je pushmeldingen aanzet"
         ]
       }
     },
     "howWeUseInformation": {
       "title": "Hoe we je gegevens gebruiken",
-      "description": "We gebruiken de verzamelde gegevens om onze diensten te leveren, te verbeteren en te beveiligen.",
+      "description": "We gebruiken je gegevens om JigSwap te laten draaien — meer niet:",
       "purposes": [
-        "Ons puzzelruilplatform leveren en onderhouden",
-        "Ruilen verwerken en uitwisselingen tussen gebruikers mogelijk maken",
-        "Je ervaring personaliseren en relevante inhoud tonen",
-        "Belangrijke service-updates en meldingen versturen",
-        "Gebruikspatronen analyseren om onze dienst te verbeteren",
-        "Fraude voorkomen en de veiligheid van het platform waarborgen",
-        "Je vragen en supportverzoeken beantwoorden"
-      ]
-    },
-    "dataStorage": {
-      "title": "Gegevensopslag en hosting",
-      "description": "Je gegevens worden veilig opgeslagen en beheerd door vertrouwde externe diensten:",
-      "convex": {
-        "title": "Convex",
-        "description": "Onze primaire database en backenddiensten worden gehost door Convex. Zij verzorgen gegevensopslag, gebruikersauthenticatie en realtime-functies."
-      },
-      "vercel": {
-        "title": "Vercel",
-        "description": "Onze webapplicatie wordt gehost op de infrastructuur van Vercel, die snelle, betrouwbare en veilige hosting biedt."
+        "Je bibliotheek, voltooiingen, collecties en inzichten aanbieden",
+        "Uitwisselingen tussen leden mogelijk maken, inclusief berichten en het bijhouden van uitleningen",
+        "Je profiel en puzzels tonen aan de leden met wie je ze hebt gedeeld",
+        "Je meldingen sturen over activiteit die jou aangaat",
+        "De dienst veilig houden en misbruik voorkomen, inclusief automatische controle van geüploade foto's",
+        "Begrijpen hoe JigSwap wordt gebruikt zodat we het kunnen verbeteren",
+        "Reageren als je contact met ons opneemt"
+      ],
+      "lawfulBasis": {
+        "title": "Onze rechtsgrond, in gewone taal",
+        "description": "Onder de AVG hebben we voor elk gebruik van je gegevens een wettelijke grondslag nodig. Dit zijn de onze:",
+        "items": [
+          "Uitvoering van onze overeenkomst met jou: alles wat nodig is voor de dienst waarvoor je je hebt aangemeld — je account, bibliotheek, uitwisselingen en berichten",
+          "Gerechtvaardigd belang: JigSwap veilig houden, misbruik voorkomen, geüploade foto's controleren, operationele logging en begrijpen hoe de dienst wordt gebruikt zodat we die kunnen verbeteren",
+          "Toestemming: waar we je eerst om toestemming vragen, zoals bij pushmeldingen in je browser",
+          "Wettelijke verplichting: de zeldzame gevallen waarin we gegevens moeten bewaren of delen omdat de wet dat vereist"
+        ]
       }
     },
-    "analytics": {
-      "title": "Analyse en tracking",
-      "description": "We gebruiken analyses om te begrijpen hoe onze dienst wordt gebruikt en om de gebruikerservaring te verbeteren.",
-      "posthog": {
-        "title": "PostHog Analytics",
-        "description": "We gebruiken PostHog om anonieme gebruiksstatistieken te verzamelen. Dit helpt ons gebruikersgedrag te begrijpen en ons platform te verbeteren. PostHog-gegevens worden uitsluitend gebruikt voor verbetering van de dienst en worden niet verkocht aan derden."
+    "dataStorage": {
+      "title": "Waar je gegevens staan",
+      "description": "JigSwap heeft geen eigen servers. Je gegevens staan bij een klein aantal dienstverleners:",
+      "convex": {
+        "title": "Convex",
+        "description": "Onze database en bestandsopslag. Je bibliotheek, uitwisselingen, berichten en geüploade foto's worden opgeslagen in Convex."
       },
-      "noAdvertising": "We gebruiken je gegevens niet voor advertentiedoeleinden. Je gegevens worden nooit verkocht aan adverteerders of derden voor marketingdoeleinden."
+      "clerk": {
+        "title": "Clerk",
+        "description": "Onze authenticatieprovider. Clerk bewaart je inloggegevens en basisaccountgegevens (naam, e-mailadres, avatar) en verzorgt het inloggen. Als je je account verwijdert, krijgen wij daar bericht van via Clerk en verwijderen we je accountrecord."
+      }
+    },
+    "photos": {
+      "title": "Foto's die je uploadt",
+      "description": "Foto's die je aan je bibliotheek toevoegt doorlopen een automatisch proces voordat andere leden ze kunnen zien:",
+      "steps": [
+        "De afbeelding wordt opnieuw gecodeerd, waardoor verborgen metadata zoals EXIF-gegevens — inclusief een eventuele locatie — wordt verwijderd",
+        "Een automatische veiligheidscontrole beoordeelt de afbeelding; hiervoor gebruiken we op dit moment een model dat wordt gehost door Hugging Face, dat de afbeelding uitsluitend voor dit doel verwerkt",
+        "Totdat dit klaar is, is de foto alleen voor jou zichtbaar"
+      ]
+    },
+    "analytics": {
+      "title": "Analyse en foutrapportage",
+      "description": "We gebruiken analyse om te begrijpen hoe JigSwap wordt gebruikt en om fouten op te sporen voordat ze het plezier bederven.",
+      "posthog": {
+        "title": "PostHog",
+        "description": "We gebruiken PostHog, gehost in de Europese Unie, voor productanalyse en foutrapportage. Analyseverzoeken lopen via ons eigen domein. Deze gegevens gebruiken we alleen om JigSwap te verbeteren."
+      },
+      "noAdvertising": "We tonen geen advertenties, we gebruiken je gegevens niet voor reclame en we verkopen je gegevens nooit."
     },
     "dataSharing": {
-      "title": "Gegevens delen en derden",
-      "description": "We beschermen je privacy en verkopen je persoonsgegevens niet.",
-      "noSale": "We verkopen, verhuren of verhandelen je persoonsgegevens niet aan derden voor advertentie- of marketingdoeleinden.",
-      "limitedSharing": "We delen je gegevens alleen in deze beperkte gevallen:",
+      "title": "Gegevens delen",
+      "description": "We delen persoonsgegevens alleen met de dienstverleners die JigSwap laten draaien, en alleen wat zij nodig hebben voor hun taak.",
+      "noSale": "We verkopen, verhuren of verhandelen je persoonsgegevens niet. Nooit.",
+      "limitedSharing": "Gegevens worden alleen in deze gevallen gedeeld:",
       "circumstances": [
-        "Met jouw uitdrukkelijke toestemming",
-        "Om aan wettelijke verplichtingen te voldoen",
-        "Om onze rechten te beschermen en fraude te voorkomen",
-        "Met dienstverleners die helpen bij het beheer van het platform (onder strikte geheimhoudingsafspraken)"
+        "Met de dienstverleners uit dit beleid, als verwerkers namens ons: Convex (database en bestanden), Clerk (inloggen), PostHog (analyse en foutrapportage), Axiom (operationele logs, gehost in de EU) en Hugging Face (automatische fotocontrole)",
+        "Met andere leden, voor zover jij dat kiest — je profiel en de delen van je bibliotheek die je deelt zijn zichtbaar volgens jouw instellingen",
+        "Wanneer de wet dat vereist, of om de dienst en haar leden te beschermen tegen fraude of misbruik",
+        "Voor al het andere: alleen met jouw uitdrukkelijke toestemming"
       ]
     },
     "dataSecurity": {
-      "title": "Gegevensbeveiliging",
-      "description": "We nemen passende beveiligingsmaatregelen om je persoonsgegevens te beschermen:",
+      "title": "Beveiliging",
+      "description": "We nemen redelijke maatregelen om je gegevens te beschermen:",
       "measures": [
-        "Versleuteling van gegevens tijdens verzending en opslag",
-        "Regelmatige beveiligingsaudits en updates",
-        "Toegangscontrole en authenticatie",
-        "Veilige hostinginfrastructuur"
+        "Al het verkeer tussen je browser en JigSwap is versleuteld (TLS)",
+        "Elke lees- en schrijfactie wordt op de server gecontroleerd: leden zien alleen wat de zichtbaarheidsregels toestaan",
+        "Geüploade foto's worden ontdaan van verborgen metadata en gecontroleerd voordat anderen ze kunnen zien",
+        "Toegang tot productiegegevens is beperkt tot wat nodig is om de dienst te laten draaien"
       ]
     },
     "yourRights": {
-      "title": "Jouw rechten en keuzes",
-      "description": "Jij houdt de controle over je persoonsgegevens:",
+      "title": "Jouw rechten",
+      "description": "Onder de AVG heb je de volgende rechten, en voor de meeste heeft JigSwap ingebouwde hulpmiddelen:",
       "rights": [
-        "Je persoonsgegevens inzien en controleren",
-        "Je gegevens bijwerken of corrigeren",
-        "Je account en bijbehorende gegevens verwijderen",
-        "Je afmelden voor bepaalde gegevensverzameling",
-        "Je gegevens exporteren in een overdraagbaar formaat",
-        "Contact met ons opnemen bij privacyvragen"
+        "Inzage: bekijk de gegevens die we over je hebben — het meeste is direct zichtbaar in de app",
+        "Overdraagbaarheid: download je gegevens als bestand via de export op je Inzichten-pagina",
+        "Rectificatie: corrigeer je profiel en bibliotheek zelf op elk moment, of vraag ons iets recht te zetten",
+        "Verwijdering: verwijder je account, waarmee je accountrecord wordt verwijderd — en vraag ons om resterende content die eraan gekoppeld is te verwijderen",
+        "Bezwaar en beperking: maak bezwaar tegen verwerking op basis van ons gerechtvaardigd belang",
+        "Klacht: dien een klacht in bij je toezichthouder — in Nederland de Autoriteit Persoonsgegevens"
       ]
     },
     "cookies": {
-      "title": "Cookies en tracking",
-      "description": "We gebruiken cookies en vergelijkbare technieken om je ervaring te verbeteren:",
+      "title": "Cookies",
+      "description": "JigSwap gebruikt een klein aantal cookies en vergelijkbare technieken:",
       "types": [
-        "Essentiële cookies voor de werking van het platform",
-        "Analytische cookies om gebruikspatronen te begrijpen",
-        "Voorkeurscookies om je instellingen te onthouden"
+        "Inlogcookies van Clerk die je ingelogd houden (strikt noodzakelijk)",
+        "Een taalcookie die je voorkeur voor Engels of Nederlands onthoudt",
+        "Een cookie die onthoudt dat je de cookiemelding hebt gezien",
+        "Analyse-identifiers van PostHog, opgeslagen in cookies en local storage, om bezoeken uit elkaar te houden"
       ],
-      "control": "Je kunt cookie-instellingen beheren via de voorkeuren van je browser."
+      "control": "Je kunt cookies blokkeren of verwijderen via je browserinstellingen. JigSwap blijft werken, al moet je dan opnieuw inloggen en kunnen je voorkeuren worden gereset."
     },
     "cookieConsent": {
       "title": "We gebruiken cookies",
@@ -1009,114 +1030,123 @@
       "acceptanceText": "Door op \"Accepteren\" te klikken ga je akkoord met ons gebruik van cookies."
     },
     "children": {
-      "title": "Privacy van kinderen",
-      "description": "Onze dienst is niet bedoeld voor kinderen onder de 13 jaar. We verzamelen niet bewust persoonsgegevens van kinderen onder de 13."
+      "title": "Kinderen",
+      "description": "JigSwap is niet bedoeld voor kinderen onder de 16 en we verzamelen niet bewust persoonsgegevens van hen. Denk je dat een kind onder de 16 een account heeft, neem dan contact met ons op."
     },
     "international": {
-      "title": "Internationale gegevensoverdracht",
-      "description": "Je gegevens kunnen worden verwerkt in andere landen dan het jouwe. We zorgen voor passende waarborgen om je gegevens te beschermen."
+      "title": "Internationale doorgifte van gegevens",
+      "description": "Waar mogelijk kiezen we dienstverleners die in de EU hosten: PostHog en Axiom verwerken gegevens in de Europese Unie. Convex en Clerk zijn Amerikaanse bedrijven, dus sommige gegevens kunnen buiten de EU/EER worden verwerkt. In dat geval vindt de doorgifte plaats onder de waarborgen die deze dienstverleners bieden voor AVG-naleving, zoals de EU-standaardcontractbepalingen."
     },
     "changes": {
       "title": "Wijzigingen in dit beleid",
-      "description": "We kunnen dit privacybeleid van tijd tot tijd bijwerken. Bij belangrijke wijzigingen informeren we je door het nieuwe beleid op onze website te plaatsen en de datum bij 'Laatst bijgewerkt' aan te passen."
+      "description": "We kunnen dit beleid bijwerken naarmate JigSwap zich ontwikkelt. Belangrijke wijzigingen kondigen we aan door het nieuwe beleid op deze pagina te plaatsen en de datum bovenaan bij te werken."
     },
     "contact": {
       "title": "Contact",
-      "description": "Heb je vragen over dit privacybeleid of over hoe we met gegevens omgaan? Neem dan contact met ons op:",
-      "email": "E-mail",
-      "emailAddress": "privacy@jigswap.site",
-      "questions": "We hechten aan transparantie en beantwoorden je privacyvragen zo snel mogelijk."
+      "description": "Vragen over privacy of je gegevens? Je bereikt ons het makkelijkst via het",
+      "linkLabel": "contactformulier",
+      "emailNote": "Je kunt ook mailen naar [OWNER TO CONFIRM: contact email]."
     }
   },
   "terms": {
-    "title": "Algemene voorwaarden",
+    "title": "Algemene Voorwaarden",
     "lastUpdated": "Laatst bijgewerkt",
-    "introduction": "Deze algemene voorwaarden ('Voorwaarden') zijn van toepassing op je gebruik van JigSwap, ons platform voor het ruilen van legpuzzels. Door onze dienst te gebruiken ga je akkoord met deze voorwaarden.",
-    "effectiveDate": "20 juli 2025",
+    "effectiveDate": "2 juli 2026",
+    "introduction": "Deze algemene voorwaarden ('Voorwaarden') zijn van toepassing op je gebruik van JigSwap, een communityplatform voor legpuzzelliefhebbers, beheerd door [OWNER TO CONFIRM: legal name of the operator]. JigSwap is een hobbyproject, geen commerciële marktplaats. Door een account aan te maken of JigSwap te gebruiken ga je akkoord met deze Voorwaarden.",
     "acceptance": {
-      "title": "Akkoord met de voorwaarden",
-      "description": "Door JigSwap te bezoeken of te gebruiken ga je akkoord met deze Voorwaarden. Ben je het met een deel van deze voorwaarden oneens, dan mag je onze dienst niet gebruiken."
+      "title": "Akkoord met de Voorwaarden",
+      "description": "Door JigSwap te bezoeken of te gebruiken ga je akkoord met deze Voorwaarden. Ben je het met een deel ervan niet eens, gebruik de dienst dan niet."
     },
     "serviceDescription": {
-      "title": "Beschrijving van de dienst",
-      "description": "JigSwap is een platform waarmee gebruikers legpuzzels kunnen ruilen, uitwisselen en beheren. Onze dienst omvat:",
+      "title": "Wat JigSwap is",
+      "description": "JigSwap helpt legpuzzelverzamelaars hun puzzels bij te houden en te ruilen met andere leden. De dienst omvat:",
       "features": [
-        "Beheer en registratie van je puzzelcollectie",
-        "Ruil- en uitwisselfunctionaliteit",
-        "Communityfuncties en beoordelingen",
-        "Statistieken en voortgangsregistratie"
+        "Een door de community onderhouden puzzelcatalogus waar leden puzzels aan kunnen toevoegen",
+        "Een persoonlijke bibliotheek om je exemplaren, hun staat en foto's ervan bij te houden",
+        "Het loggen van voltooiingen (wanneer je een puzzel af had en hoe lang je erover deed) en het ordenen van exemplaren in collecties",
+        "Uitwisselingen tussen leden — ruilen, verkopen en uitlenen — met berichten om ze te regelen",
+        "Kringen (besloten vriendengroepen) om een deel van je bibliotheek te delen, plus profielen en volgen",
+        "Persoonlijke inzichten en statistieken over je puzzelen, inclusief een download van je eigen gegevens"
       ]
     },
     "userAccounts": {
-      "title": "Gebruikersaccounts",
-      "description": "Voor bepaalde functies van onze dienst moet je een account aanmaken. Je bent verantwoordelijk voor:",
+      "title": "Je account",
+      "description": "Voor de meeste functies heb je een account nodig. Inloggen en accountbeheer verlopen via Clerk, onze authenticatieprovider. Jij bent verantwoordelijk voor:",
       "responsibilities": [
-        "Het beveiligen van je account",
-        "Het verstrekken van juiste en volledige gegevens",
-        "Het melden van ongeoorloofd gebruik",
-        "Minimaal 13 jaar oud zijn om de dienst te gebruiken"
+        "Het beveiligen van de toegang tot je account",
+        "Het geven van juiste informatie in je profiel en over je puzzels",
+        "Het melden van vermoedelijk ongeoorloofd gebruik van je account",
+        "Minimaal 16 jaar oud zijn om een account aan te maken"
       ]
     },
     "userConduct": {
-      "title": "Gedragsregels",
-      "description": "Je gaat ermee akkoord onze dienst verantwoord en volgens deze voorwaarden te gebruiken:",
-      "prohibitedTitle": "Niet toegestaan:",
-      "expectedTitle": "Verwacht gedrag:",
-      "prohibited": [
-        "Het overtreden van toepasselijke wet- en regelgeving",
-        "Inbreuk maken op intellectuele-eigendomsrechten",
-        "Het lastigvallen of benadelen van andere gebruikers",
-        "Proberen ongeoorloofd toegang te krijgen tot onze systemen",
-        "De dienst zonder toestemming commercieel gebruiken"
-      ],
+      "title": "Gedrag in de community",
+      "description": "JigSwap draait op vertrouwen tussen puzzelliefhebbers. Gebruik de dienst verantwoordelijk:",
+      "expectedTitle": "Wat we verwachten:",
       "expected": [
-        "Andere gebruikers met respect behandelen",
-        "Juiste informatie over puzzels verstrekken",
-        "Ruilafspraken en toezeggingen nakomen",
-        "Verdacht of ongepast gedrag melden"
+        "Behandel andere leden met respect",
+        "Beschrijf je puzzels eerlijk, inclusief de staat en ontbrekende stukjes",
+        "Kom uitwisselingen na die je bent aangegaan",
+        "Meld problemen of verdacht gedrag via het contactformulier"
+      ],
+      "prohibitedTitle": "Wat niet mag:",
+      "prohibited": [
+        "De wet overtreden of inbreuk maken op de rechten van anderen",
+        "Andere leden intimideren, bedreigen of misleiden",
+        "Onrechtmatige, inbreukmakende of seksueel expliciete content uploaden",
+        "Spam of ongevraagd commercieel gebruik van het platform",
+        "De dienst scrapen of proberen ongeoorloofd toegang te krijgen tot accounts of systemen",
+        "Je voordoen als een andere persoon of een ander lid"
       ]
     },
     "trading": {
-      "title": "Ruilen en uitwisselingen",
-      "description": "Ons platform maakt het ruilen van puzzels tussen gebruikers mogelijk. Door deel te nemen aan ruilen ga je ermee akkoord om:",
+      "title": "Ruilen, verkopen en uitlenen",
+      "description": "Via JigSwap kunnen leden onderling puzzels ruilen, verkopen en uitlenen. Elke uitwisseling is een afspraak tussen de twee betrokken leden — niet met JigSwap. Als je meedoet aan een uitwisseling, ga je ermee akkoord dat je:",
       "agreements": [
-        "De conditie en volledigheid van puzzels eerlijk te omschrijven",
-        "Afgesproken ruilvoorwaarden na te komen",
-        "Vlot en eerlijk te communiceren",
-        "Geschillen waar mogelijk onderling op te lossen"
+        "De staat en compleetheid van je puzzels eerlijk beschrijft",
+        "De gemaakte afspraken nakomt, inclusief het terugbezorgen van geleende puzzels",
+        "Betaling en verzending onderling regelt — JigSwap verwerkt geen betalingen",
+        "Vlot communiceert en meningsverschillen respectvol probeert op te lossen"
       ],
-      "disclaimer": "JigSwap faciliteert ruilen, maar is niet verantwoordelijk voor de kwaliteit, conditie of volledigheid van geruilde puzzels. Ruilen gebeurt op eigen risico."
+      "disclaimer": "JigSwap brengt leden alleen met elkaar in contact en houdt een administratie van de uitwisseling bij. We zijn geen partij bij een uitwisseling en zijn niet verantwoordelijk voor betaling, verzending of de kwaliteit, staat of compleetheid van geruilde puzzels. Uitwisselen doe je op eigen risico."
     },
     "intellectualProperty": {
-      "title": "Intellectueel eigendom",
-      "description": "Onze dienst en de oorspronkelijke inhoud, functies en functionaliteit zijn eigendom van JigSwap en worden beschermd door internationale auteursrechten, merkenrechten en andere intellectuele-eigendomswetten."
+      "title": "Content en intellectueel eigendom",
+      "description": "Verschillende dingen op JigSwap zijn van verschillende mensen:",
+      "yourContent": {
+        "title": "Jouw content",
+        "description": "Foto's, beoordelingen, reacties en andere content die je plaatst blijven van jou. Door iets te plaatsen geef je ons een niet-exclusieve licentie om die content op te slaan en te tonen zodat de dienst kan werken — bijvoorbeeld om je puzzelfoto's te laten zien aan de leden met wie je ze hebt gedeeld. Puzzels die je aan de gedeelde catalogus toevoegt, worden onderdeel van de communitycatalogus die alle leden kunnen gebruiken. Geüploade foto's doorlopen een automatische veiligheidscontrole voordat andere leden ze kunnen zien (zie het privacybeleid voor details)."
+      },
+      "platform": {
+        "title": "Het platform en puzzelillustraties",
+        "description": "De JigSwap-software is open source onder de MIT-licentie. Puzzelafbeeldingen en illustraties in de catalogus zijn van de betreffende uitgevers en rechthebbenden en worden gebruikt om puzzels te identificeren. Heb je rechten op content die op JigSwap wordt getoond en wil je dat die wordt aangepast of verwijderd, neem dan contact met ons op."
+      }
     },
     "privacy": {
       "title": "Privacy",
-      "description": "Je privacy is belangrijk voor ons. Lees ook ons privacybeleid, dat eveneens van toepassing is op je gebruik van de dienst."
+      "description": "Hoe we met je persoonsgegevens omgaan staat in ons privacybeleid, dat naast deze Voorwaarden geldt."
     },
     "termination": {
-      "title": "Beëindiging van je account",
-      "description": "We kunnen je account per direct en zonder voorafgaande kennisgeving beëindigen of schorsen, om welke reden dan ook, waaronder schending van deze Voorwaarden."
+      "title": "Je account beëindigen",
+      "description": "Je kunt op elk moment stoppen met JigSwap en je account verwijderen. Wij kunnen accounts schorsen of verwijderen die deze Voorwaarden schenden — bijvoorbeeld bij oplichting, intimidatie of onrechtmatige content. Waar redelijkerwijs mogelijk vertellen we je waarom."
     },
     "disclaimer": {
-      "title": "Uitsluiting van garanties",
-      "description": "De dienst wordt geleverd 'zoals die is', zonder enige vorm van garantie. We garanderen niet dat de dienst ononderbroken of foutloos werkt."
+      "title": "Disclaimer",
+      "description": "JigSwap is een hobbyproject dat gratis en 'as is' wordt aangeboden. We doen ons best om alles goed te laten draaien, maar we kunnen niet beloven dat de dienst altijd beschikbaar of foutloos is."
     },
     "limitation": {
       "title": "Beperking van aansprakelijkheid",
-      "description": "JigSwap is niet aansprakelijk voor indirecte, incidentele, bijzondere of gevolgschade, of voor schadevergoedingen met een bestraffend karakter, voortvloeiend uit je gebruik van de dienst."
+      "description": "Voor zover toegestaan door het toepasselijke recht zijn JigSwap en de beheerder niet aansprakelijk voor indirecte schade of gevolgschade door je gebruik van de dienst of door uitwisselingen tussen leden. Niets in deze Voorwaarden beperkt aansprakelijkheid die volgens het toepasselijke recht niet beperkt of uitgesloten kan worden."
     },
     "changes": {
-      "title": "Wijzigingen in de voorwaarden",
-      "description": "We behouden ons het recht voor deze voorwaarden op elk moment te wijzigen. Bij belangrijke wijzigingen informeren we gebruikers door de nieuwe voorwaarden op onze website te plaatsen."
+      "title": "Wijzigingen in deze Voorwaarden",
+      "description": "We kunnen deze Voorwaarden van tijd tot tijd bijwerken. Belangrijke wijzigingen kondigen we aan door de nieuwe Voorwaarden op deze pagina te plaatsen en de datum bovenaan bij te werken. Blijf je JigSwap na een wijziging gebruiken, dan gelden de bijgewerkte Voorwaarden."
     },
     "contact": {
-      "title": "Contactgegevens",
-      "description": "Heb je vragen over deze algemene voorwaarden? Neem dan contact met ons op:",
-      "email": "E-mail",
-      "emailAddress": "legal@jigswap.site",
-      "questions": "We hechten aan transparantie en beantwoorden je vragen zo snel mogelijk."
+      "title": "Contact",
+      "description": "Vragen over deze Voorwaarden? Je bereikt ons het makkelijkst via het",
+      "linkLabel": "contactformulier",
+      "emailNote": "Je kunt ook mailen naar [OWNER TO CONFIRM: contact email]."
     }
   },
   "about": {

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -898,7 +898,7 @@
     "title": "Privacy Policy",
     "lastUpdated": "Last Updated",
     "effectiveDate": "2 July 2026",
-    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by [OWNER TO CONFIRM: legal name of the operator], who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
+    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by Sander Verkuil, who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
     "informationWeCollect": {
       "title": "Information We Collect",
       "description": "We collect information you give us directly, plus a limited amount of information collected automatically while you use JigSwap.",
@@ -916,7 +916,7 @@
       "automaticallyCollected": {
         "title": "Collected automatically",
         "items": [
-          "Product analytics events, such as pages visited and features used (via PostHog)",
+          "Product analytics events, such as pages visited and features used (via PostHog, only after you accept the cookie notice)",
           "Error reports and operational logs used to keep the service running",
           "Your language preference and cookie-notice choice, stored in cookies",
           "A push notification subscription — only if you turn push notifications on"
@@ -948,14 +948,18 @@
     },
     "dataStorage": {
       "title": "Where Your Data Lives",
-      "description": "JigSwap does not run its own servers. Your data is stored with a small number of service providers:",
+      "description": "JigSwap does not run its own servers. Your data is stored in the European Union with a small number of service providers:",
       "convex": {
         "title": "Convex",
-        "description": "Our database and file storage. Your library, exchanges, messages, and uploaded photos are stored in Convex."
+        "description": "Our database and file storage, on Convex's EU hosting. Your library, exchanges, messages, and uploaded photos are stored in the European Union."
       },
       "clerk": {
         "title": "Clerk",
-        "description": "Our authentication provider. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+        "description": "Our authentication provider, with EU data residency. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+      },
+      "vercel": {
+        "title": "Vercel",
+        "description": "Our hosting provider. The JigSwap web application is served through Vercel's global edge network. Vercel delivers the site to your browser; your personal data itself lives in the EU-hosted services above."
       }
     },
     "photos": {
@@ -972,7 +976,7 @@
       "description": "We use analytics to understand how JigSwap is used and to catch errors before they spoil the fun.",
       "posthog": {
         "title": "PostHog",
-        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. This data is used only to improve JigSwap."
+        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. PostHog only starts after you accept the cookie notice — if you decline, it is never loaded. This data is used only to improve JigSwap."
       },
       "noAdvertising": "We do not show ads, we do not use your data for advertising, and we never sell your data."
     },
@@ -982,7 +986,7 @@
       "noSale": "We do not sell, rent, or trade your personal data. Ever.",
       "limitedSharing": "Data is shared only in these cases:",
       "circumstances": [
-        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
+        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), Vercel (hosting), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
         "With other members, to the extent you choose — your profile and the parts of your library you share are visible according to your settings",
         "When the law requires it, or to protect the service and its members against fraud or abuse",
         "For anything else: only with your explicit consent"
@@ -1017,9 +1021,9 @@
         "Sign-in cookies from Clerk that keep you logged in (strictly necessary)",
         "A language cookie that remembers your English/Dutch preference",
         "A cookie that remembers that you have seen the cookie notice",
-        "Analytics identifiers from PostHog, stored in cookies and local storage, to tell visits apart"
+        "Analytics identifiers from PostHog, stored in cookies and local storage — only after you accept the cookie notice"
       ],
-      "control": "You can block or delete cookies in your browser settings. JigSwap keeps working, though you will need to sign in again and your preferences may reset."
+      "control": "Analytics is opt-in: it only runs after you accept the cookie notice, and declining means it is never loaded. You can also block or delete cookies in your browser settings; JigSwap keeps working, though you will need to sign in again and your preferences may reset."
     },
     "cookieConsent": {
       "title": "We use cookies",
@@ -1035,7 +1039,7 @@
     },
     "international": {
       "title": "International Data Transfers",
-      "description": "We prefer EU-hosted providers where we can: PostHog and Axiom process data in the European Union. Convex and Clerk are US-based companies, so some data may be processed outside the EU/EEA. Where that happens, transfers take place under the safeguards those providers offer for GDPR compliance, such as the EU standard contractual clauses."
+      "description": "Your personal data is stored in the European Union: we use the EU-hosted variants of Convex, Clerk, PostHog, and Axiom. Our hosting provider Vercel serves the website through a global edge network, so requests may pass through servers outside the EU on their way to you, but the personal data itself stays stored in the EU. Where a provider processes limited data outside the EU/EEA, transfers take place under GDPR safeguards such as the EU standard contractual clauses."
     },
     "changes": {
       "title": "Changes to This Policy",
@@ -1043,16 +1047,17 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Questions about privacy or your data? The easiest way to reach us is the",
-      "linkLabel": "contact form",
-      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
+      "description": "Questions about privacy or your data? Email us at",
+      "emailAddress": "privacy@jigswap.site",
+      "formNote": "You can also use the",
+      "linkLabel": "contact form"
     }
   },
   "terms": {
     "title": "Terms of Service",
     "lastUpdated": "Last Updated",
     "effectiveDate": "2 July 2026",
-    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by [OWNER TO CONFIRM: legal name of the operator]. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
+    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by Sander Verkuil. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
     "acceptance": {
       "title": "Acceptance of Terms",
       "description": "By accessing or using JigSwap you agree to be bound by these Terms. If you do not agree with any part of them, please do not use the service."
@@ -1144,9 +1149,10 @@
     },
     "contact": {
       "title": "Contact",
-      "description": "Questions about these Terms? The easiest way to reach us is the",
-      "linkLabel": "contact form",
-      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
+      "description": "Questions about these Terms? Email us at",
+      "emailAddress": "legal@jigswap.site",
+      "formNote": "You can also use the",
+      "linkLabel": "contact form"
     }
   },
   "about": {

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -897,108 +897,129 @@
   "privacy": {
     "title": "Privacy Policy",
     "lastUpdated": "Last Updated",
-    "introduction": "This Privacy Policy describes how JigSwap ('we', 'our', or 'us') collects, uses, and protects your personal information when you use our jigsaw puzzle trading platform.",
-    "effectiveDate": "July 20, 2025",
+    "effectiveDate": "2 July 2026",
+    "introduction": "This Privacy Policy explains what personal data JigSwap collects, why we collect it, and what your rights are. JigSwap is run by [OWNER TO CONFIRM: legal name of the operator], who is the controller for the processing described here. We aim to collect as little as possible and to be transparent about the rest.",
     "informationWeCollect": {
       "title": "Information We Collect",
-      "description": "We collect information you provide directly to us and information we collect automatically when you use our service.",
+      "description": "We collect information you give us directly, plus a limited amount of information collected automatically while you use JigSwap.",
       "personalInformation": {
-        "title": "Personal Information",
+        "title": "Information you provide",
         "items": [
-          "Account information (name, email address, username)",
-          "Profile information (bio, location, interests)",
-          "Puzzle collection data and photos",
-          "Exchange history and communications",
-          "Reviews and ratings you provide"
+          "Account details via Clerk, our sign-in provider: name, email address, username, and avatar",
+          "Your profile: display name, bio, and other details you choose to share",
+          "Your puzzle library: the copies you own, their condition, photos you upload, completions, and collections",
+          "Exchange activity: swap, sale, and loan requests, the messages you send to arrange them, and reviews",
+          "Community activity: the circles you belong to, members you follow, and comments you post",
+          "Messages you send through the contact form: your name, email address, and message"
         ]
       },
       "automaticallyCollected": {
-        "title": "Automatically Collected Information",
+        "title": "Collected automatically",
         "items": [
-          "Device information (IP address, browser type, operating system)",
-          "Usage data (pages visited, features used, time spent)",
-          "Analytics data (interaction patterns, preferences)",
-          "Technical logs and error reports"
+          "Product analytics events, such as pages visited and features used (via PostHog)",
+          "Error reports and operational logs used to keep the service running",
+          "Your language preference and cookie-notice choice, stored in cookies",
+          "A push notification subscription — only if you turn push notifications on"
         ]
       }
     },
     "howWeUseInformation": {
       "title": "How We Use Your Information",
-      "description": "We use the information we collect to provide, improve, and secure our services.",
+      "description": "We use your data to run JigSwap — nothing more:",
       "purposes": [
-        "Provide and maintain our puzzle trading platform",
-        "Process trades and facilitate exchanges between users",
-        "Personalize your experience and show relevant content",
-        "Send important service updates and notifications",
-        "Analyze usage patterns to improve our service",
-        "Prevent fraud and ensure platform security",
-        "Respond to your questions and support requests"
-      ]
-    },
-    "dataStorage": {
-      "title": "Data Storage and Hosting",
-      "description": "Your data is securely stored and managed by trusted third-party services:",
-      "convex": {
-        "title": "Convex",
-        "description": "Our primary database and backend services are hosted by Convex. They handle data storage, user authentication, and real-time features."
-      },
-      "vercel": {
-        "title": "Vercel",
-        "description": "Our web application is hosted on Vercel's infrastructure, which provides fast, reliable, and secure hosting services."
+        "Provide your library, completions, collections, and insights",
+        "Facilitate exchanges between members, including messaging and loan tracking",
+        "Show your profile and puzzles to the members you have chosen to share them with",
+        "Send you notifications about activity that concerns you",
+        "Keep the service secure and prevent abuse, including automated screening of uploaded photos",
+        "Understand how JigSwap is used so we can improve it",
+        "Respond when you contact us"
+      ],
+      "lawfulBasis": {
+        "title": "Our lawful basis, in plain terms",
+        "description": "Under the GDPR we need a legal reason for each use of your data. Ours are:",
+        "items": [
+          "Performing our agreement with you: everything needed to run the service you signed up for — your account, library, exchanges, and messages",
+          "Legitimate interests: keeping JigSwap secure, preventing abuse, screening uploaded photos, operational logging, and understanding usage so we can improve the service",
+          "Consent: where we ask you first, such as browser push notifications",
+          "Legal obligations: the rare cases where we must keep or share data because the law requires it"
+        ]
       }
     },
-    "analytics": {
-      "title": "Analytics and Tracking",
-      "description": "We use analytics to understand how our service is used and improve user experience.",
-      "posthog": {
-        "title": "PostHog Analytics",
-        "description": "We use PostHog to collect anonymous usage analytics. This helps us understand user behavior and improve our platform. PostHog data is used solely for service improvement and is not sold to third parties."
+    "dataStorage": {
+      "title": "Where Your Data Lives",
+      "description": "JigSwap does not run its own servers. Your data is stored with a small number of service providers:",
+      "convex": {
+        "title": "Convex",
+        "description": "Our database and file storage. Your library, exchanges, messages, and uploaded photos are stored in Convex."
       },
-      "noAdvertising": "We do not use your data for advertising purposes. Your information will never be sold to advertisers or third parties for marketing purposes."
+      "clerk": {
+        "title": "Clerk",
+        "description": "Our authentication provider. Clerk stores your sign-in credentials and core account details (name, email address, avatar) and handles signing in. When you delete your account, Clerk notifies us and we remove your account record."
+      }
+    },
+    "photos": {
+      "title": "Photos You Upload",
+      "description": "Photos you add to your library go through an automatic pipeline before other members can see them:",
+      "steps": [
+        "The image is re-encoded, which strips hidden metadata such as EXIF data — including any embedded location",
+        "An automated content-safety check screens the image; for this we currently use a model hosted by Hugging Face, which processes the image for this purpose only",
+        "Until this finishes, the photo is visible only to you"
+      ]
+    },
+    "analytics": {
+      "title": "Analytics and Error Reporting",
+      "description": "We use analytics to understand how JigSwap is used and to catch errors before they spoil the fun.",
+      "posthog": {
+        "title": "PostHog",
+        "description": "We use PostHog, hosted in the European Union, for product analytics and error reporting. Analytics requests are routed through our own domain. This data is used only to improve JigSwap."
+      },
+      "noAdvertising": "We do not show ads, we do not use your data for advertising, and we never sell your data."
     },
     "dataSharing": {
-      "title": "Data Sharing and Third Parties",
-      "description": "We are committed to protecting your privacy and do not sell your personal information.",
-      "noSale": "We do not sell, rent, or trade your personal information to third parties for advertising or marketing purposes.",
-      "limitedSharing": "We may share your information only in these limited circumstances:",
+      "title": "Data Sharing",
+      "description": "We share personal data only with the providers that run JigSwap, and only what they need to do their job.",
+      "noSale": "We do not sell, rent, or trade your personal data. Ever.",
+      "limitedSharing": "Data is shared only in these cases:",
       "circumstances": [
-        "With your explicit consent",
-        "To comply with legal obligations",
-        "To protect our rights and prevent fraud",
-        "With service providers who assist in platform operations (under strict confidentiality agreements)"
+        "With the providers named in this policy, as processors on our behalf: Convex (database and files), Clerk (sign-in), PostHog (analytics and error reporting), Axiom (operational logs, EU-hosted), and Hugging Face (automated photo screening)",
+        "With other members, to the extent you choose — your profile and the parts of your library you share are visible according to your settings",
+        "When the law requires it, or to protect the service and its members against fraud or abuse",
+        "For anything else: only with your explicit consent"
       ]
     },
     "dataSecurity": {
       "title": "Data Security",
-      "description": "We implement appropriate security measures to protect your personal information:",
+      "description": "We take reasonable measures to protect your data:",
       "measures": [
-        "Encryption of data in transit and at rest",
-        "Regular security audits and updates",
-        "Access controls and authentication",
-        "Secure hosting infrastructure"
+        "All traffic between your browser and JigSwap is encrypted (TLS)",
+        "Every read and write is checked on the server: members only see what the visibility rules allow",
+        "Uploaded photos are stripped of hidden metadata and screened before they become visible to others",
+        "Access to production data is limited to what is needed to run the service"
       ]
     },
     "yourRights": {
-      "title": "Your Rights and Choices",
-      "description": "You have control over your personal information:",
+      "title": "Your Rights",
+      "description": "Under the GDPR you have the following rights, and JigSwap has built-in tools for most of them:",
       "rights": [
-        "Access and review your personal data",
-        "Update or correct your information",
-        "Delete your account and associated data",
-        "Opt out of certain data collection",
-        "Export your data in a portable format",
-        "Contact us with privacy concerns"
+        "Access: see the data we hold about you — most of it is directly visible in the app",
+        "Portability: download your data as a file via the export on your Insights page",
+        "Rectification: correct your profile and library yourself at any time, or ask us to fix something",
+        "Erasure: delete your account, which removes your account record — and ask us to remove any remaining content tied to it",
+        "Objection and restriction: object to processing we base on our legitimate interests",
+        "Complaint: lodge a complaint with your data protection authority — in the Netherlands, the Autoriteit Persoonsgegevens"
       ]
     },
     "cookies": {
-      "title": "Cookies and Tracking",
-      "description": "We use cookies and similar technologies to enhance your experience:",
+      "title": "Cookies",
+      "description": "JigSwap uses a small number of cookies and similar technologies:",
       "types": [
-        "Essential cookies for platform functionality",
-        "Analytics cookies to understand usage patterns",
-        "Preference cookies to remember your settings"
+        "Sign-in cookies from Clerk that keep you logged in (strictly necessary)",
+        "A language cookie that remembers your English/Dutch preference",
+        "A cookie that remembers that you have seen the cookie notice",
+        "Analytics identifiers from PostHog, stored in cookies and local storage, to tell visits apart"
       ],
-      "control": "You can control cookie settings through your browser preferences."
+      "control": "You can block or delete cookies in your browser settings. JigSwap keeps working, though you will need to sign in again and your preferences may reset."
     },
     "cookieConsent": {
       "title": "We use cookies",
@@ -1009,114 +1030,123 @@
       "acceptanceText": "By clicking \"Accept\", you agree to our use of cookies."
     },
     "children": {
-      "title": "Children's Privacy",
-      "description": "Our service is not intended for children under 13. We do not knowingly collect personal information from children under 13."
+      "title": "Children",
+      "description": "JigSwap is not intended for children under 16, and we do not knowingly collect personal data from them. If you believe a child under 16 has an account, please contact us."
     },
     "international": {
       "title": "International Data Transfers",
-      "description": "Your data may be processed in countries other than your own. We ensure appropriate safeguards are in place to protect your information."
+      "description": "We prefer EU-hosted providers where we can: PostHog and Axiom process data in the European Union. Convex and Clerk are US-based companies, so some data may be processed outside the EU/EEA. Where that happens, transfers take place under the safeguards those providers offer for GDPR compliance, such as the EU standard contractual clauses."
     },
     "changes": {
       "title": "Changes to This Policy",
-      "description": "We may update this Privacy Policy from time to time. We will notify you of any material changes by posting the new policy on our website and updating the 'Last Updated' date."
+      "description": "We may update this policy as JigSwap evolves. Material changes are announced by posting the new policy on this page and updating the date at the top."
     },
     "contact": {
-      "title": "Contact Us",
-      "description": "If you have any questions about this Privacy Policy or our data practices, please contact us:",
-      "email": "Email",
-      "emailAddress": "privacy@jigswap.site",
-      "questions": "We're committed to transparency and will respond to your privacy inquiries promptly."
+      "title": "Contact",
+      "description": "Questions about privacy or your data? The easiest way to reach us is the",
+      "linkLabel": "contact form",
+      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
     }
   },
   "terms": {
     "title": "Terms of Service",
     "lastUpdated": "Last Updated",
-    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, our jigsaw puzzle trading platform. By using our service, you agree to these terms.",
-    "effectiveDate": "July 20, 2025",
+    "effectiveDate": "2 July 2026",
+    "introduction": "These Terms of Service ('Terms') govern your use of JigSwap, a community platform for jigsaw puzzle enthusiasts, run by [OWNER TO CONFIRM: legal name of the operator]. JigSwap is a hobby project, not a commercial marketplace. By creating an account or using JigSwap, you agree to these Terms.",
     "acceptance": {
       "title": "Acceptance of Terms",
-      "description": "By accessing or using JigSwap, you agree to be bound by these Terms. If you disagree with any part of these terms, you may not access our service."
+      "description": "By accessing or using JigSwap you agree to be bound by these Terms. If you do not agree with any part of them, please do not use the service."
     },
     "serviceDescription": {
-      "title": "Service Description",
-      "description": "JigSwap is a platform that enables users to trade, exchange, and manage jigsaw puzzles. Our service includes:",
+      "title": "What JigSwap Is",
+      "description": "JigSwap helps jigsaw puzzle collectors keep track of their puzzles and exchange them with other members. The service includes:",
       "features": [
-        "Puzzle collection management and tracking",
-        "Trading and exchange functionality",
-        "Community features and reviews",
-        "Analytics and progress tracking"
+        "A community-maintained puzzle catalog that members can add puzzles to",
+        "A personal library to track the copies you own, their condition, and photos of them",
+        "Logging completions (when you finished a puzzle and how long it took) and organising copies into collections",
+        "Exchanges between members — swaps, sales, and loans — with messaging to arrange them",
+        "Circles (private groups of friends) for sharing part of your library, plus member profiles and follows",
+        "Personal insights and statistics about your puzzling, including a download of your own data"
       ]
     },
     "userAccounts": {
-      "title": "User Accounts",
-      "description": "To use certain features of our service, you must create an account. You are responsible for:",
+      "title": "Your Account",
+      "description": "You need an account for most features. Sign-in and account management are handled by Clerk, our authentication provider. You are responsible for:",
       "responsibilities": [
-        "Maintaining the security of your account",
-        "Providing accurate and complete information",
-        "Notifying us of any unauthorized use",
-        "Being at least 13 years old to use the service"
+        "Keeping access to your account secure",
+        "Providing accurate information in your profile and about your puzzles",
+        "Letting us know if you suspect unauthorised use of your account",
+        "Being at least 16 years old to create an account"
       ]
     },
     "userConduct": {
-      "title": "User Conduct",
-      "description": "You agree to use our service responsibly and in accordance with these terms:",
-      "prohibitedTitle": "Prohibited Activities:",
-      "expectedTitle": "Expected Behavior:",
-      "prohibited": [
-        "Violating any applicable laws or regulations",
-        "Infringing on intellectual property rights",
-        "Harassing or harming other users",
-        "Attempting to gain unauthorized access to our systems",
-        "Using the service for commercial purposes without permission"
-      ],
+      "title": "Community Conduct",
+      "description": "JigSwap runs on trust between puzzle lovers. Use the service responsibly:",
+      "expectedTitle": "What we expect:",
       "expected": [
-        "Treating other users with respect",
-        "Providing accurate information about puzzles",
-        "Honoring trade agreements and commitments",
-        "Reporting suspicious or inappropriate behavior"
+        "Treat other members with respect",
+        "Describe your puzzles honestly, including condition and missing pieces",
+        "Follow through on exchanges you agree to",
+        "Report problems or suspicious behaviour via the contact form"
+      ],
+      "prohibitedTitle": "What is not allowed:",
+      "prohibited": [
+        "Breaking the law or infringing other people's rights",
+        "Harassing, threatening, or deceiving other members",
+        "Uploading unlawful, infringing, or sexually explicit content",
+        "Spam or unsolicited commercial use of the platform",
+        "Scraping the service or attempting to gain unauthorised access to accounts or systems",
+        "Impersonating another person or member"
       ]
     },
     "trading": {
-      "title": "Trading and Exchanges",
-      "description": "Our platform facilitates puzzle trading between users. By participating in trades, you agree to:",
+      "title": "Swaps, Sales, and Loans",
+      "description": "JigSwap lets members arrange swaps, sales, and loans of puzzles with each other. Every exchange is an agreement between the two members involved — not with JigSwap. When you take part in an exchange, you agree to:",
       "agreements": [
-        "Accurately describe puzzle condition and completeness",
-        "Honor agreed-upon trade terms",
-        "Communicate promptly and honestly",
-        "Resolve disputes amicably when possible"
+        "Accurately describe the condition and completeness of your puzzles",
+        "Honour the terms you agreed on, including returning borrowed puzzles",
+        "Arrange payment and shipping between yourselves — JigSwap does not process payments",
+        "Communicate promptly and try to resolve disagreements respectfully"
       ],
-      "disclaimer": "JigSwap acts as a facilitator for trades but is not responsible for the quality, condition, or completeness of traded puzzles. Users trade at their own risk."
+      "disclaimer": "JigSwap only brings members into contact and keeps a record of the exchange. We are not a party to any exchange and are not responsible for payment, shipping, or the quality, condition, or completeness of exchanged puzzles. Exchanges are at your own risk."
     },
     "intellectualProperty": {
-      "title": "Intellectual Property",
-      "description": "Our service and its original content, features, and functionality are owned by JigSwap and are protected by international copyright, trademark, and other intellectual property laws."
+      "title": "Content and Intellectual Property",
+      "description": "Different things on JigSwap belong to different people:",
+      "yourContent": {
+        "title": "Your content",
+        "description": "Photos, reviews, comments, and other content you post remain yours. By posting, you give us a non-exclusive licence to store and display that content so the service can work — for example, showing your puzzle photos to the members you have shared them with. Puzzles you add to the shared catalog become part of the community catalog that all members can use. Uploaded photos pass through an automated safety check before other members can see them (see the Privacy Policy for details)."
+      },
+      "platform": {
+        "title": "The platform and puzzle artwork",
+        "description": "The JigSwap software is open source under the MIT licence. Puzzle images and artwork in the catalog belong to their respective publishers and rights holders and are used to identify puzzles. If you hold rights to content shown on JigSwap and want it corrected or removed, please contact us."
+      }
     },
     "privacy": {
       "title": "Privacy",
-      "description": "Your privacy is important to us. Please review our Privacy Policy, which also governs your use of the service."
+      "description": "How we handle your personal data is described in our Privacy Policy, which applies alongside these Terms."
     },
     "termination": {
-      "title": "Account Termination",
-      "description": "We may terminate or suspend your account immediately, without prior notice, for any reason, including breach of these Terms."
+      "title": "Ending Your Account",
+      "description": "You can stop using JigSwap and delete your account at any time. We may suspend or remove accounts that break these Terms — for example for scams, harassment, or unlawful content. Where reasonably possible, we will tell you why."
     },
     "disclaimer": {
-      "title": "Disclaimer of Warranties",
-      "description": "The service is provided 'as is' without warranties of any kind. We do not guarantee that the service will be uninterrupted or error-free."
+      "title": "Disclaimer",
+      "description": "JigSwap is a hobby project provided free of charge and 'as is'. We do our best to keep it running well, but we cannot promise that the service will always be available or error-free."
     },
     "limitation": {
       "title": "Limitation of Liability",
-      "description": "JigSwap shall not be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of the service."
+      "description": "To the extent permitted by applicable law, JigSwap and its operator are not liable for indirect or consequential damage arising from your use of the service or from exchanges between members. Nothing in these Terms limits liability that cannot be limited or excluded under applicable law."
     },
     "changes": {
-      "title": "Changes to Terms",
-      "description": "We reserve the right to modify these terms at any time. We will notify users of any material changes by posting the new terms on our website."
+      "title": "Changes to These Terms",
+      "description": "We may update these Terms from time to time. Material changes are announced by posting the new Terms on this page and updating the date at the top. If you keep using JigSwap after a change, the updated Terms apply."
     },
     "contact": {
-      "title": "Contact Information",
-      "description": "If you have any questions about these Terms of Service, please contact us:",
-      "email": "Email",
-      "emailAddress": "legal@jigswap.site",
-      "questions": "We're committed to transparency and will respond to your inquiries promptly."
+      "title": "Contact",
+      "description": "Questions about these Terms? The easiest way to reach us is the",
+      "linkLabel": "contact form",
+      "emailNote": "You can also email [OWNER TO CONFIRM: contact email]."
     }
   },
   "about": {

--- a/apps/web/src/components/blocks/cookie-consent.tsx
+++ b/apps/web/src/components/blocks/cookie-consent.tsx
@@ -9,6 +9,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  readAnalyticsConsent,
+  writeAnalyticsConsent,
+} from "@/lib/analytics-consent";
 import { cn } from "@/lib/utils";
 import { Cookie } from "lucide-react";
 import * as React from "react";
@@ -47,16 +51,19 @@ const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps>(
 
     const handleAccept = React.useCallback(() => {
       setIsOpen(false);
-      document.cookie =
-        "cookieConsent=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+      writeAnalyticsConsent("granted");
       setTimeout(() => {
         setHide(true);
       }, 700);
       onAcceptCallback();
     }, [onAcceptCallback]);
 
+    // Declines are persisted too, so analytics stays off on every future visit
+    // and the banner doesn't nag again (the privacy policy promises declined
+    // analytics is never loaded).
     const handleDecline = React.useCallback(() => {
       setIsOpen(false);
+      writeAnalyticsConsent("denied");
       setTimeout(() => {
         setHide(true);
       }, 700);
@@ -66,7 +73,7 @@ const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps>(
     React.useEffect(() => {
       try {
         setIsOpen(true);
-        if (document.cookie.includes("cookieConsent=true") && !demo) {
+        if (readAnalyticsConsent(document.cookie) !== "unset" && !demo) {
           setIsOpen(false);
           setTimeout(() => {
             setHide(true);

--- a/apps/web/src/components/posthog-page-view.tsx
+++ b/apps/web/src/components/posthog-page-view.tsx
@@ -15,7 +15,9 @@ export function PostHogPageView(): null {
   const { user } = useUser();
 
   useEffect(() => {
-    if (pathname && posthog) {
+    // Consent gate: posthog only has __loaded once initPostHog ran (i.e. the
+    // visitor accepted the cookie notice). Without it, capture is a no-op.
+    if (pathname && posthog && posthog.__loaded) {
       let url = window.origin + pathname;
       const query = searchParams.toString();
       if (query) {
@@ -29,7 +31,7 @@ export function PostHogPageView(): null {
   }, [pathname, searchParams, posthog]);
 
   useEffect(() => {
-    if (!isLoading && isAuthenticated && user && posthog) {
+    if (!isLoading && isAuthenticated && user && posthog && posthog.__loaded) {
       posthog.identify(user.id, {
         email: user.primaryEmailAddress?.emailAddress,
         username: user.username,

--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -1,10 +1,17 @@
+import { readAnalyticsConsent } from "@/lib/analytics-consent";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import * as React from "react";
 
 // The web app inits PostHog in instrumentation-client.ts; Start has no such hook,
 // so we init lazily on the client inside the provider (same config as web).
-function initPostHog() {
+//
+// CONSENT-GATED (the privacy policy promises this): PostHog only initializes
+// after the visitor accepts the cookie notice. On load we init only when the
+// consent cookie says "granted"; when consent is granted mid-session the
+// banner's accept callback calls initPostHog() directly (no reload needed).
+// A declined or undecided notice means PostHog is never loaded.
+export function initPostHog() {
   const key = import.meta.env.VITE_POSTHOG_KEY;
   if (!key || posthog.__loaded) return;
   posthog.init(key, {
@@ -19,7 +26,8 @@ function initPostHog() {
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   // useState initializer runs once on the client; SSR skips it (no window).
   React.useState(() => {
-    if (typeof window !== "undefined") initPostHog();
+    if (typeof window === "undefined") return;
+    if (readAnalyticsConsent(document.cookie) === "granted") initPostHog();
   });
 
   return <PHProvider client={posthog}>{children}</PHProvider>;

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,6 +1,6 @@
 import CookieConsent from "@/components/blocks/cookie-consent";
 import { PostHogPageView } from "@/components/posthog-page-view";
-import { PostHogProvider } from "@/components/posthog-provider";
+import { initPostHog, PostHogProvider } from "@/components/posthog-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { type Messages, timeZone } from "@/lib/i18n";
 import { ThemeProvider } from "next-themes";
@@ -29,7 +29,9 @@ export function Providers({
       >
         <PostHogProvider>
           {children}
-          <CookieConsent variant="mini" />
+          {/* Accepting the notice starts analytics right away (no reload);
+              PostHogProvider only auto-inits when consent was already granted. */}
+          <CookieConsent variant="mini" onAcceptCallback={initPostHog} />
           <PostHogPageView />
           <Toaster />
         </PostHogProvider>

--- a/apps/web/src/lib/analytics-consent.test.ts
+++ b/apps/web/src/lib/analytics-consent.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readAnalyticsConsent } from "./analytics-consent";
+
+describe("readAnalyticsConsent", () => {
+  it("is unset when there is no cookie string", () => {
+    expect(readAnalyticsConsent(undefined)).toBe("unset");
+    expect(readAnalyticsConsent(null)).toBe("unset");
+    expect(readAnalyticsConsent("")).toBe("unset");
+  });
+
+  it("is unset when the consent cookie is absent", () => {
+    expect(readAnalyticsConsent("jigswap-intl=nl; theme=dark")).toBe("unset");
+  });
+
+  it("reads an accepted notice as granted", () => {
+    expect(readAnalyticsConsent("cookieConsent=true")).toBe("granted");
+    expect(
+      readAnalyticsConsent("jigswap-intl=nl; cookieConsent=true; theme=dark"),
+    ).toBe("granted");
+  });
+
+  it("reads a declined notice as denied", () => {
+    expect(readAnalyticsConsent("cookieConsent=false")).toBe("denied");
+    expect(readAnalyticsConsent("a=1;  cookieConsent=false ")).toBe("denied");
+  });
+
+  it("does not match cookies whose name merely contains the consent name", () => {
+    expect(readAnalyticsConsent("xcookieConsent=true")).toBe("unset");
+  });
+
+  it("treats malformed values as unset (analytics stays off)", () => {
+    expect(readAnalyticsConsent("cookieConsent=")).toBe("unset");
+    expect(readAnalyticsConsent("cookieConsent=yes")).toBe("unset");
+  });
+});

--- a/apps/web/src/lib/analytics-consent.ts
+++ b/apps/web/src/lib/analytics-consent.ts
@@ -1,0 +1,35 @@
+// Single source of truth for the analytics-consent cookie shared by the cookie
+// banner (which writes it) and the PostHog provider (which gates init on it).
+// Analytics must never start before the visitor accepts the cookie notice, and
+// must never start at all after a decline (see the privacy policy's analytics
+// section, which promises exactly this).
+
+export const ANALYTICS_CONSENT_COOKIE = "cookieConsent";
+
+export type AnalyticsConsent = "granted" | "denied" | "unset";
+
+// Pure parser (unit-tested): reads the consent decision out of a
+// `document.cookie`-style string. Anything other than an explicit true/false
+// value — missing cookie, malformed value — is "unset", which means the banner
+// shows and analytics stays off.
+export function readAnalyticsConsent(
+  cookieString: string | null | undefined,
+): AnalyticsConsent {
+  if (!cookieString) return "unset";
+  for (const part of cookieString.split(";")) {
+    const [name, ...rest] = part.split("=");
+    if (name?.trim() !== ANALYTICS_CONSENT_COOKIE) continue;
+    const value = rest.join("=").trim();
+    if (value === "true") return "granted";
+    if (value === "false") return "denied";
+  }
+  return "unset";
+}
+
+// Persist the visitor's decision. Path=/ so a choice made on any page applies
+// site-wide; ~10 years, mirroring the previous far-future expiry.
+export function writeAnalyticsConsent(decision: "granted" | "denied") {
+  const value = decision === "granted" ? "true" : "false";
+  const maxAge = 60 * 60 * 24 * 365 * 10;
+  document.cookie = `${ANALYTICS_CONSENT_COOKIE}=${value}; path=/; max-age=${maxAge}; samesite=lax`;
+}

--- a/apps/web/src/routes/_public/privacy.tsx
+++ b/apps/web/src/routes/_public/privacy.tsx
@@ -15,8 +15,7 @@ export const Route = createFileRoute("/_public/privacy")({
 });
 
 // Privacy policy in the marketing LegalDoc layout (sticky TOC + reading
-// column). The `privacy` catalog holds real copy tailored to what JigSwap does;
-// [OWNER TO CONFIRM: …] tokens mark details only the owner can fill in.
+// column). The `privacy` catalog holds real copy tailored to what JigSwap does.
 function PrivacyPolicyPage() {
   const t = useTranslations("privacy");
   const tm = useTranslations("marketing.legal");
@@ -67,6 +66,8 @@ function PrivacyPolicyPage() {
         { type: "p", text: t("dataStorage.convex.description") },
         { type: "sub", text: t("dataStorage.clerk.title") },
         { type: "p", text: t("dataStorage.clerk.description") },
+        { type: "sub", text: t("dataStorage.vercel.title") },
+        { type: "p", text: t("dataStorage.vercel.description") },
       ],
     },
     {
@@ -152,13 +153,20 @@ function PrivacyPolicyPage() {
         sections={sections}
       >
         {t("contact.description")}{" "}
+        <a
+          href={`mailto:${t("contact.emailAddress")}`}
+          className="text-mk-violet-600 font-medium hover:underline"
+        >
+          {t("contact.emailAddress")}
+        </a>
+        . {t("contact.formNote")}{" "}
         <Link
           href="/contact"
           className="text-mk-violet-600 font-medium hover:underline"
         >
           {t("contact.linkLabel")}
         </Link>
-        . {t("contact.emailNote")}
+        .
       </LegalDoc>
     </main>
   );

--- a/apps/web/src/routes/_public/privacy.tsx
+++ b/apps/web/src/routes/_public/privacy.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { pageTitle } from "@/lib/page-title";
 
+import { Link } from "@/compat/link";
 import { LegalDoc, type LegalSection } from "@/components/marketing/legal-doc";
 import { PageHero } from "@/components/marketing/page-hero";
 import { useTranslations } from "use-intl";
@@ -14,8 +15,8 @@ export const Route = createFileRoute("/_public/privacy")({
 });
 
 // Privacy policy in the marketing LegalDoc layout (sticky TOC + reading
-// column). Content keeps the existing, substantive `privacy` catalog —
-// the design bundle shipped placeholder legal text.
+// column). The `privacy` catalog holds real copy tailored to what JigSwap does;
+// [OWNER TO CONFIRM: …] tokens mark details only the owner can fill in.
 function PrivacyPolicyPage() {
   const t = useTranslations("privacy");
   const tm = useTranslations("marketing.legal");
@@ -52,6 +53,9 @@ function PrivacyPolicyPage() {
       blocks: [
         { type: "p", text: t("howWeUseInformation.description") },
         { type: "list", items: list("howWeUseInformation.purposes") },
+        { type: "sub", text: t("howWeUseInformation.lawfulBasis.title") },
+        { type: "p", text: t("howWeUseInformation.lawfulBasis.description") },
+        { type: "list", items: list("howWeUseInformation.lawfulBasis.items") },
       ],
     },
     {
@@ -61,8 +65,16 @@ function PrivacyPolicyPage() {
         { type: "p", text: t("dataStorage.description") },
         { type: "sub", text: t("dataStorage.convex.title") },
         { type: "p", text: t("dataStorage.convex.description") },
-        { type: "sub", text: t("dataStorage.vercel.title") },
-        { type: "p", text: t("dataStorage.vercel.description") },
+        { type: "sub", text: t("dataStorage.clerk.title") },
+        { type: "p", text: t("dataStorage.clerk.description") },
+      ],
+    },
+    {
+      id: "p-photos",
+      heading: t("photos.title"),
+      blocks: [
+        { type: "p", text: t("photos.description") },
+        { type: "list", items: list("photos.steps") },
       ],
     },
     {
@@ -140,12 +152,13 @@ function PrivacyPolicyPage() {
         sections={sections}
       >
         {t("contact.description")}{" "}
-        <a
-          href={`mailto:${t("contact.emailAddress")}`}
+        <Link
+          href="/contact"
           className="text-mk-violet-600 font-medium hover:underline"
         >
-          {t("contact.emailAddress")}
-        </a>
+          {t("contact.linkLabel")}
+        </Link>
+        . {t("contact.emailNote")}
       </LegalDoc>
     </main>
   );

--- a/apps/web/src/routes/_public/terms.tsx
+++ b/apps/web/src/routes/_public/terms.tsx
@@ -15,8 +15,7 @@ export const Route = createFileRoute("/_public/terms")({
 });
 
 // Terms of service in the marketing LegalDoc layout (sticky TOC + reading
-// column). The `terms` catalog holds real copy tailored to what JigSwap does;
-// [OWNER TO CONFIRM: …] tokens mark details only the owner can fill in.
+// column). The `terms` catalog holds real copy tailored to what JigSwap does.
 function TermsOfServicePage() {
   const t = useTranslations("terms");
   const tm = useTranslations("marketing.legal");
@@ -116,13 +115,20 @@ function TermsOfServicePage() {
         sections={sections}
       >
         {t("contact.description")}{" "}
+        <a
+          href={`mailto:${t("contact.emailAddress")}`}
+          className="text-mk-violet-600 font-medium hover:underline"
+        >
+          {t("contact.emailAddress")}
+        </a>
+        . {t("contact.formNote")}{" "}
         <Link
           href="/contact"
           className="text-mk-violet-600 font-medium hover:underline"
         >
           {t("contact.linkLabel")}
         </Link>
-        . {t("contact.emailNote")}
+        .
       </LegalDoc>
     </main>
   );

--- a/apps/web/src/routes/_public/terms.tsx
+++ b/apps/web/src/routes/_public/terms.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { pageTitle } from "@/lib/page-title";
 
+import { Link } from "@/compat/link";
 import { LegalDoc, type LegalSection } from "@/components/marketing/legal-doc";
 import { PageHero } from "@/components/marketing/page-hero";
 import { useTranslations } from "use-intl";
@@ -14,8 +15,8 @@ export const Route = createFileRoute("/_public/terms")({
 });
 
 // Terms of service in the marketing LegalDoc layout (sticky TOC + reading
-// column). Content keeps the existing, substantive `terms` catalog —
-// the design bundle shipped placeholder legal text.
+// column). The `terms` catalog holds real copy tailored to what JigSwap does;
+// [OWNER TO CONFIRM: …] tokens mark details only the owner can fill in.
 function TermsOfServicePage() {
   const t = useTranslations("terms");
   const tm = useTranslations("marketing.legal");
@@ -67,7 +68,13 @@ function TermsOfServicePage() {
     {
       id: "t-ip",
       heading: t("intellectualProperty.title"),
-      blocks: [{ type: "p", text: t("intellectualProperty.description") }],
+      blocks: [
+        { type: "p", text: t("intellectualProperty.description") },
+        { type: "sub", text: t("intellectualProperty.yourContent.title") },
+        { type: "p", text: t("intellectualProperty.yourContent.description") },
+        { type: "sub", text: t("intellectualProperty.platform.title") },
+        { type: "p", text: t("intellectualProperty.platform.description") },
+      ],
     },
     {
       id: "t-privacy",
@@ -109,12 +116,13 @@ function TermsOfServicePage() {
         sections={sections}
       >
         {t("contact.description")}{" "}
-        <a
-          href={`mailto:${t("contact.emailAddress")}`}
+        <Link
+          href="/contact"
           className="text-mk-violet-600 font-medium hover:underline"
         >
-          {t("contact.emailAddress")}
-        </a>
+          {t("contact.linkLabel")}
+        </Link>
+        . {t("contact.emailNote")}
       </LegalDoc>
     </main>
   );


### PR DESCRIPTION
## Summary

Replaces the placeholder legal copy on `/terms` and `/privacy` with real Terms of Service and Privacy Policy text (EN + NL), tailored to what JigSwap actually is and does, and — per owner review — makes analytics genuinely consent-gated so the policy's claims are true in code. Every factual claim was verified against the codebase:

- **What the service is**: community puzzle catalog, personal library with photos, completions, collections, exchanges (swap/sale/loan) with messaging, circles, profiles/follows, insights.
- **Clerk** handles sign-in and core account data (EU data residency); account deletion via Clerk removes the Convex user record (`http.ts` `user.deleted` webhook → `users.deleteUser`).
- **Convex** (EU hosting) stores all app data and uploaded files; **Axiom** (EU region) receives operational logs; **Hugging Face** runs the automated photo content check.
- **Photos**: the moderation pipeline (`library/moderatePhoto.ts`) re-encodes uploads (dropping all EXIF metadata, including location) and content-screens them; pending photos are visible only to the uploader — the policy describes exactly this.
- **PostHog** is EU-hosted, reverse-proxied through `/ingest`, and now **opt-in** (see below).
- **Hosting**: Vercel named as host; the policy explains the edge network serves the site while personal data itself is stored in the EU-hosted providers.
- **GDPR**: rights named (access, rectification, erasure, portability via the Insights export, objection/restriction, complaint to the Autoriteit Persoonsgegevens), lawful bases in plain language, contact via legal@/privacy@jigswap.site plus the `/contact` form.
- **No payments**: exchanges are member-to-member; the terms say JigSwap is not a party and does not process payments.
- "Last updated" set to 2 July 2026 in both languages; EN copy mirrored into `locales/source.json` (dev/Crowdin source catalog). Minimum age is 16 (Dutch GDPR digital-consent age), approved by owner.

## Consent-gated analytics (code change)

The cookie banner previously only hid itself — PostHog initialized regardless. Now:

- New unit-tested helper `src/lib/analytics-consent.ts` is the single source of truth for the `cookieConsent` cookie (`granted` / `denied` / `unset`).
- `PostHogProvider` initializes PostHog **only** when consent is already granted; accepting the banner calls `initPostHog()` immediately (no reload); declining persists `cookieConsent=false` (site-wide `path=/`, previously missing) and PostHog is never loaded.
- `PostHogPageView` no-ops until PostHog is initialized, so declined sessions emit nothing.
- The privacy policy (EN + NL) now truthfully claims opt-in analytics.

## Owner feedback resolved

All previous `[OWNER TO CONFIRM]` tokens are resolved: operator/controller is **Sander Verkuil**; contact mailboxes restored by use-case (`legal@jigswap.site` for terms, `privacy@jigswap.site` for privacy), with the `/contact` form as a secondary route.

> **Note**: Written by an AI against the codebase and **not legal advice**; please have it reviewed before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
