### PR TITLE
fix(admin): server-side admin gating, requireAdmin, i18n admin UI, triage views

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2178,6 +2178,8 @@
     "admin": "Admin — JigSwap",
     "adminCategories": "Category management — JigSwap",
     "adminModeration": "Moderation — JigSwap",
+    "adminContact": "Contact messages — JigSwap",
+    "adminFeedback": "Docs feedback — JigSwap",
     "signIn": "Sign in — JigSwap",
     "signUp": "Sign up — JigSwap",
     "library": "My Library — JigSwap",
@@ -2557,6 +2559,74 @@
       "objects": "Objects",
       "symbols": "Symbols",
       "flags": "Flags"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "Admin Dashboard",
+      "subtitle": "Manage your application settings and content.",
+      "categories": {
+        "title": "Categories",
+        "description": "Manage puzzle categories with localization support",
+        "cta": "Manage Categories"
+      },
+      "moderation": {
+        "title": "Puzzle Moderation",
+        "description": "Review and approve or reject pending puzzle submissions",
+        "cta": "Review Submissions"
+      },
+      "contact": {
+        "title": "Contact Messages",
+        "description": "Read and triage messages sent through the contact form",
+        "cta": "View Messages"
+      },
+      "docFeedback": {
+        "title": "Docs Feedback",
+        "description": "Review “Was this page helpful?” votes from the documentation",
+        "cta": "View Feedback"
+      }
+    },
+    "moderation": {
+      "title": "Puzzle Moderation",
+      "subtitle": "Review pending submissions before they appear in the public catalog.",
+      "loading": "Loading submissions…",
+      "empty": "No pending submissions.",
+      "pending": "Pending",
+      "pieces": "{count} pieces",
+      "approve": "Approve",
+      "reject": "Reject",
+      "approveSuccess": "Puzzle approved",
+      "rejectSuccess": "Puzzle rejected",
+      "error": "Failed to update submission"
+    },
+    "contact": {
+      "title": "Contact Messages",
+      "subtitle": "Messages sent through the contact form, newest first.",
+      "loading": "Loading messages…",
+      "empty": "No contact messages yet.",
+      "statusNew": "New",
+      "statusHandled": "Handled",
+      "subject": {
+        "swap": "Lending or swapping",
+        "account": "My account",
+        "idea": "Idea or feedback",
+        "other": "Something else"
+      },
+      "markHandled": "Mark as handled",
+      "markHandledSuccess": "Message marked as handled",
+      "markHandledError": "Failed to update message"
+    },
+    "docFeedback": {
+      "title": "Docs Feedback",
+      "subtitle": "“Was this page helpful?” votes from the documentation, newest first.",
+      "loading": "Loading feedback…",
+      "empty": "No feedback yet.",
+      "helpful": "Helpful",
+      "notHelpful": "Not helpful"
+    },
+    "layout": {
+      "home": "Home",
+      "loading": "Loading admin panel…"
     }
   }
 }

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2178,6 +2178,8 @@
     "admin": "Beheer — JigSwap",
     "adminCategories": "Categoriebeheer — JigSwap",
     "adminModeration": "Moderatie — JigSwap",
+    "adminContact": "Contactberichten — JigSwap",
+    "adminFeedback": "Documentatiefeedback — JigSwap",
     "signIn": "Inloggen — JigSwap",
     "signUp": "Registreren — JigSwap",
     "library": "Mijn Bibliotheek — JigSwap",
@@ -2557,6 +2559,74 @@
       "objects": "Objecten",
       "symbols": "Symbolen",
       "flags": "Vlaggen"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "Beheerdersdashboard",
+      "subtitle": "Beheer je applicatie-instellingen en inhoud.",
+      "categories": {
+        "title": "Categorieën",
+        "description": "Beheer puzzelcategorieën met ondersteuning voor vertalingen",
+        "cta": "Categorieën beheren"
+      },
+      "moderation": {
+        "title": "Puzzelmoderatie",
+        "description": "Beoordeel ingediende puzzels en keur ze goed of af",
+        "cta": "Inzendingen beoordelen"
+      },
+      "contact": {
+        "title": "Contactberichten",
+        "description": "Lees en verwerk berichten die via het contactformulier zijn verstuurd",
+        "cta": "Berichten bekijken"
+      },
+      "docFeedback": {
+        "title": "Documentatiefeedback",
+        "description": "Bekijk “Was deze pagina nuttig?”-stemmen uit de documentatie",
+        "cta": "Feedback bekijken"
+      }
+    },
+    "moderation": {
+      "title": "Puzzelmoderatie",
+      "subtitle": "Beoordeel inzendingen voordat ze in de openbare catalogus verschijnen.",
+      "loading": "Inzendingen laden…",
+      "empty": "Geen openstaande inzendingen.",
+      "pending": "In afwachting",
+      "pieces": "{count} stukjes",
+      "approve": "Goedkeuren",
+      "reject": "Afkeuren",
+      "approveSuccess": "Puzzel goedgekeurd",
+      "rejectSuccess": "Puzzel afgekeurd",
+      "error": "Inzending bijwerken mislukt"
+    },
+    "contact": {
+      "title": "Contactberichten",
+      "subtitle": "Berichten die via het contactformulier zijn verstuurd, nieuwste eerst.",
+      "loading": "Berichten laden…",
+      "empty": "Nog geen contactberichten.",
+      "statusNew": "Nieuw",
+      "statusHandled": "Afgehandeld",
+      "subject": {
+        "swap": "Lenen of ruilen",
+        "account": "Mijn account",
+        "idea": "Idee of feedback",
+        "other": "Iets anders"
+      },
+      "markHandled": "Markeren als afgehandeld",
+      "markHandledSuccess": "Bericht gemarkeerd als afgehandeld",
+      "markHandledError": "Bericht bijwerken mislukt"
+    },
+    "docFeedback": {
+      "title": "Documentatiefeedback",
+      "subtitle": "“Was deze pagina nuttig?”-stemmen uit de documentatie, nieuwste eerst.",
+      "loading": "Feedback laden…",
+      "empty": "Nog geen feedback.",
+      "helpful": "Nuttig",
+      "notHelpful": "Niet nuttig"
+    },
+    "layout": {
+      "home": "Home",
+      "loading": "Beheerpaneel laden…"
     }
   }
 }

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2178,6 +2178,8 @@
     "admin": "Admin — JigSwap",
     "adminCategories": "Category management — JigSwap",
     "adminModeration": "Moderation — JigSwap",
+    "adminContact": "Contact messages — JigSwap",
+    "adminFeedback": "Docs feedback — JigSwap",
     "signIn": "Sign in — JigSwap",
     "signUp": "Sign up — JigSwap",
     "library": "My Library — JigSwap",
@@ -2557,6 +2559,74 @@
       "objects": "Objects",
       "symbols": "Symbols",
       "flags": "Flags"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "Admin Dashboard",
+      "subtitle": "Manage your application settings and content.",
+      "categories": {
+        "title": "Categories",
+        "description": "Manage puzzle categories with localization support",
+        "cta": "Manage Categories"
+      },
+      "moderation": {
+        "title": "Puzzle Moderation",
+        "description": "Review and approve or reject pending puzzle submissions",
+        "cta": "Review Submissions"
+      },
+      "contact": {
+        "title": "Contact Messages",
+        "description": "Read and triage messages sent through the contact form",
+        "cta": "View Messages"
+      },
+      "docFeedback": {
+        "title": "Docs Feedback",
+        "description": "Review “Was this page helpful?” votes from the documentation",
+        "cta": "View Feedback"
+      }
+    },
+    "moderation": {
+      "title": "Puzzle Moderation",
+      "subtitle": "Review pending submissions before they appear in the public catalog.",
+      "loading": "Loading submissions…",
+      "empty": "No pending submissions.",
+      "pending": "Pending",
+      "pieces": "{count} pieces",
+      "approve": "Approve",
+      "reject": "Reject",
+      "approveSuccess": "Puzzle approved",
+      "rejectSuccess": "Puzzle rejected",
+      "error": "Failed to update submission"
+    },
+    "contact": {
+      "title": "Contact Messages",
+      "subtitle": "Messages sent through the contact form, newest first.",
+      "loading": "Loading messages…",
+      "empty": "No contact messages yet.",
+      "statusNew": "New",
+      "statusHandled": "Handled",
+      "subject": {
+        "swap": "Lending or swapping",
+        "account": "My account",
+        "idea": "Idea or feedback",
+        "other": "Something else"
+      },
+      "markHandled": "Mark as handled",
+      "markHandledSuccess": "Message marked as handled",
+      "markHandledError": "Failed to update message"
+    },
+    "docFeedback": {
+      "title": "Docs Feedback",
+      "subtitle": "“Was this page helpful?” votes from the documentation, newest first.",
+      "loading": "Loading feedback…",
+      "empty": "No feedback yet.",
+      "helpful": "Helpful",
+      "notHelpful": "Not helpful"
+    },
+    "layout": {
+      "home": "Home",
+      "loading": "Loading admin panel…"
     }
   }
 }

--- a/apps/web/src/lib/require-admin.ts
+++ b/apps/web/src/lib/require-admin.ts
@@ -1,21 +1,30 @@
+import { gateway } from "@/gateway";
 import { auth } from "@clerk/tanstack-react-start/server";
 import { redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import { ConvexHttpClient } from "convex/browser";
 
-// Server-only: reads the Clerk session and reports whether the caller is an admin
-// (publicMetadata.role === "admin" surfaced as sessionClaims.metadata.role). Runs
-// in the admin route's beforeLoad so the role check happens before any chrome renders.
+// Server-only: resolves the caller's admin status from the BACKEND's identity
+// context (gateway.identity.isAdmin -> convex identity/isCurrentUserAdmin), so
+// the route guard and the server-side gates on every admin function share one
+// source of truth. The Convex query reads the role from the Clerk "convex" JWT
+// and fails closed: no session, no token, or a missing claim is NOT admin.
 const fetchAdminStatus = createServerFn({ method: "GET" }).handler(async () => {
-  const { userId, sessionClaims } = await auth();
-  return {
-    userId,
-    isAdmin: sessionClaims?.metadata?.role === "admin",
-  };
+  const { userId, getToken } = await auth();
+  if (!userId) return { userId: null, isAdmin: false };
+  const token = await getToken({ template: "convex" });
+  if (!token) return { userId, isAdmin: false };
+  const convex = new ConvexHttpClient(
+    import.meta.env.VITE_CONVEX_URL as string,
+  );
+  convex.setAuth(token);
+  return { userId, isAdmin: await convex.query(gateway.identity.isAdmin, {}) };
 });
 
-// beforeLoad guard for the /admin routes: the Next layout did auth()+redirect, with
-// a TODO for the role check. Here we require both an authenticated user (-> Clerk
-// sign-in) and the admin role (-> home for non-admins).
+// beforeLoad guard for the /admin routes: require both an authenticated user
+// (-> Clerk sign-in) and the backend-confirmed admin role (-> home for
+// non-admins). Cosmetic only — every admin Convex function re-checks isAdmin
+// server-side regardless of how the route was reached.
 export async function requireAdmin(opts: { location: { href: string } }) {
   const { userId, isAdmin } = await fetchAdminStatus();
   if (!userId) {

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -18,20 +18,28 @@ import {
 } from "@/components/ui/sidebar";
 import { requireAdmin } from "@/lib/require-admin";
 import { Home } from "lucide-react";
+import { useTranslations } from "use-intl";
 
-// Path layout for /admin. The Next admin layout was an async server component doing
-// auth()+redirect with a TODO admin check; that becomes a beforeLoad (requireAdmin:
-// authenticated AND publicMetadata.role === "admin"). Renders the admin sidebar chrome
-// + Outlet; children are routes/admin/{index,categories,moderation}.tsx.
+// Path layout for /admin. beforeLoad (requireAdmin) requires an authenticated user AND
+// the backend-confirmed admin role (gateway.identity.isAdmin); non-admins are redirected.
+// The guard is cosmetic — every admin Convex function re-checks isAdmin server-side.
+// Renders the admin sidebar chrome + Outlet; children are
+// routes/admin/{index,categories,moderation,contact,feedback}.tsx.
 export const Route = createFileRoute("/admin")({
   beforeLoad: ({ location }) => requireAdmin({ location }),
-  pendingComponent: () => <PageLoading message="Loading admin panel..." />,
+  pendingComponent: AdminPending,
   // 404 inside /admin renders within the admin shell (this layout's Outlet).
   notFoundComponent: AdminNotFound,
   component: AdminLayout,
 });
 
+function AdminPending() {
+  const t = useTranslations("admin.layout");
+  return <PageLoading message={t("loading")} />;
+}
+
 function AdminLayout() {
+  const t = useTranslations("admin.layout");
   return (
     <div className="min-h-screen bg-background">
       <SidebarProvider>
@@ -47,7 +55,7 @@ function AdminLayout() {
                 <SidebarMenuButton asChild>
                   <Link href="/dashboard">
                     <Home />
-                    Home
+                    {t("home")}
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/apps/web/src/routes/admin/contact.tsx
+++ b/apps/web/src/routes/admin/contact.tsx
@@ -1,0 +1,119 @@
+import { pageTitle } from "@/lib/page-title";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PageLoading } from "@/components/ui/loading";
+import type { Id } from "@/gateway";
+import { gateway } from "@/gateway";
+import { useMutation, useQuery } from "convex/react";
+import { Check } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useFormatter, useTranslations } from "use-intl";
+
+export const Route = createFileRoute("/admin/contact")({
+  head: ({ match }) => ({
+    meta: [{ title: pageTitle(match.context, "adminContact") }],
+  }),
+  component: ContactTriagePage,
+});
+
+// Admin triage inbox for the public contact form: every message newest first,
+// with a single "mark as handled" transition (new -> handled). The listing and
+// the transition are admin-gated server-side in the Convex functions.
+function ContactTriagePage() {
+  const t = useTranslations("admin.contact");
+  const format = useFormatter();
+  const messages = useQuery(gateway.adminTriage.contactMessages);
+  const markHandled = useMutation(gateway.adminTriage.markContactHandled);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const handle = async (id: Id<"contactMessages">) => {
+    setBusyId(id);
+    try {
+      await markHandled({ id });
+      toast.success(t("markHandledSuccess"));
+    } catch {
+      toast.error(t("markHandledError"));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (messages === undefined) {
+    return <PageLoading message={t("loading")} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
+        <p className="text-muted-foreground mt-2">{t("subtitle")}</p>
+      </div>
+
+      {messages.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            {t("empty")}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {messages.map((message) => (
+            <Card key={message._id}>
+              <CardHeader>
+                <div className="flex items-center justify-between gap-2">
+                  <CardTitle>{message.name}</CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">
+                      {t(`subject.${message.subject}`)}
+                    </Badge>
+                    {message.status === "new" ? (
+                      <Badge variant="default">{t("statusNew")}</Badge>
+                    ) : (
+                      <Badge variant="secondary">{t("statusHandled")}</Badge>
+                    )}
+                  </div>
+                </div>
+                <CardDescription>
+                  <a href={`mailto:${message.email}`} className="underline">
+                    {message.email}
+                  </a>
+                  {" • "}
+                  {format.dateTime(new Date(message.createdAt), {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                  {message.locale && ` • ${message.locale}`}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm whitespace-pre-wrap">{message.message}</p>
+                {message.status === "new" && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handle(message._id)}
+                    disabled={busyId === message._id}
+                    className="flex items-center gap-1"
+                  >
+                    <Check className="h-3 w-3" />
+                    {t("markHandled")}
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin/feedback.tsx
+++ b/apps/web/src/routes/admin/feedback.tsx
@@ -1,0 +1,93 @@
+import { pageTitle } from "@/lib/page-title";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PageLoading } from "@/components/ui/loading";
+import { gateway } from "@/gateway";
+import { useQuery } from "convex/react";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
+
+export const Route = createFileRoute("/admin/feedback")({
+  head: ({ match }) => ({
+    meta: [{ title: pageTitle(match.context, "adminFeedback") }],
+  }),
+  component: DocFeedbackPage,
+});
+
+// Admin triage view for the public /docs "Was this page helpful?" votes,
+// newest first. Read-only; the listing is admin-gated server-side.
+function DocFeedbackPage() {
+  const t = useTranslations("admin.docFeedback");
+  const format = useFormatter();
+  const feedback = useQuery(gateway.adminTriage.docFeedback);
+
+  if (feedback === undefined) {
+    return <PageLoading message={t("loading")} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
+        <p className="text-muted-foreground mt-2">{t("subtitle")}</p>
+      </div>
+
+      {feedback.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            {t("empty")}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {feedback.map((entry) => (
+            <Card key={entry._id}>
+              <CardHeader>
+                <div className="flex items-center justify-between gap-2">
+                  <CardTitle className="text-base">{entry.slug}</CardTitle>
+                  {entry.helpful ? (
+                    <Badge
+                      variant="default"
+                      className="flex items-center gap-1"
+                    >
+                      <ThumbsUp className="h-3 w-3" />
+                      {t("helpful")}
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="secondary"
+                      className="flex items-center gap-1"
+                    >
+                      <ThumbsDown className="h-3 w-3" />
+                      {t("notHelpful")}
+                    </Badge>
+                  )}
+                </div>
+                <CardDescription>
+                  {format.dateTime(new Date(entry.createdAt), {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                  {entry.locale && ` • ${entry.locale}`}
+                </CardDescription>
+              </CardHeader>
+              {entry.comment && (
+                <CardContent>
+                  <p className="text-sm whitespace-pre-wrap">{entry.comment}</p>
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin/index.tsx
+++ b/apps/web/src/routes/admin/index.tsx
@@ -1,7 +1,9 @@
 import { pageTitle } from "@/lib/page-title";
 import { createFileRoute } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
 
 import { Link } from "@/compat/link";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -17,52 +19,41 @@ export const Route = createFileRoute("/admin/")({
   component: AdminDashboardPage,
 });
 
+// The admin landing page: one card per admin surface (categories, moderation,
+// contact triage, docs feedback), each linking into its section.
+const SECTIONS = [
+  { key: "categories", href: "/admin/categories" },
+  { key: "moderation", href: "/admin/moderation" },
+  { key: "contact", href: "/admin/contact" },
+  { key: "docFeedback", href: "/admin/feedback" },
+] as const;
+
 function AdminDashboardPage() {
+  const t = useTranslations("admin.dashboard");
+
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-foreground">Admin Dashboard</h1>
-        <p className="text-muted-foreground mt-2">
-          Manage your application settings and content.
-        </p>
+        <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
+        <p className="text-muted-foreground mt-2">{t("subtitle")}</p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Categories</CardTitle>
-            <CardDescription>
-              Manage puzzle categories with localization support
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link
-              href="/admin/categories"
-              className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Manage Categories
-            </Link>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Puzzle Moderation</CardTitle>
-            <CardDescription>
-              Review and approve or reject pending puzzle submissions
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link
-              href="/admin/moderation"
-              className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Review Submissions
-            </Link>
-          </CardContent>
-        </Card>
-
-        {/* Add more admin cards here as needed */}
+        {SECTIONS.map((section) => (
+          <Card key={section.key}>
+            <CardHeader>
+              <CardTitle>{t(`${section.key}.title`)}</CardTitle>
+              <CardDescription>
+                {t(`${section.key}.description`)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild>
+                <Link href={section.href}>{t(`${section.key}.cta`)}</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/routes/admin/moderation.tsx
+++ b/apps/web/src/routes/admin/moderation.tsx
@@ -16,6 +16,7 @@ import { useMutation, useQuery } from "convex/react";
 import { Check, X } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { useTranslations } from "use-intl";
 
 export const Route = createFileRoute("/admin/moderation")({
   head: ({ match }) => ({
@@ -27,6 +28,7 @@ export const Route = createFileRoute("/admin/moderation")({
 // Minimal moderation queue: list pending puzzle submissions with approve/reject, wired to the
 // domain-driven catalog mutations. Submissions become public only once approved.
 function ModerationPage() {
+  const t = useTranslations("admin.moderation");
   const pending = useQuery(gateway.catalog.pending);
   const approve = useMutation(gateway.catalog.approve);
   const reject = useMutation(gateway.catalog.reject);
@@ -43,34 +45,30 @@ function ModerationPage() {
       const run = action === "approve" ? approve : reject;
       await run({ puzzleDefinitionId: aggregateId });
       toast.success(
-        action === "approve" ? "Puzzle approved" : "Puzzle rejected",
+        action === "approve" ? t("approveSuccess") : t("rejectSuccess"),
       );
     } catch {
-      toast.error("Failed to update submission");
+      toast.error(t("error"));
     } finally {
       setBusyId(null);
     }
   };
 
   if (pending === undefined) {
-    return <PageLoading message="Loading submissions..." />;
+    return <PageLoading message={t("loading")} />;
   }
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-foreground">
-          Puzzle Moderation
-        </h1>
-        <p className="text-muted-foreground mt-2">
-          Review pending submissions before they appear in the public catalog.
-        </p>
+        <h1 className="text-3xl font-bold text-foreground">{t("title")}</h1>
+        <p className="text-muted-foreground mt-2">{t("subtitle")}</p>
       </div>
 
       {pending.length === 0 ? (
         <Card>
           <CardContent className="py-10 text-center text-muted-foreground">
-            No pending submissions.
+            {t("empty")}
           </CardContent>
         </Card>
       ) : (
@@ -80,11 +78,11 @@ function ModerationPage() {
               <CardHeader>
                 <div className="flex items-center justify-between gap-2">
                   <CardTitle>{puzzle.title}</CardTitle>
-                  <Badge variant="secondary">Pending</Badge>
+                  <Badge variant="secondary">{t("pending")}</Badge>
                 </div>
                 <CardDescription>
                   {puzzle.brand && `${puzzle.brand} • `}
-                  {puzzle.pieceCount} pieces
+                  {t("pieces", { count: puzzle.pieceCount })}
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -111,7 +109,7 @@ function ModerationPage() {
                     className="flex items-center gap-1"
                   >
                     <Check className="h-3 w-3" />
-                    Approve
+                    {t("approve")}
                   </Button>
                   <Button
                     size="sm"
@@ -120,10 +118,10 @@ function ModerationPage() {
                     disabled={
                       !puzzle.aggregateId || busyId === puzzle.aggregateId
                     }
-                    className="flex items-center gap-1 text-red-600 hover:text-red-700"
+                    className="flex items-center gap-1 text-destructive hover:text-destructive"
                   >
                     <X className="h-3 w-3" />
-                    Reject
+                    {t("reject")}
                   </Button>
                 </div>
               </CardContent>

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -45,9 +45,12 @@ import type * as catalog_setCatalogCategoryActive from "../catalog/setCatalogCat
 import type * as catalog_submitPuzzleDefinition from "../catalog/submitPuzzleDefinition.js";
 import type * as catalog_updateCatalogCategory from "../catalog/updateCatalogCategory.js";
 import type * as catalog_updatePuzzleDefinition from "../catalog/updatePuzzleDefinition.js";
+import type * as contact_listContactMessages from "../contact/listContactMessages.js";
+import type * as contact_markContactMessageHandled from "../contact/markContactMessageHandled.js";
 import type * as contact_submitContactMessage from "../contact/submitContactMessage.js";
 import type * as custody_getCopyCustodyTimeline from "../custody/getCopyCustodyTimeline.js";
 import type * as custody_subscriber from "../custody/subscriber.js";
+import type * as docs_listDocFeedback from "../docs/listDocFeedback.js";
 import type * as docs_submitDocFeedback from "../docs/submitDocFeedback.js";
 import type * as events_dispatch from "../events/dispatch.js";
 import type * as events_makeEventPublisher from "../events/makeEventPublisher.js";
@@ -81,6 +84,7 @@ import type * as identity_getUserByClerkId from "../identity/getUserByClerkId.js
 import type * as identity_getUserById from "../identity/getUserById.js";
 import type * as identity_getUserStats from "../identity/getUserStats.js";
 import type * as identity_isAdmin from "../identity/isAdmin.js";
+import type * as identity_isCurrentUserAdmin from "../identity/isCurrentUserAdmin.js";
 import type * as identity_requireMember from "../identity/requireMember.js";
 import type * as identity_searchUsers from "../identity/searchUsers.js";
 import type * as identity_toMemberView from "../identity/toMemberView.js";
@@ -298,9 +302,12 @@ declare const fullApi: ApiFromModules<{
   "catalog/submitPuzzleDefinition": typeof catalog_submitPuzzleDefinition;
   "catalog/updateCatalogCategory": typeof catalog_updateCatalogCategory;
   "catalog/updatePuzzleDefinition": typeof catalog_updatePuzzleDefinition;
+  "contact/listContactMessages": typeof contact_listContactMessages;
+  "contact/markContactMessageHandled": typeof contact_markContactMessageHandled;
   "contact/submitContactMessage": typeof contact_submitContactMessage;
   "custody/getCopyCustodyTimeline": typeof custody_getCopyCustodyTimeline;
   "custody/subscriber": typeof custody_subscriber;
+  "docs/listDocFeedback": typeof docs_listDocFeedback;
   "docs/submitDocFeedback": typeof docs_submitDocFeedback;
   "events/dispatch": typeof events_dispatch;
   "events/makeEventPublisher": typeof events_makeEventPublisher;
@@ -334,6 +341,7 @@ declare const fullApi: ApiFromModules<{
   "identity/getUserById": typeof identity_getUserById;
   "identity/getUserStats": typeof identity_getUserStats;
   "identity/isAdmin": typeof identity_isAdmin;
+  "identity/isCurrentUserAdmin": typeof identity_isCurrentUserAdmin;
   "identity/requireMember": typeof identity_requireMember;
   "identity/searchUsers": typeof identity_searchUsers;
   "identity/toMemberView": typeof identity_toMemberView;

--- a/packages/backend/convex/adminTriage.test.ts
+++ b/packages/backend/convex/adminTriage.test.ts
@@ -1,0 +1,171 @@
+import { convexTest } from "convex-test";
+import { ConvexError } from "convex/values";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    await ctx.db.insert("users", {
+      clerkId: "clerk_alice",
+      email: "alice@example.com",
+      name: "Alice",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const older = await ctx.db.insert("contactMessages", {
+      name: "Mara",
+      email: "mara@example.com",
+      subject: "swap",
+      message: "I'd love to swap my 1000-piece forest puzzle.",
+      status: "new",
+      createdAt: now - 1000,
+    });
+    const newer = await ctx.db.insert("contactMessages", {
+      name: "Tom",
+      email: "tom@example.com",
+      subject: "account",
+      message: "I cannot change my profile picture, please help.",
+      status: "handled",
+      createdAt: now,
+    });
+    await ctx.db.insert("docFeedback", {
+      slug: "getting-started",
+      helpful: true,
+      comment: "Very clear, thanks!",
+      locale: "en",
+      createdAt: now,
+    });
+    return { older, newer };
+  });
+
+const asMember = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+const asAdmin = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice", metadata: { role: "admin" } });
+
+describe("contact/listContactMessages", () => {
+  test("rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      t.query(api.contact.listContactMessages.listContactMessages, {}),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
+  test("rejects a non-admin member", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      asMember(t).query(
+        api.contact.listContactMessages.listContactMessages,
+        {},
+      ),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("returns every message, newest first, for an admin", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const rows = await asAdmin(t).query(
+      api.contact.listContactMessages.listContactMessages,
+      {},
+    );
+    expect(rows.map((r) => r.name)).toEqual(["Tom", "Mara"]);
+    expect(rows.map((r) => r.status)).toEqual(["handled", "new"]);
+  });
+});
+
+describe("contact/markContactMessageHandled", () => {
+  test("rejects a non-admin member", async () => {
+    const t = convexTest(schema, modules);
+    const { older } = await seed(t);
+    await expect(
+      asMember(t).mutation(
+        api.contact.markContactMessageHandled.markContactMessageHandled,
+        { id: older },
+      ),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("marks a new message handled for an admin", async () => {
+    const t = convexTest(schema, modules);
+    const { older } = await seed(t);
+    await asAdmin(t).mutation(
+      api.contact.markContactMessageHandled.markContactMessageHandled,
+      { id: older },
+    );
+    const row = await t.run((ctx) => ctx.db.get(older));
+    expect(row?.status).toBe("handled");
+  });
+});
+
+describe("docs/listDocFeedback", () => {
+  test("rejects an unauthenticated caller", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      t.query(api.docs.listDocFeedback.listDocFeedback, {}),
+    ).rejects.toBeInstanceOf(ConvexError);
+  });
+
+  test("rejects a non-admin member", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      asMember(t).query(api.docs.listDocFeedback.listDocFeedback, {}),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("returns the feedback entries for an admin", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const rows = await asAdmin(t).query(
+      api.docs.listDocFeedback.listDocFeedback,
+      {},
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      slug: "getting-started",
+      helpful: true,
+      comment: "Very clear, thanks!",
+    });
+  });
+});
+
+describe("identity/isCurrentUserAdmin", () => {
+  test("false for an unauthenticated caller (fails closed)", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    expect(
+      await t.query(api.identity.isCurrentUserAdmin.isCurrentUserAdmin, {}),
+    ).toBe(false);
+  });
+
+  test("false for a member without the admin role", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    expect(
+      await asMember(t).query(
+        api.identity.isCurrentUserAdmin.isCurrentUserAdmin,
+        {},
+      ),
+    ).toBe(false);
+  });
+
+  test("true for an admin (metadata.role claim)", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    expect(
+      await asAdmin(t).query(
+        api.identity.isCurrentUserAdmin.isCurrentUserAdmin,
+        {},
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/backend/convex/catalogMutations.test.ts
+++ b/packages/backend/convex/catalogMutations.test.ts
@@ -200,6 +200,32 @@ const submitPending = async (t: ReturnType<typeof convexTest>) => {
 };
 
 describe("catalog moderation lifecycle", () => {
+  // Authz audit: moderation is admin-only server-side; a plain member (route
+  // guards aside) must be rejected before any state transition happens.
+  test("approve rejects a non-admin member (Forbidden)", async () => {
+    const t = convexTest(schema, modules);
+    const id = await submitPending(t);
+    await expect(
+      asAlice(t).mutation(
+        api.catalog.approvePuzzleDefinition.approvePuzzleDefinition,
+        { puzzleDefinitionId: id },
+      ),
+    ).rejects.toThrow(/Forbidden/);
+    expect((await puzzleRow(t, id))?.status).toBe("pending");
+  });
+
+  test("reject rejects a non-admin member (Forbidden)", async () => {
+    const t = convexTest(schema, modules);
+    const id = await submitPending(t);
+    await expect(
+      asAlice(t).mutation(
+        api.catalog.rejectPuzzleDefinition.rejectPuzzleDefinition,
+        { puzzleDefinitionId: id },
+      ),
+    ).rejects.toThrow(/Forbidden/);
+    expect((await puzzleRow(t, id))?.status).toBe("pending");
+  });
+
   test("approve moves pending -> approved", async () => {
     const t = convexTest(schema, modules);
     const id = await submitPending(t);
@@ -305,6 +331,18 @@ describe("catalog category management", () => {
       api.catalog.createCatalogCategory.createCatalogCategory,
       { name, sortOrder },
     )) as string;
+
+  // Authz audit: taxonomy writes are admin-only server-side.
+  test("create rejects a non-admin member (Forbidden)", async () => {
+    const t = convexTest(schema, modules);
+    await seedMember(t);
+    await expect(
+      asAlice(t).mutation(
+        api.catalog.createCatalogCategory.createCatalogCategory,
+        { name: NAME, sortOrder: 0 },
+      ),
+    ).rejects.toThrow(/Forbidden/);
+  });
 
   test("create starts active with the given sortOrder", async () => {
     const t = convexTest(schema, modules);

--- a/packages/backend/convex/contact/listContactMessages.ts
+++ b/packages/backend/convex/contact/listContactMessages.ts
@@ -1,0 +1,16 @@
+import { ConvexError } from "convex/values";
+import { query } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
+import { requireMember } from "../identity/requireMember";
+
+// Admin triage read for the marketing contact form inbox: every message,
+// newest first. Admin-only (requireMember + isAdmin), like the sibling
+// catalog admin reads — the table holds visitor names/emails.
+export const listContactMessages = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
+    return await ctx.db.query("contactMessages").order("desc").collect();
+  },
+});

--- a/packages/backend/convex/contact/markContactMessageHandled.ts
+++ b/packages/backend/convex/contact/markContactMessageHandled.ts
@@ -1,0 +1,17 @@
+import { ConvexError, v } from "convex/values";
+import { mutation } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
+import { requireMember } from "../identity/requireMember";
+
+// Admin triage write: mark a contact-form message as handled (the only status
+// transition — new -> handled). Admin-only, mirroring listContactMessages.
+export const markContactMessageHandled = mutation({
+  args: { id: v.id("contactMessages") },
+  handler: async (ctx, args) => {
+    await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
+    const message = await ctx.db.get(args.id);
+    if (!message) throw new ConvexError({ code: "message_not_found" });
+    await ctx.db.patch(args.id, { status: "handled" });
+  },
+});

--- a/packages/backend/convex/docs/listDocFeedback.ts
+++ b/packages/backend/convex/docs/listDocFeedback.ts
@@ -1,0 +1,16 @@
+import { ConvexError } from "convex/values";
+import { query } from "../_generated/server";
+import { isAdmin } from "../identity/isAdmin";
+import { requireMember } from "../identity/requireMember";
+
+// Admin triage read for the public /docs "Was this page helpful?" votes:
+// every entry, newest first. Admin-only (requireMember + isAdmin), like the
+// sibling contact-message triage read.
+export const listDocFeedback = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireMember(ctx);
+    if (!(await isAdmin(ctx))) throw new ConvexError("Forbidden");
+    return await ctx.db.query("docFeedback").order("desc").collect();
+  },
+});

--- a/packages/backend/convex/identity/isCurrentUserAdmin.ts
+++ b/packages/backend/convex/identity/isCurrentUserAdmin.ts
@@ -1,0 +1,11 @@
+import { query } from "../_generated/server";
+import { isAdmin } from "./isAdmin";
+
+// Whether the acting caller is an admin, exposed as a public query so the web
+// tier's /admin route guard can ask the backend (the single authz source of
+// truth) instead of re-deriving the role from Clerk session claims. Reuses the
+// isAdmin helper, so it fails CLOSED: unauthenticated or missing claim => false.
+export const isCurrentUserAdmin = query({
+  args: {},
+  handler: async (ctx) => isAdmin(ctx),
+});

--- a/packages/gateway/src/operations.ts
+++ b/packages/gateway/src/operations.ts
@@ -150,6 +150,9 @@ export const gateway = {
     updateProfile: api.users.updateUserProfile,
     userStats: api.identity.getUserStats.getUserStats,
     search: api.identity.searchUsers.searchUsers,
+    // Whether the acting caller is an admin (fails closed). Backs the web /admin
+    // route guard; the server-side gate on every admin function stays authoritative.
+    isAdmin: api.identity.isCurrentUserAdmin.isCurrentUserAdmin,
   },
 
   // Solving: solve tracking, puzzle reviews, goals. Ownership / 24h edit window / rating are
@@ -287,6 +290,16 @@ export const gateway = {
   // Collections. Empty/short terms and unauthenticated callers return empty groups.
   search: {
     global: api.search.globalSearch.global,
+  },
+
+  // Admin triage: the operational/support inboxes written by the public contact
+  // form and docs-feedback widget. Reads and the handled-transition are admin-only
+  // (enforced server-side in the Convex functions).
+  adminTriage: {
+    contactMessages: api.contact.listContactMessages.listContactMessages,
+    markContactHandled:
+      api.contact.markContactMessageHandled.markContactMessageHandled,
+    docFeedback: api.docs.listDocFeedback.listDocFeedback,
   },
 
   // Catalog moderation: the global, moderated category taxonomy (admin). Writes go through the


### PR DESCRIPTION
## Summary

Track B: close the admin gap.

1. **Server-side isAdmin audit** of every admin-facing Convex function (table below). Result: **no unguarded functions found** — every admin surface already enforces `requireMember` + `isAdmin` server-side. Added audit-hardening tests asserting a non-admin member is rejected (`Forbidden`) by the moderation and taxonomy mutations, which previously had no negative authz tests.
2. **requireAdmin finished**: the `/admin` route guard now resolves the role from the backend (`gateway.identity.isAdmin` → new `identity/isCurrentUserAdmin` query, fail-closed) via an authed `ConvexHttpClient` in the server fn, instead of re-deriving it from Clerk session claims. Non-admins are redirected home; unauthenticated users to sign-in. The guard stays cosmetic — every admin function re-checks `isAdmin` server-side.
3. **Admin UI to i18n + design system**: `/admin` dashboard and `/admin/moderation` strings moved to the locale files (`en.json`, `nl.json`, `source.json` — kept in sync, 1839 → 1887 keys each); raw `bg-blue-600` links replaced with the design-system `Button`, raw red reject styling replaced with the `destructive` token. (`/admin/categories` still has hard-coded strings — out of scope here, noted as follow-up.)
4. **Contact + doc-feedback triage**: new admin-gated Convex reads for the write-only `contactMessages` and `docFeedback` tables plus a `markContactMessageHandled` mutation (`new` → `handled`), exposed through the gateway as `adminTriage.*`, with two new fully-i18n'd admin pages `/admin/contact` and `/admin/feedback` linked from the admin dashboard.

`_generated/api.d.ts` is hand-edited to register the new function modules (no deployment available for codegen in the worktree); a later `convex dev` regenerates it identically.

## Audit: admin-facing Convex functions

| Function | Kind | Server-side gate | Verdict |
|---|---|---|---|
| `adminCategories.getAllAdminCategories` | query | `requireMember` + `isAdmin` | OK (already gated) |
| `adminCategories.getAdminCategoryById` | query | `requireMember` + `isAdmin` | OK (already gated) |
| `adminCategories.getActiveAdminCategories` | query | public by design (marketing/public taxonomy read, active rows only) | OK |
| `catalog/createCatalogCategory` | mutation | `requireMember` + `isAdmin` | OK (already gated; non-admin test added) |
| `catalog/updateCatalogCategory` | mutation | `requireMember` + `isAdmin` | OK (already gated) |
| `catalog/reorderCatalogCategories` | mutation | `requireMember` + `isAdmin` | OK (already gated) |
| `catalog/setCatalogCategoryActive` | mutation | `requireMember` + `isAdmin` | OK (already gated) |
| `catalog/approvePuzzleDefinition` | mutation | `requireMember` + `isAdmin` | OK (already gated; non-admin test added) |
| `catalog/rejectPuzzleDefinition` | mutation | `requireMember` + `isAdmin` | OK (already gated; non-admin test added) |
| `catalog/listPendingPuzzleDefinitions` | query | `requireMember` + `isAdmin` | OK (already gated) |
| `library/moderatePhoto` | internalAction | not client-callable | OK |
| `identity/isCurrentUserAdmin` | query (new) | fail-closed boolean, leaks nothing | OK |
| `contact/listContactMessages` | query (new) | `requireMember` + `isAdmin` | added |
| `contact/markContactMessageHandled` | mutation (new) | `requireMember` + `isAdmin` | added |
| `docs/listDocFeedback` | query (new) | `requireMember` + `isAdmin` | added |

`isAdmin` itself fails closed (unauthenticated / missing `metadata.role` claim ⇒ not admin), so a misconfigured Clerk JWT template can never over-grant.

## Test plan

- [x] `packages/backend/convex/adminTriage.test.ts` (new): unauthenticated and non-admin callers rejected for all three triage functions; admin list order + handled transition; `isCurrentUserAdmin` false/false/true for anon/member/admin.
- [x] `catalogMutations.test.ts`: non-admin `Forbidden` for approve/reject (state stays `pending`) and `createCatalogCategory`.
- [x] `pnpm run format:check` — clean.
- [x] `pnpm exec nx build @jigswap/web --skip-nx-cache` — passes (prerender 0 pages is the known no-env behaviour), regenerating `routeTree.gen.ts` with the new admin routes.
- [x] `pnpm exec nx run-many -t lint type-check test arch-check --parallel=4 --skip-nx-cache` — all 5 projects green (only pre-existing `no-img-element` lint warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)