### PR TITLE
refactor(web): route all Convex data access through TanStack Query

### DIFF
--- a/apps/web/src/components/admin/category-dialog.tsx
+++ b/apps/web/src/components/admin/category-dialog.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-// Create/edit dialog for admin catalog categories (the edit-approve-dialog
-// pattern: RHF + zod, re-seeded every time the dialog opens). The route owns
-// when the dialog is open and for which category; the dialog owns the
+// Create/edit dialog for admin catalog categories (RHF + zod). All per-open
+// form state lives in CategoryForm inside DialogContent — Radix unmounts
+// closed content, so every open mounts it fresh and the useState/useForm
+// initializers seed it (no reseed effect needed). The route owns when the
+// dialog is open and for which category; the dialog owns the
 // create/update mutations. sortOrder is not a form field — a new category is
 // appended at the end of the list (nextSortOrder) and order is managed by
 // drag-reorder in the list; activation is a row-level action there too.
@@ -40,15 +42,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { gateway } from "@/gateway";
+import { useConvexMutation } from "@convex-dev/react-query";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "convex/react";
+import { useMutation } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
-import {
-  useForm,
-  useWatch,
-  type FieldErrors,
-  type UseFormReturn,
-} from "react-hook-form";
+import { useForm, useWatch, type FieldErrors } from "react-hook-form";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
 import { z } from "zod";
@@ -89,44 +87,18 @@ export function CategoryDialog({
 }) {
   const t = useTranslations("admin.categories.form");
   const tCommon = useTranslations("common");
-  const createCategory = useMutation(gateway.adminCatalog.create);
-  const updateCategory = useMutation(gateway.adminCatalog.update);
-  const [busy, setBusy] = useState(false);
-  // Name-derived color stops once the picker is used; editing an existing
-  // category counts as touched so a stored color is never overwritten.
-  const [colorTouched, setColorTouched] = useState(Boolean(category));
-
-  const schema = useMemo(
-    () =>
-      z.object({
-        name: z.object({
-          en: z.string().min(1, t("nameRequired")),
-          nl: z.string().min(1, t("nameRequired")),
-        }),
-        description: z.object({ en: z.string(), nl: z.string() }),
-        color: z.string(),
-      }),
-    [t],
-  );
-
-  const form = useForm<CategoryFormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: toDefaults(category),
+  const createCategory = useMutation({
+    mutationFn: useConvexMutation(gateway.adminCatalog.create),
   });
-
-  // Re-seed when the dialog opens for a (possibly different) category.
-  useEffect(() => {
-    if (open) {
-      form.reset(toDefaults(category));
-      setColorTouched(Boolean(category));
-    }
-  }, [open, category, form]);
+  const updateCategory = useMutation({
+    mutationFn: useConvexMutation(gateway.adminCatalog.update),
+  });
+  const busy = createCategory.isPending || updateCategory.isPending;
 
   const onSubmit = async (values: CategoryFormValues) => {
-    setBusy(true);
     try {
       if (category?.aggregateId) {
-        await updateCategory({
+        await updateCategory.mutateAsync({
           catalogCategoryId: category.aggregateId,
           name: values.name,
           description: nonEmptyDescription(values.description),
@@ -134,7 +106,7 @@ export function CategoryDialog({
         });
         toast.success(t("updateSuccess"));
       } else {
-        await createCategory({
+        await createCategory.mutateAsync({
           name: values.name,
           sortOrder: nextSortOrder,
           description: nonEmptyDescription(values.description),
@@ -145,8 +117,6 @@ export function CategoryDialog({
       onOpenChange(false);
     } catch {
       toast.error(t("saveError"));
-    } finally {
-      setBusy(false);
     }
   };
 
@@ -176,10 +146,8 @@ export function CategoryDialog({
         </DialogHeader>
         <TranslatableFieldsProvider>
           <CategoryForm
-            form={form}
+            category={category}
             onSubmit={onSubmit}
-            colorTouched={colorTouched}
-            onColorTouched={() => setColorTouched(true)}
             initialFocusRef={initialFocusRef}
           />
         </TranslatableFieldsProvider>
@@ -202,23 +170,43 @@ export function CategoryDialog({
 }
 
 // The form body lives under the TranslatableFieldsProvider so it can drive the
-// synced locale toggle (onInvalid auto-switch below).
+// synced locale toggle (onInvalid auto-switch below). It mounts fresh on every
+// dialog open (Radix unmounts closed content), so the initializers below seed
+// the per-open state.
 function CategoryForm({
-  form,
+  category,
   onSubmit,
-  colorTouched,
-  onColorTouched,
   initialFocusRef,
 }: {
-  form: UseFormReturn<CategoryFormValues>;
+  category?: Category;
   onSubmit: (values: CategoryFormValues) => Promise<void>;
-  colorTouched: boolean;
-  onColorTouched: () => void;
   // Written here, called by DialogContent's onOpenAutoFocus above.
   initialFocusRef: RefObject<(() => void) | null>;
 }) {
   const t = useTranslations("admin.categories.form");
   const { locales, activeLocale, setActiveLocale } = useTranslatableFields();
+
+  // Name-derived color stops once the picker is used; editing an existing
+  // category counts as touched so a stored color is never overwritten.
+  const [colorTouched, setColorTouched] = useState(() => Boolean(category));
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        name: z.object({
+          en: z.string().min(1, t("nameRequired")),
+          nl: z.string().min(1, t("nameRequired")),
+        }),
+        description: z.object({ en: z.string(), nl: z.string() }),
+        color: z.string(),
+      }),
+    [t],
+  );
+
+  const form = useForm<CategoryFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: toDefaults(category),
+  });
 
   // Keep the dialog's open-focus callback pointed at the visible name input.
   // This effect runs before Radix's autofocus effect (child effects run before
@@ -286,7 +274,7 @@ function CategoryForm({
                 <ColorPicker
                   value={field.value}
                   onChange={(color) => {
-                    onColorTouched();
+                    setColorTouched(true);
                     field.onChange(color);
                   }}
                   badge={

--- a/apps/web/src/components/admin/category-list.tsx
+++ b/apps/web/src/components/admin/category-list.tsx
@@ -107,7 +107,11 @@ export function CategoryList({
 
   // The category awaiting the destructive deactivate confirm.
   const [confirming, setConfirming] = useState<Category | null>(null);
-  const [busyId, setBusyId] = useState<string | null>(null);
+  // Per-row busy state derived from the in-flight mutation's variables (the
+  // trades.tsx idiom) instead of a manual keyed flag — busy-state rule v2.
+  const busyId = setCategoryActive.isPending
+    ? (setCategoryActive.variables?.catalogCategoryId ?? null)
+    : null;
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -144,7 +148,6 @@ export function CategoryList({
     messages: { success: string; error: string },
   ) => {
     if (!category.aggregateId) return;
-    setBusyId(category._id);
     try {
       await setCategoryActive.mutateAsync({
         catalogCategoryId: category.aggregateId,
@@ -153,8 +156,6 @@ export function CategoryList({
       toast.success(messages.success);
     } catch {
       toast.error(messages.error);
-    } finally {
-      setBusyId(null);
     }
   };
 
@@ -175,7 +176,8 @@ export function CategoryList({
               <CategoryRow
                 key={category._id}
                 category={category}
-                busy={busyId === category._id}
+                // The mutation is keyed by aggregateId (its catalogCategoryId arg).
+                busy={busyId !== null && busyId === category.aggregateId}
                 onEdit={() => onEdit(category)}
                 onDeactivate={() => setConfirming(category)}
                 onReactivate={() =>

--- a/apps/web/src/components/admin/category-list.tsx
+++ b/apps/web/src/components/admin/category-list.tsx
@@ -30,6 +30,7 @@ import {
 import { gateway } from "@/gateway";
 import { locales, type Locale } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
+import { useConvexMutation } from "@convex-dev/react-query";
 import {
   closestCenter,
   DndContext,
@@ -48,7 +49,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useMutation } from "convex/react";
+import { useMutation } from "@tanstack/react-query";
 import { Edit, Eye, EyeOff, GripVertical } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -78,26 +79,30 @@ export function CategoryList({
   const tCommon = useTranslations("common");
   const uiLocale = useLocale() as Locale;
   // The domain soft-deactivates; there is no hard delete, so "delete" hides a node via setActive.
-  const setCategoryActive = useMutation(gateway.adminCatalog.delete);
+  const setCategoryActive = useMutation({
+    mutationFn: useConvexMutation(gateway.adminCatalog.delete),
+  });
   // Optimistically renumber the listAll rows so the drop lands instantly; Convex
   // rolls the patch back if the mutation is rejected.
-  const reorderCategories = useMutation(
-    gateway.adminCatalog.reorder,
-  ).withOptimisticUpdate((localStore, args) => {
-    const current = localStore.getQuery(gateway.adminCatalog.listAll, {});
-    if (current === undefined) return;
-    const orders = new Map(
-      args.order.map((entry) => [entry.catalogCategoryId, entry.sortOrder]),
-    );
-    localStore.setQuery(
-      gateway.adminCatalog.listAll,
-      {},
-      current.map((row) =>
-        row.aggregateId !== undefined && orders.has(row.aggregateId)
-          ? { ...row, sortOrder: orders.get(row.aggregateId)! }
-          : row,
-      ),
-    );
+  const reorderCategories = useMutation({
+    mutationFn: useConvexMutation(
+      gateway.adminCatalog.reorder,
+    ).withOptimisticUpdate((localStore, args) => {
+      const current = localStore.getQuery(gateway.adminCatalog.listAll, {});
+      if (current === undefined) return;
+      const orders = new Map(
+        args.order.map((entry) => [entry.catalogCategoryId, entry.sortOrder]),
+      );
+      localStore.setQuery(
+        gateway.adminCatalog.listAll,
+        {},
+        current.map((row) =>
+          row.aggregateId !== undefined && orders.has(row.aggregateId)
+            ? { ...row, sortOrder: orders.get(row.aggregateId)! }
+            : row,
+        ),
+      );
+    }),
   });
 
   // The category awaiting the destructive deactivate confirm.
@@ -127,7 +132,7 @@ export function CategoryList({
         sortOrder: index,
       }));
     try {
-      await reorderCategories({ order });
+      await reorderCategories.mutateAsync({ order });
     } catch {
       toast.error(t("reorderError"));
     }
@@ -141,7 +146,7 @@ export function CategoryList({
     if (!category.aggregateId) return;
     setBusyId(category._id);
     try {
-      await setCategoryActive({
+      await setCategoryActive.mutateAsync({
         catalogCategoryId: category.aggregateId,
         isActive,
       });

--- a/apps/web/src/components/admin/moderation/activity-log.tsx
+++ b/apps/web/src/components/admin/moderation/activity-log.tsx
@@ -8,7 +8,8 @@
 import { QueueEmpty } from "@/components/admin/queue-empty";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import {
   CheckCircle,
@@ -36,9 +37,13 @@ const KIND_META: Record<ActivityRow["kind"], [LucideIcon, string]> = {
 export function ActivityLog({ emptyTitle }: { emptyTitle: string }) {
   const t = useTranslations("admin.moderation");
   const format = useFormatter();
-  const activity = useQuery(gateway.admin.getModerationActivity, {});
+  const { data: activity, isPending } = useQuery(
+    convexQuery(gateway.admin.getModerationActivity, {}),
+  );
 
-  if (activity === undefined) {
+  // The undefined check narrows `activity` for TypeScript (TanStack's result union
+  // still allows undefined data in the error branch); isPending is the loading signal.
+  if (isPending || activity === undefined) {
     return <PageLoading message={t("activity.loading")} />;
   }
   if (activity.length === 0) {

--- a/apps/web/src/components/admin/moderation/kpi-row.tsx
+++ b/apps/web/src/components/admin/moderation/kpi-row.tsx
@@ -6,7 +6,8 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   CircleCheck,
   CircleX,
@@ -53,7 +54,9 @@ function KpiTile({
 
 export function KpiRow() {
   const t = useTranslations("admin.moderation.kpis");
-  const stats = useQuery(gateway.admin.getModerationStats);
+  const { data: stats } = useQuery(
+    convexQuery(gateway.admin.getModerationStats, {}),
+  );
   const thisWeek = t("thisWeek");
 
   return (

--- a/apps/web/src/components/admin/moderation/submission-detail.tsx
+++ b/apps/web/src/components/admin/moderation/submission-detail.tsx
@@ -9,7 +9,8 @@
 import { Button } from "@/components/ui/button";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { AlertTriangle, Check, Pencil, Puzzle, X } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -82,10 +83,12 @@ export function SubmissionDetail({
 
   // Possible-dup check for the SELECTED submission only: the approved-only
   // suggestions index is the catalog's existing cheap title lookup.
-  const suggestions = useQuery(gateway.catalog.puzzleSuggestions, {
-    searchTerm: submission.title,
-    limit: 5,
-  });
+  const { data: suggestions } = useQuery(
+    convexQuery(gateway.catalog.puzzleSuggestions, {
+      searchTerm: submission.title,
+      limit: 5,
+    }),
+  );
   const dup = findTitleMatch(submission.title, suggestions);
 
   const meta: [string, string][] = [

--- a/apps/web/src/components/collections/edit-collection-dialog.tsx
+++ b/apps/web/src/components/collections/edit-collection-dialog.tsx
@@ -20,7 +20,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Globe, Lock } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -89,7 +90,9 @@ function EditCollectionForm({
   const t = useTranslations("collections");
   const tCommon = useTranslations("common");
 
-  const updateCollection = useMutation(gateway.collections.update);
+  const updateCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.update),
+  });
 
   const [formData, setFormData] = useState<FormData>(() =>
     collectionToForm(collection),
@@ -101,7 +104,7 @@ function EditCollectionForm({
       return;
     }
     try {
-      await updateCollection({
+      await updateCollection.mutateAsync({
         collectionId: collection.aggregateId,
         name: formData.name,
         description: formData.description,

--- a/apps/web/src/components/copies/edit-copy-dialog.tsx
+++ b/apps/web/src/components/copies/edit-copy-dialog.tsx
@@ -20,7 +20,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { Check, ImageOff } from "lucide-react";
 import { useState } from "react";
@@ -51,10 +52,18 @@ export function EditCopyDialog({
   const t = useTranslations("copyInstance");
   const tPuzzles = useTranslations("puzzles");
 
-  const changeCondition = useMutation(gateway.library.changeCondition);
-  const updateSharing = useMutation(gateway.library.updateSharing);
-  const updateDetails = useMutation(gateway.library.updateDetails);
-  const setCopyCover = useMutation(gateway.library.setCopyCover);
+  const changeCondition = useMutation({
+    mutationFn: useConvexMutation(gateway.library.changeCondition),
+  });
+  const updateSharing = useMutation({
+    mutationFn: useConvexMutation(gateway.library.updateSharing),
+  });
+  const updateDetails = useMutation({
+    mutationFn: useConvexMutation(gateway.library.updateDetails),
+  });
+  const setCopyCover = useMutation({
+    mutationFn: useConvexMutation(gateway.library.setCopyCover),
+  });
 
   const { snapshot, gallery } = copy;
   const aggregateId = copy.aggregateId;
@@ -69,7 +78,11 @@ export function EditCopyDialog({
   const [coverImageId, setCoverImageId] = useState<string | null>(
     snapshot.coverImageId,
   );
-  const [saving, setSaving] = useState(false);
+  const saving =
+    changeCondition.isPending ||
+    updateSharing.isPending ||
+    updateDetails.isPending ||
+    setCopyCover.isPending;
 
   const conditionOptions = CONDITION_OPTIONS.map((o) => ({
     value: o.value,
@@ -77,12 +90,13 @@ export function EditCopyDialog({
   }));
 
   const save = async () => {
-    setSaving(true);
     try {
       const ops: Array<Promise<unknown>> = [];
 
       if (domainEditable && condition !== snapshot.condition) {
-        ops.push(changeCondition({ copyId: aggregateId, condition }));
+        ops.push(
+          changeCondition.mutateAsync({ copyId: aggregateId, condition }),
+        );
       }
 
       const availabilityChanged =
@@ -91,18 +105,25 @@ export function EditCopyDialog({
         availability.forSale !== snapshot.availability.forSale;
       if (domainEditable && availabilityChanged) {
         ops.push(
-          updateSharing(availabilityToSharing(aggregateId, availability)),
+          updateSharing.mutateAsync(
+            availabilityToSharing(aggregateId, availability),
+          ),
         );
       }
 
       const trimmedNotes = notes.trim();
       if (domainEditable && trimmedNotes !== (snapshot.notes ?? "")) {
-        ops.push(updateDetails({ copyId: aggregateId, notes: trimmedNotes }));
+        ops.push(
+          updateDetails.mutateAsync({
+            copyId: aggregateId,
+            notes: trimmedNotes,
+          }),
+        );
       }
 
       if (coverImageId !== snapshot.coverImageId) {
         ops.push(
-          setCopyCover({
+          setCopyCover.mutateAsync({
             copyId: copy.copyId as Id<"ownedPuzzles">,
             ...(coverImageId
               ? { coverImageId: coverImageId as Id<"ownedPuzzleImages"> }
@@ -116,8 +137,6 @@ export function EditCopyDialog({
       onOpenChange(false);
     } catch {
       toast.error(t("editCopy.editFailed"));
-    } finally {
-      setSaving(false);
     }
   };
 

--- a/apps/web/src/components/copies/photo-lightbox.tsx
+++ b/apps/web/src/components/copies/photo-lightbox.tsx
@@ -12,7 +12,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import {
   ChevronLeft,
@@ -63,10 +64,14 @@ export function PhotoLightbox({
 }) {
   const t = useTranslations("copyInstance.photoLightbox");
   const format = useFormatter();
-  const setCopyCover = useMutation(gateway.library.setCopyCover);
-  const removeCopyPhoto = useMutation(gateway.library.removeCopyPhoto);
-  const [settingCover, setSettingCover] = useState(false);
-  const [removing, setRemoving] = useState(false);
+  const setCopyCover = useMutation({
+    mutationFn: useConvexMutation(gateway.library.setCopyCover),
+  });
+  const removeCopyPhoto = useMutation({
+    mutationFn: useConvexMutation(gateway.library.removeCopyPhoto),
+  });
+  const settingCover = setCopyCover.isPending;
+  const removing = removeCopyPhoto.isPending;
   const [confirmRemove, setConfirmRemove] = useState(false);
 
   const count = gallery.length;
@@ -80,44 +85,38 @@ export function PhotoLightbox({
 
   const setAsCover = async () => {
     if (!photo) return;
-    setSettingCover(true);
     try {
-      await setCopyCover({
+      await setCopyCover.mutateAsync({
         copyId: copyId as Id<"ownedPuzzles">,
         coverImageId: photo.id as Id<"ownedPuzzleImages">,
       });
       toast.success(t("coverUpdated"));
     } catch {
       toast.error(t("coverFailed"));
-    } finally {
-      setSettingCover(false);
     }
   };
 
   // Clear the cover (omit coverImageId) so the copy falls back to the catalogue image.
   const unsetCover = async () => {
-    setSettingCover(true);
     try {
-      await setCopyCover({ copyId: copyId as Id<"ownedPuzzles"> });
+      await setCopyCover.mutateAsync({ copyId: copyId as Id<"ownedPuzzles"> });
       toast.success(t("coverUpdated"));
     } catch {
       toast.error(t("coverFailed"));
-    } finally {
-      setSettingCover(false);
     }
   };
 
   const removePhoto = async () => {
     if (!photo) return;
-    setRemoving(true);
     try {
-      await removeCopyPhoto({ imageId: photo.id as Id<"ownedPuzzleImages"> });
+      await removeCopyPhoto.mutateAsync({
+        imageId: photo.id as Id<"ownedPuzzleImages">,
+      });
       toast.success(t("photoRemoved"));
       onOpenChange(false); // close; the gallery refetches via Convex reactivity
     } catch {
       toast.error(t("removeFailed"));
     } finally {
-      setRemoving(false);
       setConfirmRemove(false);
     }
   };
@@ -317,12 +316,16 @@ function PhotoComments({ photoId }: { photoId: Id<"ownedPuzzleImages"> }) {
 
   // Keyed on the ACTIVE photo's id: navigating in the lightbox swaps `photoId`, which re-runs
   // this Convex query and re-renders the list for the newly shown photo.
-  const comments = useQuery(gateway.library.listPhotoComments, { photoId });
-  const me = useQuery(gateway.identity.currentUser, {});
-  const postComment = useMutation(gateway.library.postPhotoComment);
+  const { data: comments } = useQuery(
+    convexQuery(gateway.library.listPhotoComments, { photoId }),
+  );
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
+  const postComment = useMutation({
+    mutationFn: useConvexMutation(gateway.library.postPhotoComment),
+  });
 
   const [text, setText] = useState("");
-  const [posting, setPosting] = useState(false);
+  const posting = postComment.isPending;
   const [now] = useState(() => Date.now());
 
   const list = comments ?? [];
@@ -332,14 +335,11 @@ function PhotoComments({ photoId }: { photoId: Id<"ownedPuzzleImages"> }) {
   const submit = async () => {
     const trimmed = text.trim();
     if (!trimmed) return;
-    setPosting(true);
     try {
-      await postComment({ photoId, text: trimmed });
+      await postComment.mutateAsync({ photoId, text: trimmed });
       setText("");
     } catch {
       toast.error(t("commentFailed"));
-    } finally {
-      setPosting(false);
     }
   };
 

--- a/apps/web/src/components/dashboard-home/briefing-hero.tsx
+++ b/apps/web/src/components/dashboard-home/briefing-hero.tsx
@@ -6,7 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { CircleCheck, Plus, Search } from "lucide-react";
 import type { ReactNode } from "react";
@@ -194,11 +195,12 @@ function QuickActions() {
 export function BriefingHero() {
   const { member, isMemberLoading } = useCurrentMember();
 
-  const exchanges = useQuery(
-    gateway.exchange.forUser,
-    member?._id ? {} : "skip",
+  const { data: exchanges } = useQuery(
+    convexQuery(gateway.exchange.forUser, member?._id ? {} : "skip"),
   );
-  const goals = useQuery(gateway.solving.myGoals, member?._id ? {} : "skip");
+  const { data: goals } = useQuery(
+    convexQuery(gateway.solving.myGoals, member?._id ? {} : "skip"),
+  );
 
   const loading =
     isMemberLoading ||

--- a/apps/web/src/components/dashboard-home/fresh-section.tsx
+++ b/apps/web/src/components/dashboard-home/fresh-section.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { SectionHead } from "./section-head";
@@ -18,11 +19,13 @@ export function FreshSection() {
   const t = useTranslations("dashboard.fresh");
   const { member, isMemberLoading } = useCurrentMember();
 
-  const copies = useQuery(
-    gateway.library.ownedByOwner,
-    member?._id
-      ? { ownerId: member._id as Id<"users">, includeUnavailable: true }
-      : "skip",
+  const { data: copies } = useQuery(
+    convexQuery(
+      gateway.library.ownedByOwner,
+      member?._id
+        ? { ownerId: member._id as Id<"users">, includeUnavailable: true }
+        : "skip",
+    ),
   );
 
   const loading = isMemberLoading || (member != null && copies === undefined);

--- a/apps/web/src/components/dashboard-home/pulse-section.tsx
+++ b/apps/web/src/components/dashboard-home/pulse-section.tsx
@@ -7,7 +7,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { ArrowLeftRight, Bell, Package, Target } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -310,9 +311,11 @@ function ActivityRow({
   const isMe = entry.memberId === me._id;
   // The feed entry only carries the member id; resolve the display identity
   // here (Convex dedupes the subscription across rows for the same member).
-  const other = useQuery(
-    gateway.identity.byId,
-    isMe ? "skip" : { userId: entry.memberId as Id<"users"> },
+  const { data: other } = useQuery(
+    convexQuery(
+      gateway.identity.byId,
+      isMe ? "skip" : { userId: entry.memberId as Id<"users"> },
+    ),
   );
   const actor = isMe ? me : other;
 
@@ -397,14 +400,17 @@ function PulseSkeleton() {
 export function PulseSection() {
   const { member, isMemberLoading } = useCurrentMember();
 
-  const exchanges = useQuery(
-    gateway.exchange.forUser,
-    member?._id ? {} : "skip",
+  const { data: exchanges } = useQuery(
+    convexQuery(gateway.exchange.forUser, member?._id ? {} : "skip"),
   );
-  const goals = useQuery(gateway.solving.myGoals, member?._id ? {} : "skip");
-  const feed = useQuery(
-    gateway.social.activityFeed,
-    member?._id ? { limit: 8 } : "skip",
+  const { data: goals } = useQuery(
+    convexQuery(gateway.solving.myGoals, member?._id ? {} : "skip"),
+  );
+  const { data: feed } = useQuery(
+    convexQuery(
+      gateway.social.activityFeed,
+      member?._id ? { limit: 8 } : "skip",
+    ),
   );
 
   const loading =

--- a/apps/web/src/components/dashboard-home/shelf-section.tsx
+++ b/apps/web/src/components/dashboard-home/shelf-section.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { BookOpen, ChevronRight } from "lucide-react";
 import { useMemo } from "react";
@@ -95,19 +96,22 @@ export function ShelfSection() {
   const isMobile = useIsMobile();
   const { member, isMemberLoading } = useCurrentMember();
 
-  const copies = useQuery(
-    gateway.library.ownedByOwner,
-    member?._id
-      ? { ownerId: member._id as Id<"users">, includeUnavailable: true }
-      : "skip",
+  const { data: copies } = useQuery(
+    convexQuery(
+      gateway.library.ownedByOwner,
+      member?._id
+        ? { ownerId: member._id as Id<"users">, includeUnavailable: true }
+        : "skip",
+    ),
   );
-  const stats = useQuery(
-    gateway.identity.userStats,
-    member?._id ? { userId: member._id as Id<"users"> } : "skip",
+  const { data: stats } = useQuery(
+    convexQuery(
+      gateway.identity.userStats,
+      member?._id ? { userId: member._id as Id<"users"> } : "skip",
+    ),
   );
-  const exchanges = useQuery(
-    gateway.exchange.forUser,
-    member?._id ? {} : "skip",
+  const { data: exchanges } = useQuery(
+    convexQuery(gateway.exchange.forUser, member?._id ? {} : "skip"),
   );
 
   // Memoized so the 3D plank's color-resolution effect doesn't re-run on every

--- a/apps/web/src/components/dashboard-home/use-current-member.ts
+++ b/apps/web/src/components/dashboard-home/use-current-member.ts
@@ -1,16 +1,21 @@
 "use client";
 
 import { gateway } from "@/gateway";
-import { useConvexAuth, useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+// sanctioned convex/react exception: useConvexAuth (see tanstack-query migration spec)
+import { useConvexAuth } from "convex/react";
 
 // Shared auth-gated member lookup for the dashboard sections. Every section
 // needs the Convex member to scope its reads; Convex deduplicates identical
 // subscriptions so each section can call this independently.
 export function useCurrentMember() {
   const { isLoading, isAuthenticated } = useConvexAuth();
-  const member = useQuery(
-    gateway.identity.currentUser,
-    isLoading || !isAuthenticated ? "skip" : {},
+  const { data: member } = useQuery(
+    convexQuery(
+      gateway.identity.currentUser,
+      isLoading || !isAuthenticated ? "skip" : {},
+    ),
   );
   return {
     member,

--- a/apps/web/src/components/dashboard-layout/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard-layout/app-sidebar.tsx
@@ -25,7 +25,8 @@ import {
 } from "@/components/ui/sidebar";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 import {
   ADMIN_GROUP,
@@ -41,7 +42,9 @@ export function AppSidebar() {
 
   // Backend-confirmed admin role — the same source the /admin route guard uses,
   // so the nav and the routes can't diverge. Convex dedupes the subscription.
-  const isAdmin = useQuery(gateway.identity.isAdmin, user?.id ? {} : "skip");
+  const { data: isAdmin } = useQuery(
+    convexQuery(gateway.identity.isAdmin, user?.id ? {} : "skip"),
+  );
 
   return (
     <Sidebar
@@ -112,11 +115,13 @@ function NavLink({ item }: { item: ShellNavItem }) {
   // other item skips). The backend caps the value at 50, so 50 genuinely
   // means "50 or more" and renders "50+".
   const { member } = useCurrentMember();
-  const unread =
-    useQuery(
+  const { data: unreadTotal } = useQuery(
+    convexQuery(
       gateway.conversation.getUnreadTotal,
       item.key === "messages" && member?._id ? {} : "skip",
-    ) ?? 0;
+    ),
+  );
+  const unread = unreadTotal ?? 0;
 
   return (
     <SidebarMenuItem>

--- a/apps/web/src/components/dashboard-layout/command-palette.tsx
+++ b/apps/web/src/components/dashboard-layout/command-palette.tsx
@@ -17,7 +17,10 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { gateway } from "@/gateway";
-import { useConvexAuth, useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+// sanctioned convex/react exception: useConvexAuth (see tanstack-query migration spec)
+import { useConvexAuth } from "convex/react";
 import {
   CircleCheck,
   FolderOpen,
@@ -89,9 +92,11 @@ export function CommandPalette({
   }, [value]);
 
   const hasTerm = term.length >= MIN_TERM_LENGTH;
-  const results = useQuery(
-    gateway.search.global,
-    hasTerm && isAuthenticated ? { term } : "skip",
+  const { data: results } = useQuery(
+    convexQuery(
+      gateway.search.global,
+      hasTerm && isAuthenticated ? { term } : "skip",
+    ),
   );
   const isSearching = hasTerm && results === undefined;
   const totalHits = results
@@ -103,7 +108,9 @@ export function CommandPalette({
 
   // Backend-confirmed admin role — same source as the /admin route guard and
   // the sidebar's gated group; Convex dedupes the shared subscription.
-  const isAdmin = useQuery(gateway.identity.isAdmin, user?.id ? {} : "skip");
+  const { data: isAdmin } = useQuery(
+    convexQuery(gateway.identity.isAdmin, user?.id ? {} : "skip"),
+  );
 
   const go = (href: string) => {
     handleOpenChange(false);

--- a/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-tab-bar.tsx
@@ -12,7 +12,8 @@ import { usePathname } from "@/compat/navigation";
 import { useCurrentMember } from "@/components/dashboard-home/use-current-member";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeftRight,
   BookOpen,
@@ -60,9 +61,8 @@ export function MobileTabBar() {
   // Incoming swap requests still awaiting an answer — the same definition the
   // dashboard's pending banner uses; Convex dedupes the shared subscription.
   const { member } = useCurrentMember();
-  const exchanges = useQuery(
-    gateway.exchange.forUser,
-    member?._id ? {} : "skip",
+  const { data: exchanges } = useQuery(
+    convexQuery(gateway.exchange.forUser, member?._id ? {} : "skip"),
   );
   const pending = (exchanges ?? []).filter(
     (exchange) =>

--- a/apps/web/src/components/dashboard-layout/mobile-top-bar.tsx
+++ b/apps/web/src/components/dashboard-layout/mobile-top-bar.tsx
@@ -14,7 +14,8 @@ import { usePathname } from "@/compat/navigation";
 import logoIcon from "@/components/common/header-icon/logo.png";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Bell, ChevronLeft, Search } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { getNavGroup, getRouteMeta } from "./route-meta";
@@ -31,8 +32,10 @@ export function MobileTopBar({ onOpenPalette }: { onOpenPalette: () => void }) {
   const { user } = useUser();
 
   // Same reactive count the desktop bell subscribes to — Convex dedupes it.
-  const unread =
-    useQuery(gateway.notifications.unreadCount, user?.id ? {} : "skip") ?? 0;
+  const { data: unreadCount } = useQuery(
+    convexQuery(gateway.notifications.unreadCount, user?.id ? {} : "skip"),
+  );
+  const unread = unreadCount ?? 0;
 
   const meta = getRouteMeta(pathname);
   const isHome = meta?.variant === "dashboard";

--- a/apps/web/src/components/dashboard-layout/shell-user-button.tsx
+++ b/apps/web/src/components/dashboard-layout/shell-user-button.tsx
@@ -12,7 +12,8 @@ import { Switch } from "@/components/ui/switch";
 import { gateway } from "@/gateway";
 import { useUserSettings } from "@/hooks/use-user-settings";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Bell, Shield, SlidersHorizontal, User } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShellPreferences } from "./preferences";
@@ -31,7 +32,9 @@ export function ShellUserButton({
   // Backend-confirmed admin role — same source as the /admin route guard and
   // the sidebar's gated group; Convex dedupes the shared subscription. This
   // menu item is the mobile path to /admin (no admin tab in the tab bar).
-  const isAdmin = useQuery(gateway.identity.isAdmin, user?.id ? {} : "skip");
+  const { data: isAdmin } = useQuery(
+    convexQuery(gateway.identity.isAdmin, user?.id ? {} : "skip"),
+  );
 
   return (
     <UserButton

--- a/apps/web/src/components/details/collection-detail/index.tsx
+++ b/apps/web/src/components/details/collection-detail/index.tsx
@@ -6,7 +6,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Grid, List, Plus, Search } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -35,13 +36,15 @@ export function CollectionDetail({
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [searchTerm, setSearchTerm] = useState("");
 
-  const collection = useQuery(gateway.collections.byId, {
-    collectionId,
-  });
-
-  const removeFromCollection = useMutation(
-    gateway.collections.removeOwnedPuzzle,
+  const { data: collection, isPending } = useQuery(
+    convexQuery(gateway.collections.byId, {
+      collectionId,
+    }),
   );
+
+  const removeFromCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.removeOwnedPuzzle),
+  });
 
   const handleRemovePuzzle = async (ownedPuzzleId: Id<"ownedPuzzles">) => {
     // The domain remove takes the Collection + Copy aggregateIds; resolve them from the loaded
@@ -54,7 +57,7 @@ export function CollectionDetail({
       return;
     }
     try {
-      await removeFromCollection({
+      await removeFromCollection.mutateAsync({
         collectionId: collection.aggregateId,
         copyId: copy.aggregateId,
       });
@@ -95,7 +98,7 @@ export function CollectionDetail({
       )
       .filter(Boolean) || [];
 
-  if (collection === undefined) {
+  if (isPending || collection === undefined) {
     return <PageLoading message={tCommon("loading")} />;
   }
 

--- a/apps/web/src/components/details/puzzle-detail/custody-timeline.tsx
+++ b/apps/web/src/components/details/puzzle-detail/custody-timeline.tsx
@@ -2,7 +2,8 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { ArrowRight, History, User } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -21,9 +22,11 @@ type ProjectedMember = CustodyTimelineView["currentOwner"];
 // each settled transfer -> current owner) from the custody read-model via the gateway.
 export function CustodyTimeline({ copyId }: CustodyTimelineProps) {
   const t = useTranslations("custody");
-  const timeline = useQuery(gateway.custody.timeline, { copyId });
+  const { data: timeline, isPending } = useQuery(
+    convexQuery(gateway.custody.timeline, { copyId }),
+  );
 
-  if (timeline === undefined) {
+  if (isPending || timeline === undefined) {
     return (
       <Card>
         <CardHeader>

--- a/apps/web/src/components/details/puzzle-detail/index.tsx
+++ b/apps/web/src/components/details/puzzle-detail/index.tsx
@@ -3,7 +3,8 @@
 import { Image } from "@/compat/image";
 import { Card, CardContent } from "@/components/ui/card";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Grid } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -41,11 +42,13 @@ export function PuzzleDetail({
 }: PuzzleDetailProps) {
   const t = useTranslations("puzzles");
 
-  const ownedPuzzle = useQuery(gateway.library.ownedWithCollectionStatus, {
-    ownedPuzzleId,
-  });
+  const { data: ownedPuzzle, isPending } = useQuery(
+    convexQuery(gateway.library.ownedWithCollectionStatus, {
+      ownedPuzzleId,
+    }),
+  );
 
-  if (ownedPuzzle === undefined) {
+  if (isPending || ownedPuzzle === undefined) {
     return <PageLoading message="Loading puzzle..." />;
   }
 

--- a/apps/web/src/components/details/puzzle-detail/loan-history.tsx
+++ b/apps/web/src/components/details/puzzle-detail/loan-history.tsx
@@ -3,7 +3,8 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { HandHelping, User } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -22,9 +23,11 @@ const STATUS_VARIANT = {
 // first), read from the lending read-model via the gateway. Mirrors the custody timeline sibling.
 export function LoanHistory({ copyId }: LoanHistoryProps) {
   const t = useTranslations("lending");
-  const loans = useQuery(gateway.lending.copyHistory, { copyId });
+  const { data: loans, isPending } = useQuery(
+    convexQuery(gateway.lending.copyHistory, { copyId }),
+  );
 
-  if (loans === undefined) {
+  if (isPending || loans === undefined) {
     return (
       <Card>
         <CardHeader>

--- a/apps/web/src/components/docs/doc-helpful.tsx
+++ b/apps/web/src/components/docs/doc-helpful.tsx
@@ -1,21 +1,24 @@
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
 import { useLocale, useTranslations } from "use-intl";
 
 export function DocHelpful({ slug }: { slug: string }) {
-  const submit = useMutation(gateway.docs.submitFeedback);
+  const submit = useMutation({
+    mutationFn: useConvexMutation(gateway.docs.submitFeedback),
+  });
   const locale = useLocale();
   const t = useTranslations("marketing.docs");
   const [state, setState] = React.useState<"idle" | "negative" | "done">(
     "idle",
   );
   const [comment, setComment] = React.useState("");
-  const [sending, setSending] = React.useState(false);
+  const sending = submit.isPending;
 
   const vote = async (helpful: boolean) => {
     if (!helpful) {
@@ -23,24 +26,20 @@ export function DocHelpful({ slug }: { slug: string }) {
       return;
     }
     if (sending) return;
-    setSending(true);
     try {
-      await submit({ slug, helpful: true, locale });
+      await submit.mutateAsync({ slug, helpful: true, locale });
       setState("done");
       toast.success(t("helpfulThanks"));
     } catch {
       // Keep the buttons usable so the reader can retry.
       toast.error(t("helpfulError"));
-    } finally {
-      setSending(false);
     }
   };
 
   const sendNegative = async () => {
     if (sending) return;
-    setSending(true);
     try {
-      await submit({
+      await submit.mutateAsync({
         slug,
         helpful: false,
         comment: comment.trim() || undefined,
@@ -50,8 +49,6 @@ export function DocHelpful({ slug }: { slug: string }) {
       toast.success(t("helpfulThanksNegative"));
     } catch {
       toast.error(t("helpfulError"));
-    } finally {
-      setSending(false);
     }
   };
 

--- a/apps/web/src/components/forms/puzzle-form/puzzle-form-content.tsx
+++ b/apps/web/src/components/forms/puzzle-form/puzzle-form-content.tsx
@@ -19,7 +19,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -40,7 +41,9 @@ export const PuzzleFormContent = () => {
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
 
-  const categories = useQuery(gateway.adminCatalog.listAll);
+  const { data: categories, isPending } = useQuery(
+    convexQuery(gateway.adminCatalog.listAll, {}),
+  );
 
   const t = useTranslations("forms.puzzle-form");
 
@@ -53,7 +56,7 @@ export const PuzzleFormContent = () => {
 
   const isFileEnabled = useFeatureFlagEnabled("file-upload");
 
-  if (categories === undefined) {
+  if (isPending || categories === undefined) {
     return <LoadingState message={t("loading")} />;
   }
 

--- a/apps/web/src/components/insights/export-button.tsx
+++ b/apps/web/src/components/insights/export-button.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { gateway } from "@/gateway";
+// sanctioned convex/react exception: useConvex (see tanstack-query migration spec)
 import { useConvex } from "convex/react";
 import { Download } from "lucide-react";
 import { useState } from "react";

--- a/apps/web/src/components/marketing/header.tsx
+++ b/apps/web/src/components/marketing/header.tsx
@@ -10,6 +10,7 @@ import {
 import { clearIntlCache, type Locale, setLocale } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { useLocation, useRouter } from "@tanstack/react-router";
+// sanctioned convex/react exception: Authenticated/Unauthenticated auth-state components (see tanstack-query migration spec)
 import { Authenticated, Unauthenticated } from "convex/react";
 import { Menu, Moon, Sun, X } from "lucide-react";
 import { useTheme } from "next-themes";

--- a/apps/web/src/components/marketing/home/hero.tsx
+++ b/apps/web/src/components/marketing/home/hero.tsx
@@ -7,8 +7,8 @@ import { useStartHref } from "@/components/marketing/use-start-href";
 import { Button } from "@/components/ui/button";
 import { gateway } from "@/gateway";
 import { globalStatsQuery } from "@/lib/marketing-queries";
-import { useQuery as useStatsQuery } from "@tanstack/react-query";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import * as React from "react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -189,17 +189,20 @@ function TrustRow() {
   const t = useTranslations("marketing.home");
   const format = useFormatter();
   // Prefetched in the home route loader, so the count is present on first paint.
-  const { data: stats } = useStatsQuery(globalStatsQuery);
+  const { data: stats } = useQuery(globalStatsQuery);
 
   // Stable per-visit seed: generated client-side after mount (SSR-safe).
   // The query is skipped until the seed is ready; FALLBACK_AVATARS fills the
   // cluster meanwhile as a decorative placeholder.
   const [seed, setSeed] = React.useState<number | null>(null);
   React.useEffect(() => setSeed(Math.floor(Math.random() * 0xffffffff)), []);
-  const communityAvatars: CommunityAvatar[] | undefined = useQuery(
-    gateway.insights.communityAvatars,
-    seed === null ? "skip" : { limit: 4, seed },
+  const { data } = useQuery(
+    convexQuery(
+      gateway.insights.communityAvatars,
+      seed === null ? "skip" : { limit: 4, seed },
+    ),
   );
+  const communityAvatars: CommunityAvatar[] | undefined = data;
 
   // Only render the avatar cluster once real community members are loaded — never
   // fake placeholder users. Until then (loading or no members) the cluster is hidden.
@@ -283,11 +286,13 @@ export function Hero() {
   // meanwhile as a loading fallback.
   const [seed, setSeed] = React.useState<number | null>(null);
   React.useEffect(() => setSeed(Math.floor(Math.random() * 0xffffffff)), []);
-  const livePuzzles = useQuery(
-    gateway.insights.plankPuzzles,
-    // 12 is the backend's clamp ceiling — enough for ~4 unique boxes per
-    // shelf row before the scene starts cycling them.
-    seed === null ? "skip" : { limit: 12, seed },
+  const { data: livePuzzles } = useQuery(
+    convexQuery(
+      gateway.insights.plankPuzzles,
+      // 12 is the backend's clamp ceiling — enough for ~4 unique boxes per
+      // shelf row before the scene starts cycling them.
+      seed === null ? "skip" : { limit: 12, seed },
+    ),
   );
   const rows = React.useMemo(
     () =>

--- a/apps/web/src/components/marketing/use-start-href.ts
+++ b/apps/web/src/components/marketing/use-start-href.ts
@@ -1,3 +1,4 @@
+// sanctioned convex/react exception: useConvexAuth (see tanstack-query migration spec)
 import { useConvexAuth } from "convex/react";
 
 // Target for the "Start trading" CTAs on the marketing site: a signed-in member goes straight to

--- a/apps/web/src/components/messaging/message-composer.tsx
+++ b/apps/web/src/components/messaging/message-composer.tsx
@@ -11,8 +11,9 @@ import { conversationErrorCode } from "@/components/messaging/format";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import type { OptimisticUpdate } from "convex/browser";
-import { useMutation } from "convex/react";
 import type { FunctionArgs } from "convex/server";
 import { Send } from "lucide-react";
 import { useState } from "react";
@@ -59,9 +60,11 @@ export function MessageComposer({ threadId }: { threadId: string }) {
   const [body, setBody] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const postMessage = useMutation(
-    gateway.conversation.postMessage,
-  ).withOptimisticUpdate(optimisticAppend(me));
+  const postMessage = useMutation({
+    mutationFn: useConvexMutation(
+      gateway.conversation.postMessage,
+    ).withOptimisticUpdate(optimisticAppend(me)),
+  });
 
   const send = async () => {
     const trimmed = body.trim();
@@ -70,7 +73,7 @@ export function MessageComposer({ threadId }: { threadId: string }) {
     // Clear immediately — the optimistic append already shows the message.
     setBody("");
     try {
-      await postMessage({ threadId, kind: "text", body: trimmed });
+      await postMessage.mutateAsync({ threadId, kind: "text", body: trimmed });
     } catch (err) {
       // Give the text back unless the user already started typing a new one.
       setBody((current) => current || trimmed);

--- a/apps/web/src/components/messaging/thread-list.tsx
+++ b/apps/web/src/components/messaging/thread-list.tsx
@@ -11,7 +11,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { gateway } from "@/gateway";
 import { useDateFnsLocale } from "@/lib/date-locale";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowLeftRight, MessageSquare, User } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -56,9 +57,8 @@ export function ThreadSubjectAvatar({
 export function ThreadList({ activeThreadId }: { activeThreadId?: string }) {
   const t = useTranslations("messages");
   const { member } = useCurrentMember();
-  const inbox = useQuery(
-    gateway.conversation.getMyInbox,
-    member?._id ? {} : "skip",
+  const { data: inbox } = useQuery(
+    convexQuery(gateway.conversation.getMyInbox, member?._id ? {} : "skip"),
   );
 
   if (inbox === undefined) {

--- a/apps/web/src/components/messaging/thread-view.tsx
+++ b/apps/web/src/components/messaging/thread-view.tsx
@@ -14,7 +14,8 @@ import { Link } from "@/compat/link";
 import { useCurrentMember } from "@/components/dashboard-home/use-current-member";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronLeft, MessageSquare } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -36,14 +37,21 @@ export function ThreadView({
   const { member } = useCurrentMember();
   const me = member?._id;
 
-  const messages = useQuery(
-    gateway.conversation.getThreadMessages,
-    me ? { threadId } : "skip",
+  const { data: messages } = useQuery(
+    convexQuery(
+      gateway.conversation.getThreadMessages,
+      me ? { threadId } : "skip",
+    ),
   );
-  const inbox = useQuery(gateway.conversation.getMyInbox, me ? {} : "skip");
+  const { data: inbox } = useQuery(
+    convexQuery(gateway.conversation.getMyInbox, me ? {} : "skip"),
+  );
   const thread = inbox?.find((row) => row.threadId === threadId);
 
-  const markThreadRead = useMutation(gateway.conversation.markThreadRead);
+  // mutateAsync is referentially stable, so the effect deps below behave as before.
+  const { mutateAsync: markThreadRead } = useMutation({
+    mutationFn: useConvexMutation(gateway.conversation.markThreadRead),
+  });
   const messageCount = messages?.length;
   const newestAuthorId = messages?.at(-1)?.authorId;
 

--- a/apps/web/src/components/messaging/thread-view.tsx
+++ b/apps/web/src/components/messaging/thread-view.tsx
@@ -37,12 +37,16 @@ export function ThreadView({
   const { member } = useCurrentMember();
   const me = member?._id;
 
-  const { data: messages } = useQuery(
-    convexQuery(
+  const { data: messages } = useQuery({
+    ...convexQuery(
       gateway.conversation.getThreadMessages,
       me ? { threadId } : "skip",
     ),
-  );
+    // Stale/foreign thread ids must THROW so the $threadId route's
+    // errorComponent renders AppNotFound (TanStack returns errors in .error
+    // by default, which would leave the skeleton up forever).
+    throwOnError: true,
+  });
   const { data: inbox } = useQuery(
     convexQuery(gateway.conversation.getMyInbox, me ? {} : "skip"),
   );

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -13,7 +13,8 @@ import {
 import { gateway } from "@/gateway";
 import { useDateFnsLocale } from "@/lib/date-locale";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Bell, CheckCheck } from "lucide-react";
 import { useState } from "react";
@@ -41,17 +42,19 @@ export function NotificationBell() {
   // Both reactive: the badge and the preview update live as events land. Gated on a signed-in
   // member so we never fire the query unauthenticated (and to mirror the existing "skip" pattern).
   const signedIn = Boolean(user?.id);
-  const unread = useQuery(
-    gateway.notifications.unreadCount,
-    signedIn ? {} : "skip",
+  const { data: unread } = useQuery(
+    convexQuery(gateway.notifications.unreadCount, signedIn ? {} : "skip"),
   );
   const notifications = useQuery(
-    gateway.notifications.list,
-    signedIn && open ? {} : "skip",
-  ) as NotificationRow[] | undefined;
+    convexQuery(gateway.notifications.list, signedIn && open ? {} : "skip"),
+  ).data as NotificationRow[] | undefined;
 
-  const markRead = useMutation(gateway.notifications.markRead);
-  const markAllRead = useMutation(gateway.notifications.markAllRead);
+  const markRead = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.markRead),
+  });
+  const markAllRead = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.markAllRead),
+  });
 
   const unreadCount = unread ?? 0;
   const preview = (notifications ?? []).slice(0, PREVIEW_COUNT);
@@ -60,9 +63,11 @@ export function NotificationBell() {
     setOpen(false);
     // Optimistic-feeling: fire the read mutation but don't block navigation on it.
     if (!row.isRead) {
-      markRead({ notificationId: notificationId(row) }).catch(() => {
-        toast.error(t("markError"));
-      });
+      markRead
+        .mutateAsync({ notificationId: notificationId(row) })
+        .catch(() => {
+          toast.error(t("markError"));
+        });
     }
     const href = notificationHref(row);
     if (href) router.push(href);
@@ -70,7 +75,7 @@ export function NotificationBell() {
 
   const handleMarkAll = async () => {
     try {
-      const count = await markAllRead({});
+      const count = await markAllRead.mutateAsync({});
       toast.success(t("markedAllRead", { count: count ?? 0 }));
     } catch {
       toast.error(t("markError"));

--- a/apps/web/src/components/notifications/notification-preferences-panel.tsx
+++ b/apps/web/src/components/notifications/notification-preferences-panel.tsx
@@ -8,7 +8,8 @@ import {
 import { PushDeviceSection } from "@/components/notifications/push-device-section";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
@@ -25,11 +26,12 @@ export function NotificationPreferencesPanel() {
   const tCommon = useTranslations("common");
 
   const preferences = useQuery(
-    gateway.notifications.preferences,
-    user?.id ? {} : "skip",
-  ) as Toggles | undefined;
+    convexQuery(gateway.notifications.preferences, user?.id ? {} : "skip"),
+  ).data as Toggles | undefined;
 
-  const updatePreference = useMutation(gateway.notifications.updatePreference);
+  const updatePreference = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.updatePreference),
+  });
 
   if (!user || preferences === undefined) {
     return <PageLoading message={tCommon("loading")} />;
@@ -47,7 +49,7 @@ export function NotificationPreferencesPanel() {
     enabled: boolean,
   ) => {
     try {
-      await updatePreference({ type, channel, enabled });
+      await updatePreference.mutateAsync({ type, channel, enabled });
     } catch {
       toast.error(t("preferencesError"));
     }

--- a/apps/web/src/components/notifications/push-device-section.tsx
+++ b/apps/web/src/components/notifications/push-device-section.tsx
@@ -24,12 +24,10 @@ export function PushDeviceSection() {
   const t = useTranslations("notifications");
   const pushConfig = useQuery(convexQuery(gateway.notifications.pushConfig, {}))
     .data as { vapidPublicKey: string | null } | undefined;
-  const registerPush = useMutation({
-    mutationFn: useConvexMutation(gateway.notifications.registerPush),
-  });
-  const unregisterPush = useMutation({
-    mutationFn: useConvexMutation(gateway.notifications.unregisterPush),
-  });
+  const registerPush = useConvexMutation(gateway.notifications.registerPush);
+  const unregisterPush = useConvexMutation(
+    gateway.notifications.unregisterPush,
+  );
 
   // `mounted` defers all browser-only reads (pushSupported, Notification.permission, the existing
   // subscription) to the client, so the server render and first client render agree (no hydration
@@ -39,7 +37,6 @@ export function PushDeviceSection() {
   const [permission, setPermission] = useState<NotificationPermission | null>(
     null,
   );
-  const [busy, setBusy] = useState(false);
   const supported = mounted && pushSupported();
 
   // Re-read the SOURCE OF TRUTH — does this browser actually hold a push subscription — and reflect
@@ -52,6 +49,7 @@ export function PushDeviceSection() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing mount/hydration sync; surfaced once this component became compiler-analyzable
     setMounted(true);
     if (!pushSupported()) return;
     setPermission(Notification.permission);
@@ -60,9 +58,10 @@ export function PushDeviceSection() {
       .catch(() => {});
   }, []);
 
-  const enable = async () => {
-    setBusy(true);
-    try {
+  // The WHOLE enable flow — permission prompt, browser PushManager subscribe, server register —
+  // runs as one mutationFn so isPending spans the entire sequence natively (busy-state rule v2).
+  const enableDevice = useMutation({
+    mutationFn: async () => {
       const perm = await Notification.requestPermission();
       setPermission(perm);
       if (perm !== "granted") return;
@@ -76,14 +75,11 @@ export function PushDeviceSection() {
       // (the browser is already subscribed and must remain turn-off-able). Timed out so a stalled
       // mutation can't hang the button either.
       console.log("[push] register subscription with server…");
-      await withTimeout(
-        registerPush.mutateAsync(payload),
-        15000,
-        "register subscription",
-      );
+      await withTimeout(registerPush(payload), 15000, "register subscription");
       console.log("[push] done");
       toast.success(t("pushEnabled"));
-    } catch (error) {
+    },
+    onError: (error) => {
       // Surface the real cause: the subscribe pipeline (permission → SW activation → PushManager)
       // has many failure points, and a silent generic toast made them undiagnosable. A hung
       // PushManager.subscribe means the browser couldn't reach its push backend (FCM/Mozilla) —
@@ -96,30 +92,30 @@ export function PushDeviceSection() {
           ? t("pushServiceUnreachable")
           : `${t("pushError")}: ${msg}`,
       );
-    } finally {
-      // Always reconcile with the real browser state, whatever happened above.
-      syncFromBrowser();
-      setBusy(false);
-    }
-  };
+    },
+    // Always reconcile with the real browser state, whatever happened above.
+    onSettled: () => syncFromBrowser(),
+  });
 
-  const disable = async () => {
-    setBusy(true);
-    try {
+  // Same treatment for disable: browser unsubscribe + server unregister as one span.
+  const disableDevice = useMutation({
+    mutationFn: async () => {
       // Unsubscribe in the browser (the truth) and flip the UI before the server cleanup, so a
       // failing unregister can't leave the device stuck "on".
       const ep = await unsubscribeFromPush();
       setEndpoint(null);
-      if (ep) await unregisterPush.mutateAsync({ endpoint: ep });
+      if (ep) await unregisterPush({ endpoint: ep });
       toast.success(t("pushDisabled"));
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error("[push] disable failed:", error);
       toast.error(`${t("pushError")}: ${errorMessage(error)}`);
-    } finally {
-      syncFromBrowser();
-      setBusy(false);
-    }
-  };
+    },
+    onSettled: () => syncFromBrowser(),
+  });
+
+  // Shared disable across both actions, matching the old single busy flag.
+  const busy = enableDevice.isPending || disableDevice.isPending;
 
   const loading = pushConfig === undefined;
   const configured = pushConfig?.vapidPublicKey != null;
@@ -142,7 +138,12 @@ export function PushDeviceSection() {
           <BellRing className="text-jigsaw-secondary h-4 w-4" />
           {t("pushEnabledOnDevice")}
         </span>
-        <Button variant="outline" size="sm" disabled={busy} onClick={disable}>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          onClick={() => disableDevice.mutate()}
+        >
           {t("pushDisable")}
         </Button>
       </>
@@ -154,7 +155,12 @@ export function PushDeviceSection() {
           <BellOff className="h-4 w-4" />
           {t("pushDeviceDesc")}
         </span>
-        <Button variant="brand" size="sm" disabled={busy} onClick={enable}>
+        <Button
+          variant="brand"
+          size="sm"
+          disabled={busy}
+          onClick={() => enableDevice.mutate()}
+        >
           {t("pushEnable")}
         </Button>
       </>

--- a/apps/web/src/components/notifications/push-device-section.tsx
+++ b/apps/web/src/components/notifications/push-device-section.tsx
@@ -11,9 +11,21 @@ import {
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { BellOff, BellRing, Smartphone } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
+
+// A subscribe that never fires: with `useSyncExternalStore` this yields the client snapshot on the
+// first client render and the server snapshot during SSR — the canonical hydration-safe way to read
+// browser-only values without a mount effect.
+const emptySubscribe = () => () => {};
+
+// Snapshot of the browser's notification permission. Re-read on every render (the store never
+// pushes), so it refreshes whenever something else re-renders the component — e.g. the enable
+// mutation settling after `Notification.requestPermission()` resolves.
+const getPermissionSnapshot = (): NotificationPermission | null =>
+  typeof Notification !== "undefined" ? Notification.permission : null;
+const getServerPermissionSnapshot = () => null;
 
 // Per-device Web Push control: a browser subscription is global to this device, separate from the
 // per-type push preference toggles (which decide WHICH notifications go to push). This card-free
@@ -31,11 +43,18 @@ export function PushDeviceSection() {
 
   // `mounted` defers all browser-only reads (pushSupported, Notification.permission, the existing
   // subscription) to the client, so the server render and first client render agree (no hydration
-  // mismatch) and we never touch `Notification`/`navigator` during SSR.
-  const [mounted, setMounted] = useState(false);
+  // mismatch) and we never touch `Notification`/`navigator` during SSR. false during SSR/hydration,
+  // true from the first client render after.
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
   const [endpoint, setEndpoint] = useState<string | null>(null);
-  const [permission, setPermission] = useState<NotificationPermission | null>(
-    null,
+  const permission = useSyncExternalStore(
+    emptySubscribe,
+    getPermissionSnapshot,
+    getServerPermissionSnapshot,
   );
   const supported = mounted && pushSupported();
 
@@ -48,11 +67,9 @@ export function PushDeviceSection() {
       .catch(() => setEndpoint(null));
   };
 
+  // Seed the endpoint from the browser's actual subscription once, on the client.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing mount/hydration sync; surfaced once this component became compiler-analyzable
-    setMounted(true);
     if (!pushSupported()) return;
-    setPermission(Notification.permission);
     currentSubscriptionEndpoint()
       .then(setEndpoint)
       .catch(() => {});
@@ -62,8 +79,9 @@ export function PushDeviceSection() {
   // runs as one mutationFn so isPending spans the entire sequence natively (busy-state rule v2).
   const enableDevice = useMutation({
     mutationFn: async () => {
+      // `permission` (the useSyncExternalStore snapshot above) picks the new value up on the
+      // re-render this mutation triggers when it settles — no manual setState needed.
       const perm = await Notification.requestPermission();
-      setPermission(perm);
       if (perm !== "granted") return;
       const key = pushConfig?.vapidPublicKey;
       if (!key) return;

--- a/apps/web/src/components/notifications/push-device-section.tsx
+++ b/apps/web/src/components/notifications/push-device-section.tsx
@@ -8,7 +8,8 @@ import {
   unsubscribeFromPush,
   withTimeout,
 } from "@/lib/web-push";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { BellOff, BellRing, Smartphone } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -21,11 +22,14 @@ import { useTranslations } from "use-intl";
 // subscription. The UI follows the ACTUAL browser subscription; the server sync is best-effort.
 export function PushDeviceSection() {
   const t = useTranslations("notifications");
-  const pushConfig = useQuery(gateway.notifications.pushConfig, {}) as
-    | { vapidPublicKey: string | null }
-    | undefined;
-  const registerPush = useMutation(gateway.notifications.registerPush);
-  const unregisterPush = useMutation(gateway.notifications.unregisterPush);
+  const pushConfig = useQuery(convexQuery(gateway.notifications.pushConfig, {}))
+    .data as { vapidPublicKey: string | null } | undefined;
+  const registerPush = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.registerPush),
+  });
+  const unregisterPush = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.unregisterPush),
+  });
 
   // `mounted` defers all browser-only reads (pushSupported, Notification.permission, the existing
   // subscription) to the client, so the server render and first client render agree (no hydration
@@ -72,7 +76,11 @@ export function PushDeviceSection() {
       // (the browser is already subscribed and must remain turn-off-able). Timed out so a stalled
       // mutation can't hang the button either.
       console.log("[push] register subscription with server…");
-      await withTimeout(registerPush(payload), 15000, "register subscription");
+      await withTimeout(
+        registerPush.mutateAsync(payload),
+        15000,
+        "register subscription",
+      );
       console.log("[push] done");
       toast.success(t("pushEnabled"));
     } catch (error) {
@@ -102,7 +110,7 @@ export function PushDeviceSection() {
       // failing unregister can't leave the device stuck "on".
       const ep = await unsubscribeFromPush();
       setEndpoint(null);
-      if (ep) await unregisterPush({ endpoint: ep });
+      if (ep) await unregisterPush.mutateAsync({ endpoint: ep });
       toast.success(t("pushDisabled"));
     } catch (error) {
       console.error("[push] disable failed:", error);

--- a/apps/web/src/components/posthog-page-view.tsx
+++ b/apps/web/src/components/posthog-page-view.tsx
@@ -1,5 +1,6 @@
 import { useUser } from "@/compat/clerk";
 import { usePathname, useSearchParams } from "@/compat/navigation";
+// sanctioned convex/react exception: useConvexAuth (see tanstack-query migration spec)
 import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";

--- a/apps/web/src/components/profile/arrange-shelf-dialog.tsx
+++ b/apps/web/src/components/profile/arrange-shelf-dialog.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/components/ui/dialog";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { ArrowDown, ArrowUp, Check, X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -42,18 +43,21 @@ export function ArrangeShelfDialog({
 }) {
   const t = useTranslations("profile.shelf.arrangeDialog");
 
-  const copies = useQuery(gateway.library.ownedByOwner, {
-    ownerId,
-    includeUnavailable: true,
-  });
+  const { data: copies } = useQuery(
+    convexQuery(gateway.library.ownedByOwner, {
+      ownerId,
+      includeUnavailable: true,
+    }),
+  );
 
-  const arrange = useMutation(gateway.social.arrangeShelf);
+  const arrange = useMutation({
+    mutationFn: useConvexMutation(gateway.social.arrangeShelf),
+  });
 
   // Selected copy ids in display order (the arrangement).
   const [selected, setSelected] = useState<Id<"ownedPuzzles">[]>(
     () => currentFeaturedIds,
   );
-  const [saving, setSaving] = useState(false);
 
   // Build a lookup for quick title resolution.
   const copyMap = useMemo(() => {
@@ -100,15 +104,12 @@ export function ArrangeShelfDialog({
   }
 
   async function handleSave() {
-    setSaving(true);
     try {
-      await arrange({ copyIds: selected });
+      await arrange.mutateAsync({ copyIds: selected });
       toast.success(t("saved"));
       onClose();
     } catch {
       toast.error(t("saveError"));
-    } finally {
-      setSaving(false);
     }
   }
 
@@ -252,12 +253,16 @@ export function ArrangeShelfDialog({
             type="button"
             variant="outline"
             onClick={onClose}
-            disabled={saving}
+            disabled={arrange.isPending}
           >
             {t("cancel")}
           </Button>
-          <Button type="button" onClick={handleSave} disabled={saving}>
-            {saving ? t("saving") : t("save")}
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={arrange.isPending}
+          >
+            {arrange.isPending ? t("saving") : t("save")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/profile/edit-profile-form.tsx
+++ b/apps/web/src/components/profile/edit-profile-form.tsx
@@ -7,7 +7,8 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Save } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -38,31 +39,33 @@ export function EditProfileForm({
 }) {
   const t = useTranslations("profile");
   const { user } = useUser();
-  const updateProfile = useMutation(gateway.identity.updateProfile);
-  const setProfileVisibility = useMutation(gateway.social.setProfileVisibility);
+  const updateProfile = useMutation({
+    mutationFn: useConvexMutation(gateway.identity.updateProfile),
+  });
+  const setProfileVisibility = useMutation({
+    mutationFn: useConvexMutation(gateway.social.setProfileVisibility),
+  });
 
   // The visibility setting lives on the Social profile (separate from the identity account fields
   // above). Treat an absent profile/value as the "public" default.
-  const socialProfile = useQuery(gateway.social.profile, {});
+  const { data: socialProfile } = useQuery(
+    convexQuery(gateway.social.profile, {}),
+  );
   const isPrivate = socialProfile?.visibility === "private";
 
   const [username, setUsername] = useState(member.username ?? "");
   const [location, setLocation] = useState(member.location ?? "");
   const [bio, setBio] = useState(member.bio ?? "");
   const [saving, setSaving] = useState(false);
-  const [visibilitySaving, setVisibilitySaving] = useState(false);
 
   const handleVisibilityChange = async (nextPrivate: boolean) => {
-    setVisibilitySaving(true);
     try {
-      await setProfileVisibility({
+      await setProfileVisibility.mutateAsync({
         visibility: nextPrivate ? "private" : "public",
       });
       toast.success(t("saved"));
     } catch {
       toast.error(t("saveError"));
-    } finally {
-      setVisibilitySaving(false);
     }
   };
 
@@ -76,7 +79,7 @@ export function EditProfileForm({
         await user.update({ username: nextUsername });
       }
       // Location/bio live only in Convex.
-      await updateProfile({
+      await updateProfile.mutateAsync({
         location: location.trim() || undefined,
         bio: bio.trim() || undefined,
       });
@@ -129,7 +132,9 @@ export function EditProfileForm({
         <Switch
           id="profile-visibility"
           checked={isPrivate}
-          disabled={visibilitySaving || socialProfile === undefined}
+          disabled={
+            setProfileVisibility.isPending || socialProfile === undefined
+          }
           onCheckedChange={handleVisibilityChange}
           aria-label={t("visibility.label")}
         />

--- a/apps/web/src/components/profile/edit-profile-form.tsx
+++ b/apps/web/src/components/profile/edit-profile-form.tsx
@@ -39,9 +39,7 @@ export function EditProfileForm({
 }) {
   const t = useTranslations("profile");
   const { user } = useUser();
-  const updateProfile = useMutation({
-    mutationFn: useConvexMutation(gateway.identity.updateProfile),
-  });
+  const updateProfile = useConvexMutation(gateway.identity.updateProfile);
   const setProfileVisibility = useMutation({
     mutationFn: useConvexMutation(gateway.social.setProfileVisibility),
   });
@@ -56,7 +54,31 @@ export function EditProfileForm({
   const [username, setUsername] = useState(member.username ?? "");
   const [location, setLocation] = useState(member.location ?? "");
   const [bio, setBio] = useState(member.bio ?? "");
-  const [saving, setSaving] = useState(false);
+
+  // The WHOLE save — the Clerk username update AND the Convex profile write — runs as one
+  // mutationFn so isPending spans both steps with no gap (busy-state rule v2).
+  const saveProfile = useMutation({
+    mutationFn: async () => {
+      // Username -> Clerk (the source of truth); the user.updated webhook mirrors
+      // it into the Convex `users` cache. Only call when it actually changed.
+      const nextUsername = username.trim();
+      if (user && nextUsername !== (member.username ?? "")) {
+        await user.update({ username: nextUsername });
+      }
+      // Location/bio live only in Convex.
+      await updateProfile({
+        location: location.trim() || undefined,
+        bio: bio.trim() || undefined,
+      });
+    },
+    onSuccess: () => {
+      toast.success(t("saved"));
+      onDone();
+    },
+    onError: (err) => {
+      toast.error(clerkErrorMessage(err) ?? t("saveError"));
+    },
+  });
 
   const handleVisibilityChange = async (nextPrivate: boolean) => {
     try {
@@ -66,29 +88,6 @@ export function EditProfileForm({
       toast.success(t("saved"));
     } catch {
       toast.error(t("saveError"));
-    }
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      // Username -> Clerk (the source of truth); the user.updated webhook mirrors
-      // it into the Convex `users` cache. Only call when it actually changed.
-      const nextUsername = username.trim();
-      if (user && nextUsername !== (member.username ?? "")) {
-        await user.update({ username: nextUsername });
-      }
-      // Location/bio live only in Convex.
-      await updateProfile.mutateAsync({
-        location: location.trim() || undefined,
-        bio: bio.trim() || undefined,
-      });
-      toast.success(t("saved"));
-      onDone();
-    } catch (err) {
-      toast.error(clerkErrorMessage(err) ?? t("saveError"));
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -140,11 +139,18 @@ export function EditProfileForm({
         />
       </div>
       <div className="flex gap-2 sm:col-span-2">
-        <Button onClick={handleSave} disabled={saving}>
+        <Button
+          onClick={() => saveProfile.mutate()}
+          disabled={saveProfile.isPending}
+        >
           <Save aria-hidden />
-          {saving ? t("saving") : t("save")}
+          {saveProfile.isPending ? t("saving") : t("save")}
         </Button>
-        <Button variant="outline" onClick={onDone} disabled={saving}>
+        <Button
+          variant="outline"
+          onClick={onDone}
+          disabled={saveProfile.isPending}
+        >
           {t("cancel")}
         </Button>
       </div>

--- a/apps/web/src/components/profile/identity-header.tsx
+++ b/apps/web/src/components/profile/identity-header.tsx
@@ -5,7 +5,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { AtSign, Calendar, MapPin, Pencil, Star, X } from "lucide-react";
 import { useTranslations } from "use-intl";
 import type { Member } from "./member-view";
@@ -26,9 +27,11 @@ export function IdentityHeader({
 }) {
   const t = useTranslations("profile");
   const { user } = useUser();
-  const reputation = useQuery(gateway.reputation.profile, {
-    memberId: member._id as Id<"users">,
-  });
+  const { data: reputation } = useQuery(
+    convexQuery(gateway.reputation.profile, {
+      memberId: member._id as Id<"users">,
+    }),
+  );
 
   const avatarSrc = member.avatar ?? user?.imageUrl;
   const initials = (member.name ?? "?")

--- a/apps/web/src/components/profile/shelf-section.tsx
+++ b/apps/web/src/components/profile/shelf-section.tsx
@@ -7,7 +7,8 @@ import { SectionHead } from "@/components/dashboard-home/section-head";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import { BookOpen, Settings2 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -59,18 +60,22 @@ export function ProfileShelfSection({ member }: { member: Member }) {
   const [arrangeOpen, setArrangeOpen] = useState(false);
 
   // Determine whether the signed-in user is the profile owner.
-  const me = useQuery(gateway.identity.currentUser);
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
   const isOwner = me?._id === member._id;
 
-  const copies = useQuery(gateway.library.ownedByOwner, {
-    ownerId: member._id as Id<"users">,
-    includeUnavailable: true,
-  });
+  const { data: copies } = useQuery(
+    convexQuery(gateway.library.ownedByOwner, {
+      ownerId: member._id as Id<"users">,
+      includeUnavailable: true,
+    }),
+  );
 
   // The curated shelf — empty list means uncurated (fall back to recent-6 below).
-  const featuredCopies = useQuery(gateway.social.featuredShelf, {
-    userId: member._id as Id<"users">,
-  });
+  const { data: featuredCopies } = useQuery(
+    convexQuery(gateway.social.featuredShelf, {
+      userId: member._id as Id<"users">,
+    }),
+  );
 
   const firstName = member.name?.split(/\s+/)[0] ?? member.name;
   const title = t("title", { name: firstName });

--- a/apps/web/src/components/profile/stats-section.tsx
+++ b/apps/web/src/components/profile/stats-section.tsx
@@ -3,7 +3,8 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 import type { Member } from "./member-view";
 
@@ -22,9 +23,11 @@ function trustLevelKey(
 // slim centered strip.
 export function ProfileStatsSection({ member }: { member: Member }) {
   const t = useTranslations("profile");
-  const stats = useQuery(gateway.identity.userStats, {
-    userId: member._id as Id<"users">,
-  });
+  const { data: stats } = useQuery(
+    convexQuery(gateway.identity.userStats, {
+      userId: member._id as Id<"users">,
+    }),
+  );
 
   if (stats === undefined) {
     return (

--- a/apps/web/src/components/puzzle-import/use-puzzle-import.ts
+++ b/apps/web/src/components/puzzle-import/use-puzzle-import.ts
@@ -1,5 +1,6 @@
 import { gateway } from "@/gateway";
-import { useAction } from "convex/react";
+import { useConvexAction } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import type { ImportedDraft } from "./draft-to-form-defaults";
 
@@ -19,13 +20,15 @@ export type ImportState =
   | { status: "ready"; draft: ImportedDraft; match: ImportedMatch | null };
 
 export const usePuzzleImport = () => {
-  const extract = useAction(gateway.catalog.extractPuzzleFromUrl);
+  const extract = useMutation({
+    mutationFn: useConvexAction(gateway.catalog.extractPuzzleFromUrl),
+  });
   const [state, setState] = useState<ImportState>({ status: "idle" });
 
   const run = async (url: string) => {
     setState({ status: "loading" });
     try {
-      const result = await extract({ url });
+      const result = await extract.mutateAsync({ url });
       if (!result.ok) {
         setState({ status: "error" });
         return;

--- a/apps/web/src/components/puzzle-import/use-puzzle-import.ts
+++ b/apps/web/src/components/puzzle-import/use-puzzle-import.ts
@@ -13,6 +13,9 @@ export interface ImportedMatch {
   imageUrl?: string;
 }
 
+// Kept as an explicit state machine (busy-state rule v2 exemption): the exported
+// ImportState carries draft/match result data and maps a non-throwing
+// result.ok === false to 'error', which a derived useMutation mapping would not simplify.
 export type ImportState =
   | { status: "idle" }
   | { status: "loading" }

--- a/apps/web/src/components/puzzles/puzzle-client.tsx
+++ b/apps/web/src/components/puzzles/puzzle-client.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
 import { useFavorites } from "@/hooks/use-favorites";
+// sanctioned convex/react exception: usePaginatedQuery (see tanstack-query migration spec)
 import { usePaginatedQuery } from "convex/react";
 import { Filter, Grid, Heart, List, Plus, Search, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/apps/web/src/components/puzzles/puzzle-filters.tsx
+++ b/apps/web/src/components/puzzles/puzzle-filters.tsx
@@ -13,7 +13,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -46,12 +47,14 @@ export function PuzzleFilters({
   const tPuzzles = useTranslations("puzzles");
 
   // Extract unique brands and categories from puzzles
-  const brands = useQuery(gateway.catalog.allBrands);
+  const { data: brands } = useQuery(convexQuery(gateway.catalog.allBrands, {}));
 
-  const categories = useQuery(gateway.adminCatalog.listAll);
+  const { data: categories } = useQuery(
+    convexQuery(gateway.adminCatalog.listAll, {}),
+  );
 
   // Extract all unique tags
-  const allTags = useQuery(gateway.catalog.allTags);
+  const { data: allTags } = useQuery(convexQuery(gateway.catalog.allTags, {}));
 
   const updateFilter = (key: keyof Filters, value: string | string[]) => {
     onFiltersChange({ ...filters, [key]: value });

--- a/apps/web/src/components/reputation/leave-review-dialog.tsx
+++ b/apps/web/src/components/reputation/leave-review-dialog.tsx
@@ -15,7 +15,8 @@ import { StarRating } from "@/components/ui/star-rating";
 import { Textarea } from "@/components/ui/textarea";
 import type { Id } from "@/gateway";
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ConvexError } from "convex/values";
 import { CheckCircle, Star } from "lucide-react";
 import { useState } from "react";
@@ -52,11 +53,15 @@ export function LeaveReviewDialog({
   revieweeName,
 }: LeaveReviewDialogProps) {
   const t = useTranslations("reputation");
-  const submitReview = useMutation(gateway.reputation.submitReview);
+  const submitReview = useMutation({
+    mutationFn: useConvexMutation(gateway.reputation.submitReview),
+  });
 
-  const existingReview = useQuery(
-    gateway.reputation.myReviewForExchange,
-    exchangeId ? { exchangeId } : "skip",
+  const { data: existingReview } = useQuery(
+    convexQuery(
+      gateway.reputation.myReviewForExchange,
+      exchangeId ? { exchangeId } : "skip",
+    ),
   );
 
   const [open, setOpen] = useState(false);
@@ -68,7 +73,6 @@ export function LeaveReviewDialog({
     timeliness: 0,
   });
   const [comment, setComment] = useState("");
-  const [submitting, setSubmitting] = useState(false);
 
   // Legacy rows without an aggregateId, or a missing counterparty, can't be reviewed.
   const canReview = Boolean(exchangeId && revieweeId);
@@ -97,9 +101,8 @@ export function LeaveReviewDialog({
 
   const handleSubmit = async () => {
     if (!exchangeId || !revieweeId || !allFilled) return;
-    setSubmitting(true);
     try {
-      await submitReview({
+      await submitReview.mutateAsync({
         exchangeId,
         revieweeId,
         rating,
@@ -137,8 +140,6 @@ export function LeaveReviewDialog({
         default:
           toast.error(t("errors.generic"));
       }
-    } finally {
-      setSubmitting(false);
     }
   };
 
@@ -207,12 +208,15 @@ export function LeaveReviewDialog({
           <Button
             variant="ghost"
             onClick={() => setOpen(false)}
-            disabled={submitting}
+            disabled={submitReview.isPending}
           >
             {t("cancel")}
           </Button>
-          <Button onClick={handleSubmit} disabled={!allFilled || submitting}>
-            {submitting ? t("submitting") : t("submitReview")}
+          <Button
+            onClick={handleSubmit}
+            disabled={!allFilled || submitReview.isPending}
+          >
+            {submitReview.isPending ? t("submitting") : t("submitReview")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/reputation/reputation-badge.tsx
+++ b/apps/web/src/components/reputation/reputation-badge.tsx
@@ -3,7 +3,8 @@
 import type { Id } from "@/gateway";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Star } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -17,9 +18,8 @@ interface ReputationBadgeProps {
 
 export function ReputationBadge({ memberId, className }: ReputationBadgeProps) {
   const t = useTranslations("reputation");
-  const profile = useQuery(
-    gateway.reputation.profile,
-    memberId ? { memberId } : "skip",
+  const { data: profile } = useQuery(
+    convexQuery(gateway.reputation.profile, memberId ? { memberId } : "skip"),
   );
 
   if (profile === undefined) return null;

--- a/apps/web/src/components/reputation/reputation-section.tsx
+++ b/apps/web/src/components/reputation/reputation-section.tsx
@@ -4,7 +4,8 @@ import { SectionHead } from "@/components/dashboard-home/section-head";
 import { StarRating } from "@/components/ui/star-rating";
 import type { Id } from "@/gateway";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ShieldCheck } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -27,13 +28,14 @@ function credibilityKey(credibility: number): "low" | "medium" | "high" {
 export function ReputationSection({ memberId }: ReputationSectionProps) {
   const t = useTranslations("reputation");
 
-  const profile = useQuery(
-    gateway.reputation.profile,
-    memberId ? { memberId } : "skip",
+  const { data: profile } = useQuery(
+    convexQuery(gateway.reputation.profile, memberId ? { memberId } : "skip"),
   );
-  const reviews = useQuery(
-    gateway.reputation.reviewsForMember,
-    memberId ? { memberId } : "skip",
+  const { data: reviews } = useQuery(
+    convexQuery(
+      gateway.reputation.reviewsForMember,
+      memberId ? { memberId } : "skip",
+    ),
   );
 
   if (profile === undefined || reviews === undefined) {

--- a/apps/web/src/components/social/activity-feed.tsx
+++ b/apps/web/src/components/social/activity-feed.tsx
@@ -4,7 +4,8 @@ import { EmptyState } from "@/components/community/primitives";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import { ArrowRightLeft, CircleCheck, Package } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -25,7 +26,7 @@ const META: Record<ActivityKind, { icon: LucideIcon; accent: string }> = {
 export function ActivityFeed() {
   const t = useTranslations("activity");
   const format = useFormatter();
-  const feed = useQuery(gateway.social.activityFeed, {});
+  const { data: feed } = useQuery(convexQuery(gateway.social.activityFeed, {}));
 
   if (feed === undefined) {
     return (

--- a/apps/web/src/components/social/follow-button.tsx
+++ b/apps/web/src/components/social/follow-button.tsx
@@ -2,9 +2,9 @@
 
 import { Button } from "@/components/ui/button";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { UserMinus, UserPlus } from "lucide-react";
-import { useState } from "react";
 import { toast } from "sonner";
 
 // Follow/unfollow toggle for a target member. Reads the live follow state from the gateway and
@@ -17,27 +17,30 @@ export function FollowButton({
   memberId: Id<"users">;
   size?: "default" | "sm";
 }) {
-  const following = useQuery(gateway.social.isFollowing, {
-    followeeId: memberId,
+  const { data: following } = useQuery(
+    convexQuery(gateway.social.isFollowing, {
+      followeeId: memberId,
+    }),
+  );
+  const follow = useMutation({
+    mutationFn: useConvexMutation(gateway.social.follow),
   });
-  const follow = useMutation(gateway.social.follow);
-  const unfollow = useMutation(gateway.social.unfollow);
-  const [pending, setPending] = useState(false);
+  const unfollow = useMutation({
+    mutationFn: useConvexMutation(gateway.social.unfollow),
+  });
+  const pending = follow.isPending || unfollow.isPending;
 
   const handleClick = async () => {
-    setPending(true);
     try {
       if (following) {
-        await unfollow({ followeeId: memberId });
+        await unfollow.mutateAsync({ followeeId: memberId });
         toast.success("Unfollowed");
       } else {
-        await follow({ followeeId: memberId });
+        await follow.mutateAsync({ followeeId: memberId });
         toast.success("Following");
       }
     } catch {
       toast.error("Could not update follow status");
-    } finally {
-      setPending(false);
     }
   };
 

--- a/apps/web/src/components/social/follow-list.tsx
+++ b/apps/web/src/components/social/follow-list.tsx
@@ -3,7 +3,8 @@
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 // A followers or following list for the acting member. The query resolves each counterparty's
@@ -16,11 +17,13 @@ export function FollowList({
   emptyHint: string;
 }) {
   const tCommon = useTranslations("common");
-  const edges = useQuery(
-    variant === "followers"
-      ? gateway.social.followers
-      : gateway.social.following,
-    {},
+  const { data: edges } = useQuery(
+    convexQuery(
+      variant === "followers"
+        ? gateway.social.followers
+        : gateway.social.following,
+      {},
+    ),
   );
 
   if (edges === undefined) {

--- a/apps/web/src/components/social/member-tile.tsx
+++ b/apps/web/src/components/social/member-tile.tsx
@@ -12,7 +12,8 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { MapPin, Star } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { FollowButton } from "./follow-button";
@@ -38,8 +39,12 @@ export function MemberTile({
   followsYou: boolean;
 }) {
   const t = useTranslations("people");
-  const member = useQuery(gateway.identity.byId, { userId: memberId });
-  const stats = useQuery(gateway.identity.userStats, { userId: memberId });
+  const { data: member } = useQuery(
+    convexQuery(gateway.identity.byId, { userId: memberId }),
+  );
+  const { data: stats } = useQuery(
+    convexQuery(gateway.identity.userStats, { userId: memberId }),
+  );
 
   if (member === undefined) {
     return <MemberTileSkeleton />;

--- a/apps/web/src/components/social/message-button.tsx
+++ b/apps/web/src/components/social/message-button.tsx
@@ -9,10 +9,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { gateway, Id } from "@/gateway";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
 import { MessageCircle } from "lucide-react";
-import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
 
@@ -33,23 +33,26 @@ export function MessageButton({
   const { member } = useCurrentMember();
   const me = member?._id;
 
-  const canMessage = useQuery(
-    gateway.conversation.canMessage,
-    me ? { recipientId: memberId } : "skip",
+  const { data: canMessage } = useQuery(
+    convexQuery(
+      gateway.conversation.canMessage,
+      me ? { recipientId: memberId } : "skip",
+    ),
   );
-  const openDmThread = useMutation(gateway.conversation.openDmThread);
-  const [pending, setPending] = useState(false);
+  const openDmThread = useMutation({
+    mutationFn: useConvexMutation(gateway.conversation.openDmThread),
+  });
+  const pending = openDmThread.isPending;
 
   const handleClick = async () => {
-    setPending(true);
     try {
-      const threadId = await openDmThread({ recipientId: memberId });
+      const threadId = await openDmThread.mutateAsync({
+        recipientId: memberId,
+      });
       await navigate({ to: "/messages/$threadId", params: { threadId } });
     } catch (error) {
       const code = conversationErrorCode(error);
       toast.error(code === "NotConnected" ? t("notConnected") : t("openError"));
-    } finally {
-      setPending(false);
     }
   };
 

--- a/apps/web/src/components/social/profile-edit-dialog.tsx
+++ b/apps/web/src/components/social/profile-edit-dialog.tsx
@@ -13,7 +13,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Pencil, Save, X } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -24,13 +25,15 @@ import { useTranslations } from "use-intl";
 // enforces a non-empty display name.
 export function ProfileEditDialog() {
   const t = useTranslations("profile.editor");
-  const profile = useQuery(gateway.social.profile, {});
-  const editProfile = useMutation(gateway.social.editProfile);
+  const { data: profile } = useQuery(convexQuery(gateway.social.profile, {}));
+  const editProfile = useMutation({
+    mutationFn: useConvexMutation(gateway.social.editProfile),
+  });
+  const saving = editProfile.isPending;
 
   const [open, setOpen] = useState(false);
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
-  const [saving, setSaving] = useState(false);
 
   // Reseed the form from the loaded profile every time the dialog opens, so a
   // reopen always starts from the saved values rather than a stale draft.
@@ -47,9 +50,8 @@ export function ProfileEditDialog() {
       toast.error(t("emptyNameError"));
       return;
     }
-    setSaving(true);
     try {
-      await editProfile({
+      await editProfile.mutateAsync({
         displayName: displayName.trim(),
         bio: bio.trim() === "" ? undefined : bio.trim(),
       });
@@ -57,8 +59,6 @@ export function ProfileEditDialog() {
       setOpen(false);
     } catch {
       toast.error(t("saveError"));
-    } finally {
-      setSaving(false);
     }
   };
 

--- a/apps/web/src/components/solving/edit-completion-dialog.tsx
+++ b/apps/web/src/components/solving/edit-completion-dialog.tsx
@@ -13,7 +13,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
@@ -54,7 +55,9 @@ export function EditCompletionDialog({
 }: EditCompletionDialogProps) {
   const t = useTranslations("solving.logSolve");
   const tCompletions = useTranslations("solving.completions");
-  const editCompletion = useMutation(gateway.solving.editCompletion);
+  const editCompletion = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.editCompletion),
+  });
 
   const [startDate, setStartDate] = useState(msToDateInput(initialStartDate));
   const [endDate, setEndDate] = useState(msToDateInput(initialEndDate));
@@ -65,7 +68,7 @@ export function EditCompletionDialog({
     initialTimeMinutes ? String(initialTimeMinutes % 60) : "",
   );
   const [notes, setNotes] = useState(initialNotes ?? "");
-  const [submitting, setSubmitting] = useState(false);
+  const submitting = editCompletion.isPending;
 
   const handleSubmit = async () => {
     const start = dateInputToMs(startDate);
@@ -73,9 +76,8 @@ export function EditCompletionDialog({
     const totalMinutes =
       (Number(hours) || 0) * 60 + (Number(minutes) || 0) || undefined;
 
-    setSubmitting(true);
     try {
-      await editCompletion({
+      await editCompletion.mutateAsync({
         completionId,
         startDate: start,
         endDate: end,
@@ -92,8 +94,6 @@ export function EditCompletionDialog({
         console.error("Failed to edit completion:", error);
         toast.error(t("saveError"));
       }
-    } finally {
-      setSubmitting(false);
     }
   };
 

--- a/apps/web/src/components/solving/finish-solve-dialog.tsx
+++ b/apps/web/src/components/solving/finish-solve-dialog.tsx
@@ -14,7 +14,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { gateway } from "@/gateway";
 import { useUserSettings } from "@/hooks/use-user-settings";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
@@ -37,14 +38,16 @@ export function FinishSolveDialog({
   completionId,
 }: FinishSolveDialogProps) {
   const t = useTranslations("solving.logSolve");
-  const finishCompletion = useMutation(gateway.solving.finishCompletion);
+  const finishCompletion = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.finishCompletion),
+  });
   const { trackCompletionDuration } = useUserSettings();
 
   const [endDate, setEndDate] = useState(todayInputValue);
   const [hours, setHours] = useState("");
   const [minutes, setMinutes] = useState("");
   const [allPiecesPresent, setAllPiecesPresent] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
+  const submitting = finishCompletion.isPending;
 
   const showDuration = trackCompletionDuration === true;
 
@@ -54,9 +57,8 @@ export function FinishSolveDialog({
     const totalMinutes =
       (Number(hours) || 0) * 60 + (Number(minutes) || 0) || undefined;
 
-    setSubmitting(true);
     try {
-      await finishCompletion({
+      await finishCompletion.mutateAsync({
         completionId,
         endDate: end,
         completionTimeMinutes: showDuration ? totalMinutes : undefined,
@@ -67,8 +69,6 @@ export function FinishSolveDialog({
     } catch (error) {
       console.error("Failed to finish solve:", error);
       toast.error(t("saveError"));
-    } finally {
-      setSubmitting(false);
     }
   };
 

--- a/apps/web/src/components/solving/log-solve-dialog.tsx
+++ b/apps/web/src/components/solving/log-solve-dialog.tsx
@@ -16,7 +16,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
 import { useUserSettings } from "@/hooks/use-user-settings";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
@@ -57,8 +58,12 @@ export function LogSolveDialog({
   onSuccess,
 }: LogSolveDialogProps) {
   const t = useTranslations("solving.logSolve");
-  const recordCompletion = useMutation(gateway.solving.recordCompletion);
-  const updateDetails = useMutation(gateway.library.updateDetails);
+  const recordCompletion = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.recordCompletion),
+  });
+  const updateDetails = useMutation({
+    mutationFn: useConvexMutation(gateway.library.updateDetails),
+  });
   const { trackCompletionDuration } = useUserSettings();
   const { requestPrompt } = useDurationPrompt();
 
@@ -68,7 +73,6 @@ export function LogSolveDialog({
   const [minutes, setMinutes] = useState("");
   const [notes, setNotes] = useState("");
   const [allPiecesPresent, setAllPiecesPresent] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
   const [offerUpdateCopy, setOfferUpdateCopy] = useState(false);
 
   const showDuration = trackCompletionDuration === true;
@@ -94,9 +98,8 @@ export function LogSolveDialog({
 
     const wasFirstChoice = trackCompletionDuration === undefined;
 
-    setSubmitting(true);
     try {
-      await recordCompletion({
+      await recordCompletion.mutateAsync({
         copyId,
         startDate: start,
         endDate: end,
@@ -119,14 +122,12 @@ export function LogSolveDialog({
     } catch (error) {
       console.error("Failed to log solve:", error);
       toast.error(t("saveError"));
-    } finally {
-      setSubmitting(false);
     }
   };
 
   const confirmUpdateCopy = async () => {
     try {
-      await updateDetails({ copyId, missingPiecesCount: 1 });
+      await updateDetails.mutateAsync({ copyId, missingPiecesCount: 1 });
     } catch (error) {
       console.error("Failed to update copy pieces:", error);
       toast.error(t("saveError"));
@@ -228,7 +229,10 @@ export function LogSolveDialog({
           </div>
 
           <DialogFooter>
-            <Button onClick={handleSubmit} disabled={submitting || !startDate}>
+            <Button
+              onClick={handleSubmit}
+              disabled={recordCompletion.isPending || !startDate}
+            >
               {t("submit")}
             </Button>
           </DialogFooter>

--- a/apps/web/src/components/solving/review-puzzle-dialog.tsx
+++ b/apps/web/src/components/solving/review-puzzle-dialog.tsx
@@ -13,7 +13,8 @@ import { Label } from "@/components/ui/label";
 import { StarRating } from "@/components/ui/star-rating";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
@@ -36,11 +37,12 @@ export function ReviewPuzzleDialog({
   initialText,
 }: ReviewPuzzleDialogProps) {
   const t = useTranslations("solving.review");
-  const reviewPuzzle = useMutation(gateway.solving.reviewPuzzle);
+  const reviewPuzzle = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.reviewPuzzle),
+  });
 
   const [rating, setRating] = useState(initialRating ?? 0);
   const [text, setText] = useState(initialText ?? "");
-  const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = async () => {
     // The domain validates 1–5; block the call early so the user gets an inline hint instead.
@@ -48,9 +50,8 @@ export function ReviewPuzzleDialog({
       toast.error(t("ratingRequired"));
       return;
     }
-    setSubmitting(true);
     try {
-      await reviewPuzzle({
+      await reviewPuzzle.mutateAsync({
         completionId,
         rating,
         text: text.trim() || undefined,
@@ -60,8 +61,6 @@ export function ReviewPuzzleDialog({
     } catch (error) {
       console.error("Failed to save review:", error);
       toast.error(t("saveError"));
-    } finally {
-      setSubmitting(false);
     }
   };
 
@@ -95,7 +94,7 @@ export function ReviewPuzzleDialog({
         </div>
 
         <DialogFooter>
-          <Button onClick={handleSubmit} disabled={submitting}>
+          <Button onClick={handleSubmit} disabled={reviewPuzzle.isPending}>
             {t("submit")}
           </Button>
         </DialogFooter>

--- a/apps/web/src/components/ui/collection-dropdown.tsx
+++ b/apps/web/src/components/ui/collection-dropdown.tsx
@@ -11,9 +11,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { FolderOpen, Plus } from "lucide-react";
-import { useState } from "react";
 import { useTranslations } from "use-intl";
 
 interface CollectionTargetProps {
@@ -32,23 +32,30 @@ export function CollectionMenuItems({
 }: CollectionTargetProps) {
   const { user } = useUser();
   const t = useTranslations("collections");
-  const [isAdding, setIsAdding] = useState(false);
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const collections = useQuery(
-    gateway.collections.listForUser,
-    convexUser?._id ? { userId: convexUser._id as Id<"users"> } : "skip",
+  const { data: collections } = useQuery(
+    convexQuery(
+      gateway.collections.listForUser,
+      convexUser?._id ? { userId: convexUser._id as Id<"users"> } : "skip",
+    ),
   );
 
-  const puzzleCollections = useQuery(gateway.collections.forOwnedPuzzle, {
-    ownedPuzzleId,
+  const { data: puzzleCollections } = useQuery(
+    convexQuery(gateway.collections.forOwnedPuzzle, {
+      ownedPuzzleId,
+    }),
+  );
+
+  const addPuzzleToCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.addOwnedPuzzle),
   });
-
-  const addPuzzleToCollection = useMutation(gateway.collections.addOwnedPuzzle);
 
   const handleAddToCollection = async (collectionAggregateId?: string) => {
     // The domain add takes the Collection + Copy aggregateIds; guard either missing.
@@ -56,16 +63,13 @@ export function CollectionMenuItems({
       console.error("Cannot add: collection or copy is missing aggregateId.");
       return;
     }
-    setIsAdding(true);
     try {
-      await addPuzzleToCollection({
+      await addPuzzleToCollection.mutateAsync({
         collectionId: collectionAggregateId,
         copyId: copyAggregateId,
       });
     } catch (error) {
       console.error("Failed to add puzzle to collection:", error);
-    } finally {
-      setIsAdding(false);
     }
   };
 
@@ -90,7 +94,9 @@ export function CollectionMenuItems({
         <DropdownMenuItem
           key={collection._id}
           onClick={() => handleAddToCollection(collection.aggregateId)}
-          disabled={isInCollection(collection._id) || isAdding}
+          disabled={
+            isInCollection(collection._id) || addPuzzleToCollection.isPending
+          }
           className={isInCollection(collection._id) ? "opacity-50" : ""}
         >
           <div className="flex items-center gap-2 w-full">

--- a/apps/web/src/hooks/use-favorites.ts
+++ b/apps/web/src/hooks/use-favorites.ts
@@ -1,27 +1,34 @@
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 // The member's favorited catalog definitions + an optimistic toggle. Every heart shares the one
 // myFavoritePuzzleIds subscription (Convex dedupes identical query+args pairs), and the toggle
 // patches that cached result locally so the heart flips instantly before the server confirms.
+// The optimistic patch lands in the Convex local store; the tanstack-query bridge's watch on
+// this query mirrors localQueryResult() into the QueryClient, so the heart still flips instantly.
 export function useFavorites() {
-  const ids = useQuery(gateway.catalog.myFavoritePuzzleIds, {});
-  const toggle = useMutation(
-    gateway.catalog.toggleFavorite,
-  ).withOptimisticUpdate((localStore, args) => {
-    const current = localStore.getQuery(
-      gateway.catalog.myFavoritePuzzleIds,
-      {},
-    );
-    if (current === undefined) return;
-    const next = current.includes(args.puzzleId)
-      ? current.filter((id) => id !== args.puzzleId)
-      : [...current, args.puzzleId];
-    localStore.setQuery(gateway.catalog.myFavoritePuzzleIds, {}, next);
+  const { data: ids, isPending } = useQuery(
+    convexQuery(gateway.catalog.myFavoritePuzzleIds, {}),
+  );
+  const { mutateAsync: toggle } = useMutation({
+    mutationFn: useConvexMutation(
+      gateway.catalog.toggleFavorite,
+    ).withOptimisticUpdate((localStore, args) => {
+      const current = localStore.getQuery(
+        gateway.catalog.myFavoritePuzzleIds,
+        {},
+      );
+      if (current === undefined) return;
+      const next = current.includes(args.puzzleId)
+        ? current.filter((id) => id !== args.puzzleId)
+        : [...current, args.puzzleId];
+      localStore.setQuery(gateway.catalog.myFavoritePuzzleIds, {}, next);
+    }),
   });
 
   return {
-    isLoading: ids === undefined,
+    isLoading: isPending,
     isFavorite: (puzzleId: string) =>
       (ids ?? []).includes(puzzleId as Id<"puzzles">),
     toggleFavorite: (puzzleId: string) =>

--- a/apps/web/src/hooks/use-user-settings.ts
+++ b/apps/web/src/hooks/use-user-settings.ts
@@ -1,16 +1,19 @@
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 // Reads the member's federated settings and exposes the solving duration preference + its setter.
 // `trackCompletionDuration` is undefined until first chosen; the dialogs use that to decide whether
 // to show the secondary first-time prompt. `isLoading` guards the initial fetch.
 export function useUserSettings() {
-  const settings = useQuery(gateway.settings.mine, {});
-  const setTrackDuration = useMutation(
-    gateway.solving.setTrackCompletionDuration,
+  const { data: settings, isPending } = useQuery(
+    convexQuery(gateway.settings.mine, {}),
   );
+  const { mutateAsync: setTrackDuration } = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.setTrackCompletionDuration),
+  });
   return {
-    isLoading: settings === undefined,
+    isLoading: isPending || settings === undefined,
     trackCompletionDuration: settings?.solving.trackCompletionDuration,
     setTrackDuration: (enabled: boolean) => setTrackDuration({ enabled }),
   };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -25,6 +25,17 @@ export function getRouter() {
       queries: {
         queryKeyHashFn: convexQueryClient.hashFn(),
         queryFn: convexQueryClient.queryFn(),
+        // WHY Infinity: the bridge holds a live Convex subscription per cached query and
+        // pushes every new server result straight into this cache, so data is never
+        // stale and never needs refetch-on-mount/focus. The @convex-dev/react-query
+        // README: "New query results are pushed from the server, so a staleTime of
+        // Infinity should be used." (convexQuery() also sets it per-site; this default
+        // covers anything routed through the global queryFn without the factory.)
+        staleTime: Infinity,
+        // gcTime deliberately stays at the TanStack default (5 min): the README
+        // prescribes no value, only that it controls how long the Convex subscription
+        // outlives the last unmounted useQuery — 5 min keeps remounts (tab switches,
+        // navigation) rendering instantly from live cache instead of flashing loading.
       },
     },
   });

--- a/apps/web/src/routes/_dashboard/admin/categories.tsx
+++ b/apps/web/src/routes/_dashboard/admin/categories.tsx
@@ -7,7 +7,8 @@ import { usePageHeaderActions } from "@/components/dashboard-layout/page-header-
 import { Button } from "@/components/ui/button";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Plus, Shapes } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslations } from "use-intl";
@@ -33,7 +34,9 @@ type DialogState = { mode: "create" } | { mode: "edit"; category: Category };
 
 function CategoriesPage() {
   const t = useTranslations("admin.categories");
-  const categories = useQuery(gateway.adminCatalog.listAll);
+  const { data: categories } = useQuery(
+    convexQuery(gateway.adminCatalog.listAll, {}),
+  );
 
   const [dialog, setDialog] = useState<DialogState | null>(null);
 

--- a/apps/web/src/routes/_dashboard/admin/contact.tsx
+++ b/apps/web/src/routes/_dashboard/admin/contact.tsx
@@ -7,9 +7,9 @@ import { Button } from "@/components/ui/button";
 import { PageLoading } from "@/components/ui/loading";
 import type { Id } from "@/gateway";
 import { gateway } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Check } from "lucide-react";
-import { useState } from "react";
 import { toast } from "sonner";
 import { useFormatter, useTranslations } from "use-intl";
 
@@ -27,19 +27,24 @@ function ContactTriagePage() {
   const t = useTranslations("admin.contact");
   const tAdmin = useTranslations("admin");
   const format = useFormatter();
-  const messages = useQuery(gateway.adminTriage.contactMessages);
-  const markHandled = useMutation(gateway.adminTriage.markContactHandled);
-  const [busyId, setBusyId] = useState<string | null>(null);
+  const { data: messages } = useQuery(
+    convexQuery(gateway.adminTriage.contactMessages, {}),
+  );
+  const markHandled = useMutation({
+    mutationFn: useConvexMutation(gateway.adminTriage.markContactHandled),
+  });
+  // Scope the pending state to the message being handled so only that row's
+  // button disables, exactly as the old per-id busy flag did.
+  const busyId = markHandled.isPending
+    ? (markHandled.variables?.id ?? null)
+    : null;
 
   const handle = async (id: Id<"contactMessages">) => {
-    setBusyId(id);
     try {
-      await markHandled({ id });
+      await markHandled.mutateAsync({ id });
       toast.success(t("markHandledSuccess"));
     } catch {
       toast.error(t("markHandledError"));
-    } finally {
-      setBusyId(null);
     }
   };
 

--- a/apps/web/src/routes/_dashboard/admin/feedback.tsx
+++ b/apps/web/src/routes/_dashboard/admin/feedback.tsx
@@ -5,7 +5,8 @@ import { QueueEmpty } from "@/components/admin/queue-empty";
 import { Badge } from "@/components/ui/badge";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 
@@ -22,7 +23,9 @@ function DocFeedbackPage() {
   const t = useTranslations("admin.docFeedback");
   const tAdmin = useTranslations("admin");
   const format = useFormatter();
-  const feedback = useQuery(gateway.adminTriage.docFeedback);
+  const { data: feedback } = useQuery(
+    convexQuery(gateway.adminTriage.docFeedback, {}),
+  );
 
   if (feedback === undefined) {
     return <PageLoading message={t("loading")} />;

--- a/apps/web/src/routes/_dashboard/admin/moderation.tsx
+++ b/apps/web/src/routes/_dashboard/admin/moderation.tsx
@@ -25,7 +25,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Flag, History, Inbox } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -62,19 +63,38 @@ function ModerationPage() {
   const tAdmin = useTranslations("admin");
   const format = useFormatter();
 
-  const pending = useQuery(gateway.catalog.pending);
+  const { data: pending } = useQuery(convexQuery(gateway.catalog.pending, {}));
   // One subscription serves both the tab's count pill and the tab body.
-  const flagged = useQuery(gateway.admin.listRejectedPhotos);
-  const approve = useMutation(gateway.catalog.approve);
-  const reject = useMutation(gateway.catalog.reject);
-  const update = useMutation(gateway.catalog.updatePuzzle);
-  const confirmRemoval = useMutation(gateway.admin.confirmPhotoRemoval);
-  const restorePhoto = useMutation(gateway.admin.restorePhoto);
+  const { data: flagged } = useQuery(
+    convexQuery(gateway.admin.listRejectedPhotos, {}),
+  );
+  const approve = useMutation({
+    mutationFn: useConvexMutation(gateway.catalog.approve),
+  });
+  const reject = useMutation({
+    mutationFn: useConvexMutation(gateway.catalog.reject),
+  });
+  const update = useMutation({
+    mutationFn: useConvexMutation(gateway.catalog.updatePuzzle),
+  });
+  const confirmRemoval = useMutation({
+    mutationFn: useConvexMutation(gateway.admin.confirmPhotoRemoval),
+  });
+  const restorePhoto = useMutation({
+    mutationFn: useConvexMutation(gateway.admin.restorePhoto),
+  });
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedFlagId, setSelectedFlagId] = useState<string | null>(null);
   const [editOpen, setEditOpen] = useState(false);
-  const [busy, setBusy] = useState(false);
+  // The old code shared one busy flag across every moderation action to
+  // disable the group; compose the mutations' pending states instead.
+  const busy =
+    approve.isPending ||
+    reject.isPending ||
+    update.isPending ||
+    confirmRemoval.isPending ||
+    restorePhoto.isPending;
 
   // A pre-domain pending row has no aggregateId; it still lists (keyed by _id)
   // but its actions stay disabled — same rule as the previous queue.
@@ -97,10 +117,9 @@ function ModerationPage() {
 
   const moderate = async (action: "approve" | "reject") => {
     if (!selected?.aggregateId || !pending) return;
-    setBusy(true);
     try {
       const run = action === "approve" ? approve : reject;
-      await run({ puzzleDefinitionId: selected.aggregateId });
+      await run.mutateAsync({ puzzleDefinitionId: selected.aggregateId });
       toast.success(
         t(action === "approve" ? "toast.approved" : "toast.rejected", {
           title: selected.title,
@@ -110,16 +129,13 @@ function ModerationPage() {
       selectNext(selected);
     } catch {
       toast.error(t("error"));
-    } finally {
-      setBusy(false);
     }
   };
 
   const editApprove = async (values: EditApproveValues) => {
     if (!selected?.aggregateId || !pending) return;
-    setBusy(true);
     try {
-      await update({
+      await update.mutateAsync({
         puzzleDefinitionId: selected.aggregateId,
         title: values.title,
         description: values.description || undefined,
@@ -128,7 +144,7 @@ function ModerationPage() {
         difficulty: values.difficulty,
         tags: values.tags,
       });
-      await approve({
+      await approve.mutateAsync({
         puzzleDefinitionId: selected.aggregateId,
         edited: true,
       });
@@ -142,8 +158,6 @@ function ModerationPage() {
       selectNext(selected);
     } catch {
       toast.error(t("error"));
-    } finally {
-      setBusy(false);
     }
   };
 
@@ -164,10 +178,9 @@ function ModerationPage() {
 
   const moderateFlag = async (action: "remove" | "restore") => {
     if (!selectedFlag || !flagged) return;
-    setBusy(true);
     try {
       const run = action === "remove" ? confirmRemoval : restorePhoto;
-      await run({ imageId: selectedFlag.imageId });
+      await run.mutateAsync({ imageId: selectedFlag.imageId });
       toast.success(
         t(action === "remove" ? "toast.removed" : "toast.restored", {
           title: selectedFlag.puzzleTitle,
@@ -177,8 +190,6 @@ function ModerationPage() {
       selectNextFlag(selectedFlag);
     } catch {
       toast.error(t("error"));
-    } finally {
-      setBusy(false);
     }
   };
 

--- a/apps/web/src/routes/_dashboard/admin/route.tsx
+++ b/apps/web/src/routes/_dashboard/admin/route.tsx
@@ -1,9 +1,10 @@
 import { useUser } from "@/compat/clerk";
 import { PageLoading } from "@/components/ui/loading";
 import { requireAdmin } from "@/lib/require-admin";
+import { convexQuery } from "@convex-dev/react-query";
 import { gateway } from "@jigswap/gateway";
+import { useQuery } from "@tanstack/react-query";
 import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
 import { useEffect } from "react";
 
 // Admin pages render inside the dashboard shell; this pathless-child group only
@@ -28,7 +29,9 @@ export const Route = createFileRoute("/_dashboard/admin")({
 
 function AdminGate() {
   const { user } = useUser();
-  const isAdmin = useQuery(gateway.identity.isAdmin, user?.id ? {} : "skip");
+  const { data: isAdmin } = useQuery(
+    convexQuery(gateway.identity.isAdmin, user?.id ? {} : "skip"),
+  );
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/apps/web/src/routes/_dashboard/borrowed.tsx
+++ b/apps/web/src/routes/_dashboard/borrowed.tsx
@@ -8,7 +8,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
 import { useDateFnsLocale } from "@/lib/date-locale";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { HandHelping, Package, User } from "lucide-react";
 import { useState } from "react";
@@ -34,11 +35,17 @@ function BorrowedPage() {
   const dateLocale = useDateFnsLocale();
 
   // Source of truth for "copies I'm holding on loan"; open loans where the caller is the borrower.
-  const borrowed = useQuery(gateway.lending.borrowed);
-  const returnLoan = useMutation(gateway.lending.returnLoan);
+  const { data: borrowed, isPending } = useQuery(
+    convexQuery(gateway.lending.borrowed, {}),
+  );
+  const returnLoan = useMutation({
+    mutationFn: useConvexMutation(gateway.lending.returnLoan),
+  });
 
   // The loan currently being returned, so we can disable just its button while the mutation runs.
-  const [returningId, setReturningId] = useState<string | null>(null);
+  const returningId = returnLoan.isPending
+    ? (returnLoan.variables?.loanId ?? null)
+    : null;
   // The loan for which we are logging a solve (null = dialog closed).
   const [solveFor, setSolveFor] = useState<{
     copyId: string;
@@ -46,17 +53,14 @@ function BorrowedPage() {
   } | null>(null);
 
   const handleReturn = async (loanId: string) => {
-    setReturningId(loanId);
     try {
-      await returnLoan({ loanId });
+      await returnLoan.mutateAsync({ loanId });
     } catch (error) {
       console.error("Failed to return loan:", error);
-    } finally {
-      setReturningId(null);
     }
   };
 
-  if (borrowed === undefined) {
+  if (isPending || borrowed === undefined) {
     return <PageLoading message={tCommon("loading")} />;
   }
 

--- a/apps/web/src/routes/_dashboard/browse.tsx
+++ b/apps/web/src/routes/_dashboard/browse.tsx
@@ -14,7 +14,8 @@ import { Button } from "@/components/ui/button";
 import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Grid, List } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "use-intl";
@@ -51,28 +52,34 @@ function BrowsePage() {
     return () => clearTimeout(handle);
   }, [query.text]);
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
   // Server-side filters: category, condition, difficulty, piece range, and the
   // free-text searchTerm (which the browse query matches over title / brand /
   // description / tags) are all honoured by gateway.library.browseOwned.
-  const browseOwnedPuzzlesResult = useQuery(gateway.library.browseOwned, {
-    category: query.category
-      ? (query.category as Id<"adminCategories">)
-      : undefined,
-    difficulty: query.difficulty || undefined,
-    condition: query.condition || undefined,
-    minPieceCount: query.minPieces ? parseInt(query.minPieces) : undefined,
-    maxPieceCount: query.maxPieces ? parseInt(query.maxPieces) : undefined,
-    searchTerm: debouncedText || undefined,
-    includeOwnPuzzles: false,
-    limit: 50,
-  });
+  const { data: browseOwnedPuzzlesResult } = useQuery(
+    convexQuery(gateway.library.browseOwned, {
+      category: query.category
+        ? (query.category as Id<"adminCategories">)
+        : undefined,
+      difficulty: query.difficulty || undefined,
+      condition: query.condition || undefined,
+      minPieceCount: query.minPieces ? parseInt(query.minPieces) : undefined,
+      maxPieceCount: query.maxPieces ? parseInt(query.maxPieces) : undefined,
+      searchTerm: debouncedText || undefined,
+      includeOwnPuzzles: false,
+      limit: 50,
+    }),
+  );
 
-  const categoriesRaw = useQuery(gateway.catalog.puzzleCategories);
+  const { data: categoriesRaw } = useQuery(
+    convexQuery(gateway.catalog.puzzleCategories, {}),
+  );
 
   const categories: CategoryOption[] = useMemo(
     () =>

--- a/apps/web/src/routes/_dashboard/circles/index.tsx
+++ b/apps/web/src/routes/_dashboard/circles/index.tsx
@@ -32,7 +32,8 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Plus, Settings, Trash2, Users } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -84,13 +85,17 @@ function CirclesPage() {
   const [name, setName] = useState("");
   const [manageCircleId, setManageCircleId] = useState<string | null>(null);
 
-  const circles = useQuery(gateway.sharing.myCircles, {});
-  const createCircle = useMutation(gateway.sharing.createCircle);
+  const { data: circles, isPending: circlesPending } = useQuery(
+    convexQuery(gateway.sharing.myCircles, {}),
+  );
+  const createCircle = useMutation({
+    mutationFn: useConvexMutation(gateway.sharing.createCircle),
+  });
 
   const handleCreate = async () => {
     if (!name.trim()) return;
     try {
-      await createCircle({ name: name.trim() });
+      await createCircle.mutateAsync({ name: name.trim() });
       setName("");
       setIsCreateOpen(false);
     } catch (error) {
@@ -115,7 +120,7 @@ function CirclesPage() {
     [t],
   );
 
-  if (!user || circles === undefined) {
+  if (!user || circlesPending || circles === undefined) {
     return <PageLoading message={t("loading")} />;
   }
 
@@ -240,9 +245,11 @@ function CircleRow({
 // from the (member-gated) circle detail read; while it loads we hold the space
 // with a skeleton so rows don't jump.
 function CircleAvatarStack({ circleId }: { circleId: string }) {
-  const detail = useQuery(gateway.sharing.circle, { circleId });
+  const { data: detail, isPending } = useQuery(
+    convexQuery(gateway.sharing.circle, { circleId }),
+  );
 
-  if (detail === undefined) {
+  if (isPending || detail === undefined) {
     return <Skeleton className="hidden h-8 w-20 rounded-full sm:block" />;
   }
   if (!detail || detail.members.length === 0) {
@@ -279,10 +286,14 @@ function ManageCircleDialog({
   onClose: () => void;
 }) {
   const t = useTranslations("circles");
-  const detail = useQuery(gateway.sharing.circle, { circleId });
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    viewerId ? { clerkId: viewerId } : "skip",
+  const { data: detail, isPending: detailPending } = useQuery(
+    convexQuery(gateway.sharing.circle, { circleId }),
+  );
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      viewerId ? { clerkId: viewerId } : "skip",
+    ),
   );
 
   const [search, setSearch] = useState("");
@@ -290,25 +301,37 @@ function ManageCircleDialog({
     useState<CirclePermissionLevel>("ViewOnly");
   const [shareCopyId, setShareCopyId] = useState<string>("");
 
-  const searchResults = useQuery(
-    gateway.identity.search,
-    search.trim().length >= 2 ? { searchTerm: search.trim() } : "skip",
+  const { data: searchResults } = useQuery(
+    convexQuery(
+      gateway.identity.search,
+      search.trim().length >= 2 ? { searchTerm: search.trim() } : "skip",
+    ),
   );
-  const myCopies = useQuery(
-    gateway.library.ownedByOwner,
-    convexUser?._id
-      ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
-      : "skip",
+  const { data: myCopies } = useQuery(
+    convexQuery(
+      gateway.library.ownedByOwner,
+      convexUser?._id
+        ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
+        : "skip",
+    ),
   );
 
-  const addMember = useMutation(gateway.sharing.addMember);
-  const removeMember = useMutation(gateway.sharing.removeMember);
-  const changePermission = useMutation(gateway.sharing.changePermission);
-  const shareCopy = useMutation(gateway.sharing.shareCopyToCircle);
+  const addMember = useMutation({
+    mutationFn: useConvexMutation(gateway.sharing.addMember),
+  });
+  const removeMember = useMutation({
+    mutationFn: useConvexMutation(gateway.sharing.removeMember),
+  });
+  const changePermission = useMutation({
+    mutationFn: useConvexMutation(gateway.sharing.changePermission),
+  });
+  const shareCopy = useMutation({
+    mutationFn: useConvexMutation(gateway.sharing.shareCopyToCircle),
+  });
 
   const handleAdd = async (memberId: string) => {
     try {
-      await addMember({
+      await addMember.mutateAsync({
         circleId,
         memberId: memberId as Id<"users">,
         permission: addPermission,
@@ -321,7 +344,7 @@ function ManageCircleDialog({
 
   const handleRemove = async (member: CircleMemberView) => {
     try {
-      await removeMember({
+      await removeMember.mutateAsync({
         circleId,
         memberId: member.memberId as Id<"users">,
       });
@@ -335,7 +358,7 @@ function ManageCircleDialog({
     permission: CirclePermissionLevel,
   ) => {
     try {
-      await changePermission({
+      await changePermission.mutateAsync({
         circleId,
         memberId: member.memberId as Id<"users">,
         permission,
@@ -348,7 +371,7 @@ function ManageCircleDialog({
   const handleShare = async () => {
     if (!shareCopyId) return;
     try {
-      await shareCopy({ circleId, copyId: shareCopyId });
+      await shareCopy.mutateAsync({ circleId, copyId: shareCopyId });
       setShareCopyId("");
     } catch (error) {
       console.error("Failed to share copy:", error);
@@ -367,7 +390,7 @@ function ManageCircleDialog({
           <DialogDescription>{t("manage.description")}</DialogDescription>
         </DialogHeader>
 
-        {detail === undefined ? (
+        {detailPending || detail === undefined ? (
           <PageLoading message={t("manage.loadingCircle")} />
         ) : detail === null ? (
           <p className="text-sm text-muted-foreground">

--- a/apps/web/src/routes/_dashboard/collections/$id/add-puzzles.tsx
+++ b/apps/web/src/routes/_dashboard/collections/$id/add-puzzles.tsx
@@ -10,7 +10,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { gateway, Id } from "@/gateway";
 import { pageTitle } from "@/lib/page-title";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Plus, Search } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -42,23 +43,35 @@ function AddPuzzlesToCollectionPage() {
     Set<Id<"ownedPuzzles">>
   >(new Set());
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser, isPending: convexUserPending } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const collection = useQuery(gateway.collections.byId, {
-    collectionId: id as Id<"collections">,
+  const { data: collection, isPending: collectionPending } = useQuery(
+    convexQuery(gateway.collections.byId, {
+      collectionId: id as Id<"collections">,
+    }),
+  );
+
+  const { data: availablePuzzles, isPending: availablePuzzlesPending } =
+    useQuery(
+      convexQuery(
+        gateway.library.ownedByOwner,
+        convexUser?._id
+          ? {
+              ownerId: convexUser._id as Id<"users">,
+              includeUnavailable: false,
+            }
+          : "skip",
+      ),
+    );
+
+  const addPuzzleToCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.addOwnedPuzzle),
   });
-
-  const availablePuzzles = useQuery(
-    gateway.library.ownedByOwner,
-    convexUser?._id
-      ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: false }
-      : "skip",
-  );
-
-  const addPuzzleToCollection = useMutation(gateway.collections.addOwnedPuzzle);
 
   const togglePuzzleSelection = (puzzleId: Id<"ownedPuzzles">) => {
     const newSelected = new Set(selectedPuzzles);
@@ -84,7 +97,7 @@ function AddPuzzlesToCollectionPage() {
           console.error("Skipping copy missing its aggregateId:", puzzleId);
           continue;
         }
-        await addPuzzleToCollection({
+        await addPuzzleToCollection.mutateAsync({
           collectionId: collection.aggregateId,
           copyId: copy.aggregateId,
         });
@@ -152,8 +165,11 @@ function AddPuzzlesToCollectionPage() {
       ) || [];
 
   if (
+    collectionPending ||
     collection === undefined ||
+    availablePuzzlesPending ||
     availablePuzzles === undefined ||
+    convexUserPending ||
     convexUser === undefined
   ) {
     return <PageLoading message={tCommon("loading")} />;

--- a/apps/web/src/routes/_dashboard/collections/$id/index.tsx
+++ b/apps/web/src/routes/_dashboard/collections/$id/index.tsx
@@ -29,7 +29,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronRight,
   Edit,
@@ -64,16 +65,20 @@ function CollectionDetailPage() {
   const tCommon = useTranslations("common");
   const tPuzzles = useTranslations("puzzles");
 
-  const collection = useQuery(gateway.collections.byId, {
-    collectionId: id as Id<"collections">,
-  });
-
-  const removeFromCollection = useMutation(
-    gateway.collections.removeOwnedPuzzle,
+  const { data: collection, isPending: collectionPending } = useQuery(
+    convexQuery(gateway.collections.byId, {
+      collectionId: id as Id<"collections">,
+    }),
   );
-  const updateCollection = useMutation(gateway.collections.update);
+
+  const removeFromCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.removeOwnedPuzzle),
+  });
+  const updateCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.update),
+  });
   const [shareOpen, setShareOpen] = useState(false);
-  const [sharing, setSharing] = useState(false);
+  const sharing = updateCollection.isPending;
   const [editOpen, setEditOpen] = useState(false);
 
   // Publish only the collection name as the page-head title so the chrome
@@ -100,7 +105,7 @@ function CollectionDetailPage() {
       return;
     }
     try {
-      await removeFromCollection({
+      await removeFromCollection.mutateAsync({
         collectionId: collection.aggregateId,
         copyId: copy.aggregateId,
       });
@@ -138,9 +143,8 @@ function CollectionDetailPage() {
       console.error("Cannot share: collection is missing its aggregateId.");
       return;
     }
-    setSharing(true);
     try {
-      await updateCollection({
+      await updateCollection.mutateAsync({
         collectionId: collection.aggregateId,
         visibility: "public",
       });
@@ -152,8 +156,6 @@ function CollectionDetailPage() {
     } catch (error) {
       console.error("Failed to make collection public:", error);
       toast.error(t("shareDialog.error"));
-    } finally {
-      setSharing(false);
     }
   };
 
@@ -162,7 +164,7 @@ function CollectionDetailPage() {
     setShareOpen(false);
   };
 
-  if (collection === undefined) {
+  if (collectionPending || collection === undefined) {
     return <PageLoading message={tCommon("loading")} />;
   }
 

--- a/apps/web/src/routes/_dashboard/collections/index.tsx
+++ b/apps/web/src/routes/_dashboard/collections/index.tsx
@@ -36,7 +36,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { FolderOpen, Globe, Lock, Plus, Settings } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -71,22 +72,30 @@ function CollectionsPage() {
     icon: "📦",
   });
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser, isPending: convexUserPending } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const collections = useQuery(
-    gateway.collections.listForUser,
-    convexUser?._id ? { userId: convexUser._id as Id<"users"> } : "skip",
+  const { data: collections, isPending: collectionsPending } = useQuery(
+    convexQuery(
+      gateway.collections.listForUser,
+      convexUser?._id ? { userId: convexUser._id as Id<"users"> } : "skip",
+    ),
   );
 
-  const createCollection = useMutation(gateway.collections.create);
-  const deleteCollection = useMutation(gateway.collections.delete);
+  const createCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.create),
+  });
+  const deleteCollection = useMutation({
+    mutationFn: useConvexMutation(gateway.collections.delete),
+  });
 
   const handleCreateCollection = async () => {
     try {
-      await createCollection({
+      await createCollection.mutateAsync({
         name: formData.name,
         description: formData.description,
         visibility: formData.visibility,
@@ -117,7 +126,7 @@ function CollectionsPage() {
     }
     if (confirm(t("deleteConfirm"))) {
       try {
-        await deleteCollection({
+        await deleteCollection.mutateAsync({
           collectionId: collectionAggregateId,
         });
       } catch (error) {
@@ -161,7 +170,13 @@ function CollectionsPage() {
     [headerMeta],
   );
 
-  if (!user || convexUser === undefined || collections === undefined) {
+  if (
+    !user ||
+    convexUserPending ||
+    convexUser === undefined ||
+    collectionsPending ||
+    collections === undefined
+  ) {
     return (
       <div className="flex flex-col gap-7">
         <Skeleton className="h-10 w-full" />

--- a/apps/web/src/routes/_dashboard/completions/index.tsx
+++ b/apps/web/src/routes/_dashboard/completions/index.tsx
@@ -25,7 +25,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StarRating } from "@/components/ui/star-rating";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { CircleCheck, Clock, Pencil, Plus, Star, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -80,26 +81,31 @@ function CompletionsPage() {
   const t = useTranslations("solving.completions");
   const tCommon = useTranslations("common");
   const [dialog, setDialog] = useState<DialogState>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const deleteCompletion = useMutation(gateway.solving.deleteCompletion);
+  const deleteCompletion = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.deleteCompletion),
+  });
+  const isDeleting = deleteCompletion.isPending;
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser, isPending: convexUserPending } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const completions = useQuery(
-    gateway.solving.myCompletions,
-    convexUser?._id ? {} : "skip",
+  const { data: completions, isPending: completionsPending } = useQuery(
+    convexQuery(gateway.solving.myCompletions, convexUser?._id ? {} : "skip"),
   );
 
   // The completion rows reference an owned copy by FK id only; join the member's library to
   // resolve a human title and the piece count. Built once per library load.
-  const ownedPuzzles = useQuery(
-    gateway.library.ownedByOwner,
-    convexUser?._id
-      ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
-      : "skip",
+  const { data: ownedPuzzles } = useQuery(
+    convexQuery(
+      gateway.library.ownedByOwner,
+      convexUser?._id
+        ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
+        : "skip",
+    ),
   );
 
   const infoByCopyId = useMemo(() => {
@@ -134,7 +140,13 @@ function CompletionsPage() {
     [t],
   );
 
-  if (!user || convexUser === undefined || completions === undefined) {
+  if (
+    !user ||
+    convexUserPending ||
+    convexUser === undefined ||
+    completionsPending ||
+    completions === undefined
+  ) {
     return <CompletionsSkeleton />;
   }
 
@@ -427,17 +439,14 @@ function CompletionsPage() {
                 disabled={isDeleting}
                 onClick={async () => {
                   if (!dialog.completionId) return;
-                  setIsDeleting(true);
                   try {
-                    await deleteCompletion({
+                    await deleteCompletion.mutateAsync({
                       completionId: dialog.completionId,
                     });
                     toast.success(t("deleteSuccess"));
                     setDialog(null);
                   } catch {
                     toast.error(t("deleteError"));
-                  } finally {
-                    setIsDeleting(false);
                   }
                 }}
               >

--- a/apps/web/src/routes/_dashboard/completions/new.tsx
+++ b/apps/web/src/routes/_dashboard/completions/new.tsx
@@ -11,7 +11,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { gateway, Id } from "@/gateway";
 import { pageTitle } from "@/lib/page-title";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
@@ -35,16 +36,20 @@ function NewCompletionPage() {
     title: string;
   } | null>(null);
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser, isPending: convexUserPending } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const ownedPuzzles = useQuery(
-    gateway.library.ownedByOwner,
-    convexUser?._id
-      ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
-      : "skip",
+  const { data: ownedPuzzles, isPending: ownedPuzzlesPending } = useQuery(
+    convexQuery(
+      gateway.library.ownedByOwner,
+      convexUser?._id
+        ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
+        : "skip",
+    ),
   );
 
   usePageHeader(
@@ -69,7 +74,13 @@ function NewCompletionPage() {
     [t, tShell, tCommon],
   );
 
-  if (!user || convexUser === undefined || ownedPuzzles === undefined) {
+  if (
+    !user ||
+    convexUserPending ||
+    convexUser === undefined ||
+    ownedPuzzlesPending ||
+    ownedPuzzles === undefined
+  ) {
     return <PageLoading message={tCommon("loading")} />;
   }
 

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -18,7 +18,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StarRating } from "@/components/ui/star-rating";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import {
   ArrowLeftRight,
@@ -71,16 +72,18 @@ export function CopyInstanceScreen({
   owned: boolean;
 }) {
   const router = useRouter();
-  const copy = useQuery(gateway.library.getCopyInstanceView, {
-    copyId: copyId as Id<"ownedPuzzles">,
-  });
+  const { data: copy, isPending: copyPending } = useQuery(
+    convexQuery(gateway.library.getCopyInstanceView, {
+      copyId: copyId as Id<"ownedPuzzles">,
+    }),
+  );
 
   const notOwner = owned && copy != null && copy.viewerIsOwner === false;
   useEffect(() => {
     if (notOwner) router.push(`/copies/${copyId}`);
   }, [notOwner, copyId, router]);
 
-  if (copy === undefined || notOwner) {
+  if (copyPending || copy === undefined || notOwner) {
     return <CopyInstanceSkeleton />;
   }
 
@@ -171,14 +174,16 @@ function CopyInstanceDetail({
   // copy editor (also reachable from the page-head Edit button registered below).
   const [logOpen, setLogOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
-  const updateSharing = useMutation(gateway.library.updateSharing);
+  const updateSharing = useMutation({
+    mutationFn: useConvexMutation(gateway.library.updateSharing),
+  });
 
   // Toggle a single sharing flag on the copy. Optimistic from the user's view via Convex
   // reactivity; on failure we surface a toast and the next query refresh restores the real state.
   const toggleSharing = async (flag: "forTrade" | "forLend") => {
     if (!copy.viewerIsOwner || copy.aggregateId == null) return;
     try {
-      await updateSharing(
+      await updateSharing.mutateAsync(
         availabilityToSharing(copy.aggregateId, {
           ...availability,
           [flag]: !availability[flag],
@@ -700,8 +705,12 @@ function PhotoStrip({
   const [uploading, setUploading] = useState(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
-  const generateUploadUrl = useMutation(gateway.library.generateUploadUrl);
-  const addCopyPhoto = useMutation(gateway.library.addCopyPhoto);
+  const generateUploadUrl = useMutation({
+    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
+  });
+  const addCopyPhoto = useMutation({
+    mutationFn: useConvexMutation(gateway.library.addCopyPhoto),
+  });
 
   const openLightbox = (index: number) => {
     setActiveIndex(index);
@@ -714,7 +723,7 @@ function PhotoStrip({
   const handleFile = async (file: File) => {
     setUploading(true);
     try {
-      const uploadUrl = await generateUploadUrl();
+      const uploadUrl = await generateUploadUrl.mutateAsync({});
       const res = await fetch(uploadUrl, {
         method: "POST",
         headers: { "Content-Type": file.type },
@@ -722,7 +731,7 @@ function PhotoStrip({
       });
       if (!res.ok) throw new Error("upload failed");
       const { storageId } = (await res.json()) as { storageId: string };
-      await addCopyPhoto({
+      await addCopyPhoto.mutateAsync({
         copyId: copyId as Id<"ownedPuzzles">,
         fileId: storageId as Id<"_storage">,
       });
@@ -966,15 +975,19 @@ function StarGlyph() {
 function CommentsSection({ copyId }: { copyId: string }) {
   const t = useTranslations("copyInstance");
   const format = useFormatter();
-  const comments = useQuery(gateway.social.listPuzzleComments, {
-    copyId: copyId as Id<"ownedPuzzles">,
+  const { data: comments } = useQuery(
+    convexQuery(gateway.social.listPuzzleComments, {
+      copyId: copyId as Id<"ownedPuzzles">,
+    }),
+  );
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
+  const postComment = useMutation({
+    mutationFn: useConvexMutation(gateway.social.postPuzzleComment),
   });
-  const me = useQuery(gateway.identity.currentUser, {});
-  const postComment = useMutation(gateway.social.postPuzzleComment);
 
   const [text, setText] = useState("");
   const [rating, setRating] = useState(0);
-  const [posting, setPosting] = useState(false);
+  const posting = postComment.isPending;
   const [now] = useState(() => Date.now());
 
   const list = comments ?? [];
@@ -985,9 +998,8 @@ function CommentsSection({ copyId }: { copyId: string }) {
   const submit = async () => {
     const trimmed = text.trim();
     if (!trimmed) return;
-    setPosting(true);
     try {
-      await postComment({
+      await postComment.mutateAsync({
         copyId: copyId as Id<"ownedPuzzles">,
         text: trimmed,
         ...(rating > 0 ? { rating } : {}),
@@ -996,8 +1008,6 @@ function CommentsSection({ copyId }: { copyId: string }) {
       setRating(0);
     } catch {
       toast.error(t("commentFailed"));
-    } finally {
-      setPosting(false);
     }
   };
 

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -702,15 +702,12 @@ function PhotoStrip({
 }) {
   const t = useTranslations("copyInstance");
   const inputRef = useRef<HTMLInputElement>(null);
-  const [uploading, setUploading] = useState(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
-  const generateUploadUrl = useMutation({
-    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
-  });
-  const addCopyPhoto = useMutation({
-    mutationFn: useConvexMutation(gateway.library.addCopyPhoto),
-  });
+  const generateUploadUrl = useConvexMutation(
+    gateway.library.generateUploadUrl,
+  );
+  const addCopyPhoto = useConvexMutation(gateway.library.addCopyPhoto);
 
   const openLightbox = (index: number) => {
     setActiveIndex(index);
@@ -720,10 +717,11 @@ function PhotoStrip({
   // Photo upload: ask Convex for a one-shot upload URL, POST the blob to it, then
   // attach the returned storageId to this copy. The getCopyInstanceView query
   // reads the same table so Convex reactivity refreshes the strip automatically.
-  const handleFile = async (file: File) => {
-    setUploading(true);
-    try {
-      const uploadUrl = await generateUploadUrl.mutateAsync({});
+  // The WHOLE pipeline (URL grant → raw fetch POST → attach) is the mutationFn so
+  // isPending covers the full upload span (busy-state rule v2).
+  const uploadPhoto = useMutation({
+    mutationFn: async (file: File) => {
+      const uploadUrl = await generateUploadUrl({});
       const res = await fetch(uploadUrl, {
         method: "POST",
         headers: { "Content-Type": file.type },
@@ -731,18 +729,18 @@ function PhotoStrip({
       });
       if (!res.ok) throw new Error("upload failed");
       const { storageId } = (await res.json()) as { storageId: string };
-      await addCopyPhoto.mutateAsync({
+      await addCopyPhoto({
         copyId: copyId as Id<"ownedPuzzles">,
         fileId: storageId as Id<"_storage">,
       });
-      toast.success(t("photoAdded"));
-    } catch {
-      toast.error(t("photoFailed"));
-    } finally {
-      setUploading(false);
+    },
+    onSuccess: () => toast.success(t("photoAdded")),
+    onError: () => toast.error(t("photoFailed")),
+    onSettled: () => {
       if (inputRef.current) inputRef.current.value = "";
-    }
-  };
+    },
+  });
+  const uploading = uploadPhoto.isPending;
 
   return (
     <div className="flex gap-3.5 overflow-x-auto pb-1.5">
@@ -800,7 +798,7 @@ function PhotoStrip({
             disabled={uploading}
             onChange={(e) => {
               const file = e.target.files?.[0];
-              if (file) void handleFile(file);
+              if (file) uploadPhoto.mutate(file);
             }}
           />
         </label>

--- a/apps/web/src/routes/_dashboard/goals.tsx
+++ b/apps/web/src/routes/_dashboard/goals.tsx
@@ -20,7 +20,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Plus, Target, Trophy } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -42,19 +43,21 @@ function GoalsPage() {
   const [description, setDescription] = useState("");
   const [target, setTarget] = useState("");
   const [targetDate, setTargetDate] = useState("");
-  const [submitting, setSubmitting] = useState(false);
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const goals = useQuery(
-    gateway.solving.myGoals,
-    convexUser?._id ? {} : "skip",
+  const { data: goals } = useQuery(
+    convexQuery(gateway.solving.myGoals, convexUser?._id ? {} : "skip"),
   );
 
-  const createGoal = useMutation(gateway.solving.createGoal);
+  const createGoal = useMutation({
+    mutationFn: useConvexMutation(gateway.solving.createGoal),
+  });
 
   const reset = () => {
     setTitle("");
@@ -74,9 +77,8 @@ function GoalsPage() {
     }
     const dueMs = targetDate ? new Date(targetDate).getTime() : undefined;
 
-    setSubmitting(true);
     try {
-      await createGoal({
+      await createGoal.mutateAsync({
         title: title.trim(),
         description: description.trim() || undefined,
         targetCompletions,
@@ -89,8 +91,6 @@ function GoalsPage() {
     } catch (error) {
       console.error("Failed to create goal:", error);
       toast.error(t("createError"));
-    } finally {
-      setSubmitting(false);
     }
   };
 
@@ -179,7 +179,7 @@ function GoalsPage() {
           <DialogFooter>
             <Button
               onClick={handleCreate}
-              disabled={submitting || !title.trim() || !target}
+              disabled={createGoal.isPending || !title.trim() || !target}
             >
               {t("submit")}
             </Button>

--- a/apps/web/src/routes/_dashboard/insights.tsx
+++ b/apps/web/src/routes/_dashboard/insights.tsx
@@ -19,7 +19,8 @@ import {
 import { PageLoading } from "@/components/ui/loading";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 export const Route = createFileRoute("/_dashboard/insights")({
@@ -41,24 +42,23 @@ function InsightsPage() {
 
   // requireMember-backed queries take no args; gate on the Clerk → Convex member resolving so we
   // don't fire them while signed out (they would throw), mirroring the other dashboard pages.
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
   const ready = convexUser?._id ? {} : "skip";
 
-  const stats = useQuery(gateway.insights.personalStats, ready) as
-    | PersonalStats
-    | undefined;
-  const trends = useQuery(gateway.insights.completionTrends, ready) as
-    | CompletionTrendPoint[]
-    | undefined;
-  const breakdown = useQuery(gateway.insights.collectionBreakdown, ready) as
-    | CollectionBreakdownData
-    | undefined;
-  const trades = useQuery(gateway.insights.tradeActivity, ready) as
-    | TradeActivityData
-    | undefined;
+  const stats = useQuery(convexQuery(gateway.insights.personalStats, ready))
+    .data as PersonalStats | undefined;
+  const trends = useQuery(convexQuery(gateway.insights.completionTrends, ready))
+    .data as CompletionTrendPoint[] | undefined;
+  const breakdown = useQuery(
+    convexQuery(gateway.insights.collectionBreakdown, ready),
+  ).data as CollectionBreakdownData | undefined;
+  const trades = useQuery(convexQuery(gateway.insights.tradeActivity, ready))
+    .data as TradeActivityData | undefined;
 
   if (
     !user ||

--- a/apps/web/src/routes/_dashboard/my-puzzles/add/index.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/add/index.tsx
@@ -10,7 +10,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
-import { usePaginatedQuery, useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+// sanctioned convex/react exception: usePaginatedQuery (see tanstack-query migration spec)
+import { usePaginatedQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import { Plus, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -49,7 +52,9 @@ function AddPuzzleChooserPage() {
 
   // The member's own not-yet-approved submissions — offered first so they can
   // acquire a copy of a puzzle they contributed before it is approved.
-  const mySubmissions = useQuery(gateway.catalog.myContributedPuzzles);
+  const { data: mySubmissions } = useQuery(
+    convexQuery(gateway.catalog.myContributedPuzzles, {}),
+  );
 
   // The full, paginated, approved catalogue with infinite scroll (mirrors
   // puzzle-client.tsx).

--- a/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
@@ -39,7 +39,12 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { gateway, Id } from "@/gateway";
-import { useAction, useMutation, useQuery } from "convex/react";
+import {
+  convexQuery,
+  useConvexAction,
+  useConvexMutation,
+} from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -123,17 +128,29 @@ function AddPuzzlePage() {
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Mutations & actions
-  const createPuzzle = useMutation(gateway.catalog.createPuzzle);
-  const createOwned = useMutation(gateway.library.createOwned);
-  const updateSharing = useMutation(gateway.library.updateSharing);
-  const generateUploadUrl = useMutation(gateway.library.generateUploadUrl);
-  const importImage = useAction(gateway.catalog.importPuzzleImage);
+  const createPuzzle = useMutation({
+    mutationFn: useConvexMutation(gateway.catalog.createPuzzle),
+  });
+  const createOwned = useMutation({
+    mutationFn: useConvexMutation(gateway.library.createOwned),
+  });
+  const updateSharing = useMutation({
+    mutationFn: useConvexMutation(gateway.library.updateSharing),
+  });
+  const generateUploadUrl = useMutation({
+    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
+  });
+  const importImage = useMutation({
+    mutationFn: useConvexAction(gateway.catalog.importPuzzleImage),
+  });
 
   // puzzleId from URL — pre-select an existing definition (copy mode).
   const puzzleIdFromUrl = searchParams.get("puzzleId") as Id<"puzzles"> | null;
-  const specificPuzzle = useQuery(
-    gateway.catalog.puzzleById,
-    puzzleIdFromUrl ? { puzzleId: puzzleIdFromUrl } : "skip",
+  const { data: specificPuzzle } = useQuery(
+    convexQuery(
+      gateway.catalog.puzzleById,
+      puzzleIdFromUrl ? { puzzleId: puzzleIdFromUrl } : "skip",
+    ),
   );
 
   useEffect(() => {
@@ -210,7 +227,7 @@ function AddPuzzlePage() {
   const buildImageId = async (): Promise<Id<"_storage"> | undefined> => {
     if (form.coverMode !== "photo") return undefined;
     if (form.coverFile) {
-      const uploadUrl = await generateUploadUrl();
+      const uploadUrl = await generateUploadUrl.mutateAsync({});
       const res = await fetch(uploadUrl, {
         method: "POST",
         headers: { "Content-Type": form.coverFile.type },
@@ -221,7 +238,7 @@ function AddPuzzlePage() {
       return storageId as Id<"_storage">;
     } else if (form.selectedImageUrl) {
       try {
-        return await importImage({ url: form.selectedImageUrl });
+        return await importImage.mutateAsync({ url: form.selectedImageUrl });
       } catch {
         // Non-fatal: proceed without the remote image
         return undefined;
@@ -261,13 +278,13 @@ function AddPuzzlePage() {
       let definitionId = selectedDefinitionId;
       if (!definitionId) {
         const imageId = await buildImageId();
-        definitionId = (await createPuzzle(
+        definitionId = (await createPuzzle.mutateAsync(
           buildCreatePuzzleArgs(imageId),
         )) as string;
       }
 
       // 2. Acquire a copy of that definition.
-      const copyId = (await createOwned({
+      const copyId = (await createOwned.mutateAsync({
         puzzleDefinitionId: definitionId,
         condition: form.condition,
         notes: form.notes || undefined,
@@ -275,7 +292,9 @@ function AddPuzzlePage() {
 
       // 3. Apply availability if any chip is on.
       if (hasAnyAvailability(form.availability)) {
-        await updateSharing(availabilityToSharing(copyId, form.availability));
+        await updateSharing.mutateAsync(
+          availabilityToSharing(copyId, form.availability),
+        );
       }
 
       toast.success(t("puzzleAdded"));
@@ -295,19 +314,21 @@ function AddPuzzlePage() {
       let definitionId = selectedDefinitionId;
       if (!definitionId) {
         const imageId = await buildImageId();
-        definitionId = (await createPuzzle(
+        definitionId = (await createPuzzle.mutateAsync(
           buildCreatePuzzleArgs(imageId),
         )) as string;
       }
 
-      const copyId = (await createOwned({
+      const copyId = (await createOwned.mutateAsync({
         puzzleDefinitionId: definitionId,
         condition: form.condition,
         notes: form.notes || undefined,
       })) as string;
 
       if (hasAnyAvailability(form.availability)) {
-        await updateSharing(availabilityToSharing(copyId, form.availability));
+        await updateSharing.mutateAsync(
+          availabilityToSharing(copyId, form.availability),
+        );
       }
 
       toast.success(t("puzzleAdded"));

--- a/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
@@ -46,7 +46,7 @@ import {
 } from "@convex-dev/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
 
@@ -144,19 +144,28 @@ function AddPuzzlePage() {
     ),
   );
 
-  useEffect(() => {
-    if (!puzzleIdFromUrl || !specificPuzzle) return;
-    // Only pre-fill once (when selectedDefinitionId is still null)
-    if (selectedDefinitionId) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing pre-fill sync; surfaced once this component became compiler-analyzable
-    setSelectedDefinitionId(specificPuzzle.aggregateId ?? null);
-    setForm((f) => ({
-      ...f,
-      title: specificPuzzle.title,
-      brand: specificPuzzle.brand ?? "",
-      pieceCount: specificPuzzle.pieceCount,
-    }));
-  }, [puzzleIdFromUrl, specificPuzzle, selectedDefinitionId]);
+  // Pre-fill from the loaded definition using the derive-state-during-render pattern: track the
+  // previously seen puzzle (keyed by id, not object identity — the query may re-emit new objects)
+  // and seed the selection + form fields during the render where it first appears. Only pre-fill
+  // while nothing is selected yet, matching the old once-only effect.
+  const specificPuzzleKey = specificPuzzle
+    ? (specificPuzzle.aggregateId ?? specificPuzzle._id)
+    : null;
+  const [prevSpecificPuzzleKey, setPrevSpecificPuzzleKey] = useState<
+    string | null
+  >(null);
+  if (specificPuzzleKey !== prevSpecificPuzzleKey) {
+    setPrevSpecificPuzzleKey(specificPuzzleKey);
+    if (puzzleIdFromUrl && specificPuzzle && !selectedDefinitionId) {
+      setSelectedDefinitionId(specificPuzzle.aggregateId ?? null);
+      setForm((f) => ({
+        ...f,
+        title: specificPuzzle.title,
+        brand: specificPuzzle.brand ?? "",
+        pieceCount: specificPuzzle.pieceCount,
+      }));
+    }
+  }
 
   // "Copy mode": the form is acquiring a copy of an existing catalogue
   // definition reached via ?puzzleId. We hide the import + definition-editing
@@ -166,20 +175,18 @@ function AddPuzzlePage() {
   const isCopyMode = !!puzzleIdFromUrl;
   const copyLoading = isCopyMode && specificPuzzle === undefined;
 
-  // Object URL for the cover file preview — create and revoke in one effect
-  const [coverFileUrl, setCoverFileUrl] = useState<string | undefined>(
-    undefined,
+  // Object URL for the cover file preview — derived from the file; the effect only revokes the
+  // previous URL when the file changes (or on unmount), so no setState runs inside an effect.
+  const coverFileUrl = useMemo(
+    () => (form.coverFile ? URL.createObjectURL(form.coverFile) : undefined),
+    [form.coverFile],
   );
-  useEffect(() => {
-    if (!form.coverFile) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing object-URL lifecycle; surfaced once this component became compiler-analyzable
-      setCoverFileUrl(undefined);
-      return;
-    }
-    const url = URL.createObjectURL(form.coverFile);
-    setCoverFileUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [form.coverFile]);
+  useEffect(
+    () => () => {
+      if (coverFileUrl) URL.revokeObjectURL(coverFileUrl);
+    },
+    [coverFileUrl],
+  );
 
   // The photo URL used for the live preview: uploaded file takes priority, else selected import
   const previewPhotoUrl =

--- a/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/add/new.tsx
@@ -124,25 +124,16 @@ function AddPuzzlePage() {
     string | null
   >(null);
   const [pendingMatch, setPendingMatch] = useState<ImportedMatch | null>(null);
-  const [submitting, setSubmitting] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
-  // Mutations & actions
-  const createPuzzle = useMutation({
-    mutationFn: useConvexMutation(gateway.catalog.createPuzzle),
-  });
-  const createOwned = useMutation({
-    mutationFn: useConvexMutation(gateway.library.createOwned),
-  });
-  const updateSharing = useMutation({
-    mutationFn: useConvexMutation(gateway.library.updateSharing),
-  });
-  const generateUploadUrl = useMutation({
-    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
-  });
-  const importImage = useMutation({
-    mutationFn: useConvexAction(gateway.catalog.importPuzzleImage),
-  });
+  // Convex mutations & actions, called inside the submitPuzzle wrapper below.
+  const createPuzzle = useConvexMutation(gateway.catalog.createPuzzle);
+  const createOwned = useConvexMutation(gateway.library.createOwned);
+  const updateSharing = useConvexMutation(gateway.library.updateSharing);
+  const generateUploadUrl = useConvexMutation(
+    gateway.library.generateUploadUrl,
+  );
+  const importImage = useConvexAction(gateway.catalog.importPuzzleImage);
 
   // puzzleId from URL — pre-select an existing definition (copy mode).
   const puzzleIdFromUrl = searchParams.get("puzzleId") as Id<"puzzles"> | null;
@@ -157,6 +148,7 @@ function AddPuzzlePage() {
     if (!puzzleIdFromUrl || !specificPuzzle) return;
     // Only pre-fill once (when selectedDefinitionId is still null)
     if (selectedDefinitionId) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing pre-fill sync; surfaced once this component became compiler-analyzable
     setSelectedDefinitionId(specificPuzzle.aggregateId ?? null);
     setForm((f) => ({
       ...f,
@@ -180,6 +172,7 @@ function AddPuzzlePage() {
   );
   useEffect(() => {
     if (!form.coverFile) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing object-URL lifecycle; surfaced once this component became compiler-analyzable
       setCoverFileUrl(undefined);
       return;
     }
@@ -227,7 +220,7 @@ function AddPuzzlePage() {
   const buildImageId = async (): Promise<Id<"_storage"> | undefined> => {
     if (form.coverMode !== "photo") return undefined;
     if (form.coverFile) {
-      const uploadUrl = await generateUploadUrl.mutateAsync({});
+      const uploadUrl = await generateUploadUrl({});
       const res = await fetch(uploadUrl, {
         method: "POST",
         headers: { "Content-Type": form.coverFile.type },
@@ -238,7 +231,7 @@ function AddPuzzlePage() {
       return storageId as Id<"_storage">;
     } else if (form.selectedImageUrl) {
       try {
-        return await importImage.mutateAsync({ url: form.selectedImageUrl });
+        return await importImage({ url: form.selectedImageUrl });
       } catch {
         // Non-fatal: proceed without the remote image
         return undefined;
@@ -270,21 +263,23 @@ function AddPuzzlePage() {
     image: imageId,
   });
 
-  const handleAdd = async () => {
-    if (!form.title.trim() || !form.brand.trim() || !form.pieceCount) return;
-    setSubmitting(true);
-    try {
+  // The WHOLE multi-step create — optional image upload/import, createPuzzle,
+  // createOwned, updateSharing — runs as ONE mutationFn so isPending spans the full
+  // sequence (busy-state rule v2). Both footer buttons share it; the `andAnother`
+  // variant only changes what happens after success (reset vs navigate).
+  const submitPuzzle = useMutation({
+    mutationFn: async (_variables: { andAnother: boolean }) => {
       // 1. Resolve the catalog definition id (existing match or create new).
       let definitionId = selectedDefinitionId;
       if (!definitionId) {
         const imageId = await buildImageId();
-        definitionId = (await createPuzzle.mutateAsync(
+        definitionId = (await createPuzzle(
           buildCreatePuzzleArgs(imageId),
         )) as string;
       }
 
       // 2. Acquire a copy of that definition.
-      const copyId = (await createOwned.mutateAsync({
+      const copyId = (await createOwned({
         puzzleDefinitionId: definitionId,
         condition: form.condition,
         notes: form.notes || undefined,
@@ -292,53 +287,31 @@ function AddPuzzlePage() {
 
       // 3. Apply availability if any chip is on.
       if (hasAnyAvailability(form.availability)) {
-        await updateSharing.mutateAsync(
-          availabilityToSharing(copyId, form.availability),
-        );
+        await updateSharing(availabilityToSharing(copyId, form.availability));
       }
-
+    },
+    onSuccess: (_, { andAnother }) => {
       toast.success(t("puzzleAdded"));
-      router.push("/puzzles");
-    } catch (error) {
+      if (andAnother) {
+        resetForm();
+      } else {
+        router.push("/puzzles");
+      }
+    },
+    onError: (error) => {
       console.error("Add to library failed:", error);
       toast.error(t("puzzleCreationFailed"));
-    } finally {
-      setSubmitting(false);
-    }
+    },
+  });
+
+  const handleAdd = () => {
+    if (!form.title.trim() || !form.brand.trim() || !form.pieceCount) return;
+    submitPuzzle.mutate({ andAnother: false });
   };
 
-  const handleSaveAndAddAnother = async () => {
+  const handleSaveAndAddAnother = () => {
     if (!form.title.trim() || !form.brand.trim() || !form.pieceCount) return;
-    setSubmitting(true);
-    try {
-      let definitionId = selectedDefinitionId;
-      if (!definitionId) {
-        const imageId = await buildImageId();
-        definitionId = (await createPuzzle.mutateAsync(
-          buildCreatePuzzleArgs(imageId),
-        )) as string;
-      }
-
-      const copyId = (await createOwned.mutateAsync({
-        puzzleDefinitionId: definitionId,
-        condition: form.condition,
-        notes: form.notes || undefined,
-      })) as string;
-
-      if (hasAnyAvailability(form.availability)) {
-        await updateSharing.mutateAsync(
-          availabilityToSharing(copyId, form.availability),
-        );
-      }
-
-      toast.success(t("puzzleAdded"));
-      resetForm();
-    } catch (error) {
-      console.error("Add to library failed:", error);
-      toast.error(t("puzzleCreationFailed"));
-    } finally {
-      setSubmitting(false);
-    }
+    submitPuzzle.mutate({ andAnother: true });
   };
 
   // In copy mode the definition is fixed, so only the copy fields gate submit.
@@ -490,7 +463,7 @@ function AddPuzzlePage() {
     <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
       <Button
         type="button"
-        disabled={!isReady || submitting}
+        disabled={!isReady || submitPuzzle.isPending}
         onClick={handleAdd}
       >
         {isCopyMode ? t("addToLibrary") : t("addPuzzle")}
@@ -499,7 +472,7 @@ function AddPuzzlePage() {
         <Button
           type="button"
           variant="outline"
-          disabled={!isReady || submitting}
+          disabled={!isReady || submitPuzzle.isPending}
           onClick={handleSaveAndAddAnother}
         >
           {t("saveAndAddAnother")}

--- a/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
+++ b/apps/web/src/routes/_dashboard/my-puzzles/index.tsx
@@ -14,7 +14,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { PuzzleCard, PuzzleViewProvider } from "@/components/ui/puzzle-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { gateway, Id } from "@/gateway";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Grid, List, Plus, Undo2, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslations } from "use-intl";
@@ -111,37 +112,47 @@ function PuzzlesPage() {
   const tLending = useTranslations("lending");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  // The loan currently being recalled, so we disable only that copy's Recall button.
-  const [recallingId, setRecallingId] = useState<string | null>(null);
   // The copy a solve is being logged against; null when the dialog is closed.
   const [solveTarget, setSolveTarget] = useState<{
     copyId: string;
     title: string;
   } | null>(null);
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
-  const userownedPuzzles = useQuery(
-    gateway.library.ownedByOwner,
-    convexUser?._id
-      ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
-      : "skip",
-  );
+  const { data: userownedPuzzles, isPending: userownedPuzzlesPending } =
+    useQuery(
+      convexQuery(
+        gateway.library.ownedByOwner,
+        convexUser?._id
+          ? { ownerId: convexUser._id as Id<"users">, includeUnavailable: true }
+          : "skip",
+      ),
+    );
 
-  const deletePuzzle = useMutation(gateway.library.deleteOwned);
+  const deletePuzzle = useMutation({
+    mutationFn: useConvexMutation(gateway.library.deleteOwned),
+  });
 
   // Open loans where the caller is the lender; the source of truth for "which of my copies are out".
-  const lentOut = useQuery(gateway.lending.lentOut);
-  const recallLoan = useMutation(gateway.lending.recallLoan);
+  const { data: lentOut } = useQuery(convexQuery(gateway.lending.lentOut, {}));
+  const recallLoan = useMutation({
+    mutationFn: useConvexMutation(gateway.lending.recallLoan),
+  });
+  // The loan currently being recalled, so we disable only that copy's Recall button.
+  const recallingId = recallLoan.isPending
+    ? (recallLoan.variables?.loanId ?? null)
+    : null;
 
   // The member's solve log powers the In Progress / Completed pills; keyed by
   // the copy's ownedPuzzles _id so each card resolves its state in O(1).
-  const completions = useQuery(
-    gateway.solving.myCompletions,
-    convexUser?._id ? {} : "skip",
+  const { data: completions } = useQuery(
+    convexQuery(gateway.solving.myCompletions, convexUser?._id ? {} : "skip"),
   );
   const solveStateByCopyId = useMemo(() => {
     const map = new Map<string, { inProgress: boolean; completed: boolean }>();
@@ -166,13 +177,10 @@ function PuzzlesPage() {
   );
 
   const handleRecallLoan = async (loanId: string) => {
-    setRecallingId(loanId);
     try {
-      await recallLoan({ loanId });
+      await recallLoan.mutateAsync({ loanId });
     } catch (error) {
       console.error("Failed to recall loan:", error);
-    } finally {
-      setRecallingId(null);
     }
   };
 
@@ -186,7 +194,7 @@ function PuzzlesPage() {
     }
     if (confirm(t("deleteConfirm"))) {
       try {
-        await deletePuzzle({
+        await deletePuzzle.mutateAsync({
           copyId: copy.aggregateId,
         });
       } catch (error) {
@@ -256,7 +264,12 @@ function PuzzlesPage() {
     [headerMeta],
   );
 
-  if (!user || !convexUser || userownedPuzzles === undefined) {
+  if (
+    !user ||
+    !convexUser ||
+    userownedPuzzlesPending ||
+    userownedPuzzles === undefined
+  ) {
     return <PuzzlesGridSkeleton />;
   }
 

--- a/apps/web/src/routes/_dashboard/notifications/index.tsx
+++ b/apps/web/src/routes/_dashboard/notifications/index.tsx
@@ -19,7 +19,8 @@ import { PageLoading } from "@/components/ui/loading";
 import { gateway } from "@/gateway";
 import { useDateFnsLocale } from "@/lib/date-locale";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Bell, Check, CheckCheck, Settings2 } from "lucide-react";
 import { toast } from "sonner";
@@ -41,12 +42,15 @@ function NotificationsPage() {
   const router = useRouter();
 
   const notifications = useQuery(
-    gateway.notifications.list,
-    user?.id ? {} : "skip",
-  ) as NotificationRow[] | undefined;
+    convexQuery(gateway.notifications.list, user?.id ? {} : "skip"),
+  ).data as NotificationRow[] | undefined;
 
-  const markRead = useMutation(gateway.notifications.markRead);
-  const markAllRead = useMutation(gateway.notifications.markAllRead);
+  const markRead = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.markRead),
+  });
+  const markAllRead = useMutation({
+    mutationFn: useConvexMutation(gateway.notifications.markAllRead),
+  });
 
   if (!user || notifications === undefined) {
     return <PageLoading message={tCommon("loading")} />;
@@ -56,7 +60,7 @@ function NotificationsPage() {
 
   const handleMarkRead = async (row: NotificationRow) => {
     try {
-      await markRead({ notificationId: notificationId(row) });
+      await markRead.mutateAsync({ notificationId: notificationId(row) });
     } catch {
       toast.error(t("markError"));
     }
@@ -64,9 +68,11 @@ function NotificationsPage() {
 
   const handleOpen = (row: NotificationRow) => {
     if (!row.isRead) {
-      markRead({ notificationId: notificationId(row) }).catch(() => {
-        toast.error(t("markError"));
-      });
+      markRead
+        .mutateAsync({ notificationId: notificationId(row) })
+        .catch(() => {
+          toast.error(t("markError"));
+        });
     }
     const href = notificationHref(row);
     if (href) router.push(href);
@@ -74,7 +80,7 @@ function NotificationsPage() {
 
   const handleMarkAll = async () => {
     try {
-      const count = await markAllRead({});
+      const count = await markAllRead.mutateAsync({});
       toast.success(t("markedAllRead", { count: count ?? 0 }));
     } catch {
       toast.error(t("markError"));

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/components/social/member-tile";
 import { ProfileEditDialog } from "@/components/social/profile-edit-dialog";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -30,8 +31,12 @@ export const Route = createFileRoute("/_dashboard/people")({
 function PeoplePage() {
   const t = useTranslations("people");
 
-  const following = useQuery(gateway.social.following, {});
-  const followers = useQuery(gateway.social.followers, {});
+  const { data: following } = useQuery(
+    convexQuery(gateway.social.following, {}),
+  );
+  const { data: followers } = useQuery(
+    convexQuery(gateway.social.followers, {}),
+  );
 
   const loading = following === undefined || followers === undefined;
 

--- a/apps/web/src/routes/_dashboard/profile.tsx
+++ b/apps/web/src/routes/_dashboard/profile.tsx
@@ -8,7 +8,8 @@ import { ProfileStatsSection } from "@/components/profile/stats-section";
 import { ReputationSection } from "@/components/reputation/reputation-section";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway, Id } from "@/gateway";
-import { useQuery } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslations } from "use-intl";
 
@@ -28,7 +29,9 @@ function ProfilePage() {
   const t = useTranslations("profile");
   const [isEditing, setIsEditing] = useState(false);
 
-  const member = useQuery(gateway.identity.currentUser);
+  const { data: member } = useQuery(
+    convexQuery(gateway.identity.currentUser, {}),
+  );
 
   if (member === undefined) {
     return <PageLoading message={t("loading")} />;

--- a/apps/web/src/routes/_dashboard/puzzles/$id.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/$id.tsx
@@ -22,7 +22,8 @@ import { StarRating } from "@/components/ui/star-rating";
 import { gateway, Id } from "@/gateway";
 import { useFavorites } from "@/hooks/use-favorites";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import {
   ArrowLeftRight,
@@ -54,9 +55,11 @@ export const Route = createFileRoute("/_dashboard/puzzles/$id")({
 
 function PuzzlePage() {
   const { id } = Route.useParams();
-  const view = useQuery(gateway.library.getPuzzleDefinitionView, {
-    puzzleId: id as Id<"puzzles">,
-  });
+  const { data: view } = useQuery(
+    convexQuery(gateway.library.getPuzzleDefinitionView, {
+      puzzleId: id as Id<"puzzles">,
+    }),
+  );
 
   if (view === undefined) {
     return <PuzzleDefinitionSkeleton />;
@@ -452,18 +455,23 @@ function ReviewsSection({
 }) {
   const t = useTranslations("puzzleDefinition");
   const format = useFormatter();
-  const reviews = useQuery(gateway.social.listPuzzleReviews, {
-    puzzleId: puzzleId as Id<"puzzles">,
+  const { data: reviews } = useQuery(
+    convexQuery(gateway.social.listPuzzleReviews, {
+      puzzleId: puzzleId as Id<"puzzles">,
+    }),
+  );
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
+  const { data: view } = useQuery(
+    convexQuery(gateway.library.getPuzzleDefinitionView, {
+      puzzleId: puzzleId as Id<"puzzles">,
+    }),
+  );
+  const postReview = useMutation({
+    mutationFn: useConvexMutation(gateway.social.postPuzzleReview),
   });
-  const me = useQuery(gateway.identity.currentUser, {});
-  const view = useQuery(gateway.library.getPuzzleDefinitionView, {
-    puzzleId: puzzleId as Id<"puzzles">,
-  });
-  const postReview = useMutation(gateway.social.postPuzzleReview);
 
   const [text, setText] = useState("");
   const [rating, setRating] = useState(0);
-  const [posting, setPosting] = useState(false);
   const [now] = useState(() => Date.now());
 
   const list = reviews ?? [];
@@ -475,9 +483,8 @@ function ReviewsSection({
   const submit = async () => {
     const trimmed = text.trim();
     if (!trimmed) return;
-    setPosting(true);
     try {
-      await postReview({
+      await postReview.mutateAsync({
         puzzleId: puzzleId as Id<"puzzles">,
         text: trimmed,
         ...(rating > 0 ? { rating } : {}),
@@ -486,8 +493,6 @@ function ReviewsSection({
       setRating(0);
     } catch {
       toast.error(t("reviewFailed"));
-    } finally {
-      setPosting(false);
     }
   };
 
@@ -520,7 +525,7 @@ function ReviewsSection({
             <Button
               variant="brand"
               onClick={() => void submit()}
-              disabled={posting || text.trim().length === 0}
+              disabled={postReview.isPending || text.trim().length === 0}
             >
               {t("post")}
             </Button>

--- a/apps/web/src/routes/_dashboard/puzzles/add.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/add.tsx
@@ -98,19 +98,14 @@ function ContributePuzzlePage() {
 
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [pendingMatch, setPendingMatch] = useState<ImportedMatch | null>(null);
-  const [submitting, setSubmitting] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
-  // Mutations & actions
-  const createPuzzle = useMutation({
-    mutationFn: useConvexMutation(gateway.catalog.createPuzzle),
-  });
-  const generateUploadUrl = useMutation({
-    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
-  });
-  const importImage = useMutation({
-    mutationFn: useConvexAction(gateway.catalog.importPuzzleImage),
-  });
+  // Convex mutations & actions, called inside the contribute wrapper below.
+  const createPuzzle = useConvexMutation(gateway.catalog.createPuzzle);
+  const generateUploadUrl = useConvexMutation(
+    gateway.library.generateUploadUrl,
+  );
+  const importImage = useConvexAction(gateway.catalog.importPuzzleImage);
 
   // Object URL for the cover file preview — create and revoke in one effect
   const [coverFileUrl, setCoverFileUrl] = useState<string | undefined>(
@@ -118,6 +113,7 @@ function ContributePuzzlePage() {
   );
   useEffect(() => {
     if (!form.coverFile) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing object-URL lifecycle; surfaced once this component became compiler-analyzable
       setCoverFileUrl(undefined);
       return;
     }
@@ -155,14 +151,14 @@ function ContributePuzzlePage() {
     }));
   };
 
-  const handleContribute = async () => {
-    if (!form.title.trim() || !form.brand.trim() || !form.pieceCount) return;
-    setSubmitting(true);
-    try {
+  // The WHOLE contribute flow — optional image upload/import + createPuzzle — runs
+  // as one mutationFn so isPending spans the full sequence (busy-state rule v2).
+  const contribute = useMutation({
+    mutationFn: async () => {
       let imageId: Id<"_storage"> | undefined;
       if (form.coverMode === "photo") {
         if (form.coverFile) {
-          const uploadUrl = await generateUploadUrl.mutateAsync({});
+          const uploadUrl = await generateUploadUrl({});
           const res = await fetch(uploadUrl, {
             method: "POST",
             headers: { "Content-Type": form.coverFile.type },
@@ -173,9 +169,7 @@ function ContributePuzzlePage() {
           imageId = storageId as Id<"_storage">;
         } else if (form.selectedImageUrl) {
           try {
-            imageId = await importImage.mutateAsync({
-              url: form.selectedImageUrl,
-            });
+            imageId = await importImage({ url: form.selectedImageUrl });
           } catch {
             // Non-fatal: proceed without the remote image
             imageId = undefined;
@@ -183,7 +177,7 @@ function ContributePuzzlePage() {
         }
       }
 
-      await createPuzzle.mutateAsync({
+      await createPuzzle({
         title: form.title,
         brand: form.brand || undefined,
         pieceCount: form.pieceCount!,
@@ -205,15 +199,20 @@ function ContributePuzzlePage() {
             : undefined,
         image: imageId,
       });
-
+    },
+    onSuccess: () => {
       toast.success(t("puzzleSubmittedForReview"));
       router.push("/puzzles");
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error("Contribute puzzle failed:", error);
       toast.error(t("puzzleCreationFailed"));
-    } finally {
-      setSubmitting(false);
-    }
+    },
+  });
+
+  const handleContribute = () => {
+    if (!form.title.trim() || !form.brand.trim() || !form.pieceCount) return;
+    contribute.mutate();
   };
 
   const isReady =
@@ -534,7 +533,7 @@ function ContributePuzzlePage() {
       <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
         <Button
           type="button"
-          disabled={!isReady || submitting}
+          disabled={!isReady || contribute.isPending}
           onClick={handleContribute}
         >
           {t("contributePuzzle")}

--- a/apps/web/src/routes/_dashboard/puzzles/add.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/add.tsx
@@ -37,7 +37,7 @@ import { gateway, Id } from "@/gateway";
 import { useConvexAction, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "use-intl";
 
@@ -107,20 +107,18 @@ function ContributePuzzlePage() {
   );
   const importImage = useConvexAction(gateway.catalog.importPuzzleImage);
 
-  // Object URL for the cover file preview — create and revoke in one effect
-  const [coverFileUrl, setCoverFileUrl] = useState<string | undefined>(
-    undefined,
+  // Object URL for the cover file preview — derived from the file; the effect only revokes the
+  // previous URL when the file changes (or on unmount), so no setState runs inside an effect.
+  const coverFileUrl = useMemo(
+    () => (form.coverFile ? URL.createObjectURL(form.coverFile) : undefined),
+    [form.coverFile],
   );
-  useEffect(() => {
-    if (!form.coverFile) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- pre-existing object-URL lifecycle; surfaced once this component became compiler-analyzable
-      setCoverFileUrl(undefined);
-      return;
-    }
-    const url = URL.createObjectURL(form.coverFile);
-    setCoverFileUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [form.coverFile]);
+  useEffect(
+    () => () => {
+      if (coverFileUrl) URL.revokeObjectURL(coverFileUrl);
+    },
+    [coverFileUrl],
+  );
 
   // The preview shows the photo only when mode is "photo"
   const previewPhotoUrl =

--- a/apps/web/src/routes/_dashboard/puzzles/add.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/add.tsx
@@ -34,7 +34,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { gateway, Id } from "@/gateway";
-import { useAction, useMutation } from "convex/react";
+import { useConvexAction, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -101,9 +102,15 @@ function ContributePuzzlePage() {
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Mutations & actions
-  const createPuzzle = useMutation(gateway.catalog.createPuzzle);
-  const generateUploadUrl = useMutation(gateway.library.generateUploadUrl);
-  const importImage = useAction(gateway.catalog.importPuzzleImage);
+  const createPuzzle = useMutation({
+    mutationFn: useConvexMutation(gateway.catalog.createPuzzle),
+  });
+  const generateUploadUrl = useMutation({
+    mutationFn: useConvexMutation(gateway.library.generateUploadUrl),
+  });
+  const importImage = useMutation({
+    mutationFn: useConvexAction(gateway.catalog.importPuzzleImage),
+  });
 
   // Object URL for the cover file preview — create and revoke in one effect
   const [coverFileUrl, setCoverFileUrl] = useState<string | undefined>(
@@ -155,7 +162,7 @@ function ContributePuzzlePage() {
       let imageId: Id<"_storage"> | undefined;
       if (form.coverMode === "photo") {
         if (form.coverFile) {
-          const uploadUrl = await generateUploadUrl();
+          const uploadUrl = await generateUploadUrl.mutateAsync({});
           const res = await fetch(uploadUrl, {
             method: "POST",
             headers: { "Content-Type": form.coverFile.type },
@@ -166,7 +173,9 @@ function ContributePuzzlePage() {
           imageId = storageId as Id<"_storage">;
         } else if (form.selectedImageUrl) {
           try {
-            imageId = await importImage({ url: form.selectedImageUrl });
+            imageId = await importImage.mutateAsync({
+              url: form.selectedImageUrl,
+            });
           } catch {
             // Non-fatal: proceed without the remote image
             imageId = undefined;
@@ -174,7 +183,7 @@ function ContributePuzzlePage() {
         }
       }
 
-      await createPuzzle({
+      await createPuzzle.mutateAsync({
         title: form.title,
         brand: form.brand || undefined,
         pieceCount: form.pieceCount!,

--- a/apps/web/src/routes/_dashboard/trades.tsx
+++ b/apps/web/src/routes/_dashboard/trades.tsx
@@ -15,7 +15,8 @@ import { Button } from "@/components/ui/button";
 import { PageLoading } from "@/components/ui/loading";
 import { gateway, Id } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "convex/react";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { FunctionReturnType } from "convex/server";
 import {
   ArrowLeftRight,
@@ -100,18 +101,23 @@ function ExchangesPage() {
     "all",
   );
 
-  const convexUser = useQuery(
-    gateway.identity.byClerkId,
-    user?.id ? { clerkId: user.id } : "skip",
+  const { data: convexUser } = useQuery(
+    convexQuery(
+      gateway.identity.byClerkId,
+      user?.id ? { clerkId: user.id } : "skip",
+    ),
   );
 
   // Incoming = the viewer is the owner; outgoing = the viewer is the requester.
-  const incomingExchanges = useQuery(gateway.exchange.incoming);
-  const outgoingExchanges = useQuery(gateway.exchange.outgoing);
+  const { data: incomingExchanges } = useQuery(
+    convexQuery(gateway.exchange.incoming, {}),
+  );
+  const { data: outgoingExchanges } = useQuery(
+    convexQuery(gateway.exchange.outgoing, {}),
+  );
   // Open loans the viewer is holding, only fetched once the tab is opened.
-  const borrowed = useQuery(
-    gateway.lending.borrowed,
-    tab === "borrowed" ? {} : "skip",
+  const { data: borrowed } = useQuery(
+    convexQuery(gateway.lending.borrowed, tab === "borrowed" ? {} : "skip"),
   );
 
   if (
@@ -320,10 +326,18 @@ function ExchangeDetail({
   const t = useTranslations("trades");
   const [chatOpen, setChatOpen] = useState(false);
 
-  const acceptExchange = useMutation(gateway.exchange.accept);
-  const declineExchange = useMutation(gateway.exchange.decline);
-  const completeExchange = useMutation(gateway.exchange.complete);
-  const cancelExchange = useMutation(gateway.exchange.cancel);
+  const acceptExchange = useMutation({
+    mutationFn: useConvexMutation(gateway.exchange.accept),
+  });
+  const declineExchange = useMutation({
+    mutationFn: useConvexMutation(gateway.exchange.decline),
+  });
+  const completeExchange = useMutation({
+    mutationFn: useConvexMutation(gateway.exchange.complete),
+  });
+  const cancelExchange = useMutation({
+    mutationFn: useConvexMutation(gateway.exchange.cancel),
+  });
 
   // The lifecycle mutations key off the domain aggregateId, not the Convex
   // _id; guard against legacy rows lacking one so we never send undefined.
@@ -382,7 +396,7 @@ function ExchangeDetail({
             <Button
               size="sm"
               disabled={!exchange.aggregateId}
-              onClick={run((args) => acceptExchange(args))}
+              onClick={run((args) => acceptExchange.mutateAsync(args))}
             >
               <CheckCircle className="h-4 w-4" />
               {t("accept")}
@@ -391,7 +405,7 @@ function ExchangeDetail({
               variant="outline"
               size="sm"
               disabled={!exchange.aggregateId}
-              onClick={run((args) => declineExchange(args))}
+              onClick={run((args) => declineExchange.mutateAsync(args))}
             >
               <XCircle className="h-4 w-4" />
               {t("decline")}
@@ -404,7 +418,7 @@ function ExchangeDetail({
             variant="outline"
             size="sm"
             disabled={!exchange.aggregateId}
-            onClick={run((args) => cancelExchange(args))}
+            onClick={run((args) => cancelExchange.mutateAsync(args))}
           >
             <XCircle className="h-4 w-4" />
             {t("cancel")}
@@ -415,7 +429,7 @@ function ExchangeDetail({
           <Button
             size="sm"
             disabled={!exchange.aggregateId}
-            onClick={run((args) => completeExchange(args))}
+            onClick={run((args) => completeExchange.mutateAsync(args))}
           >
             <CheckCircle className="h-4 w-4" />
             {t("markComplete")}
@@ -457,9 +471,11 @@ function ExchangeDetail({
 function ExchangeChat({ exchangeId }: { exchangeId: string }) {
   const t = useTranslations("messages");
   const { member } = useCurrentMember();
-  const threadId = useQuery(
-    gateway.conversation.getThreadByExchange,
-    member ? { exchangeId } : "skip",
+  const { data: threadId } = useQuery(
+    convexQuery(
+      gateway.conversation.getThreadByExchange,
+      member ? { exchangeId } : "skip",
+    ),
   );
 
   if (threadId === undefined) {
@@ -513,17 +529,20 @@ function PuzzleSummary({
 function BorrowedList({ borrowed }: { borrowed: BorrowedLoan[] | undefined }) {
   const t = useTranslations("lending");
   const format = useFormatter();
-  const returnLoan = useMutation(gateway.lending.returnLoan);
-  const [returningId, setReturningId] = useState<string | null>(null);
+  const returnLoan = useMutation({
+    mutationFn: useConvexMutation(gateway.lending.returnLoan),
+  });
+  // Scope the pending state to the loan being returned so only that row's
+  // button disables, exactly as the old per-id busy flag did.
+  const returningId = returnLoan.isPending
+    ? (returnLoan.variables?.loanId ?? null)
+    : null;
 
   const handleReturn = async (loanId: string) => {
-    setReturningId(loanId);
     try {
-      await returnLoan({ loanId });
+      await returnLoan.mutateAsync({ loanId });
     } catch (error) {
       console.error("Failed to return loan:", error);
-    } finally {
-      setReturningId(null);
     }
   };
 

--- a/apps/web/src/routes/_public/contact.tsx
+++ b/apps/web/src/routes/_public/contact.tsx
@@ -10,7 +10,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
-import { useMutation } from "convex/react";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { LifeBuoy, Mail, MapPin, Shield } from "lucide-react";
 import * as React from "react";
 import { useLocale, useTranslations } from "use-intl";
@@ -103,7 +104,9 @@ const SUBJECT_KEY: Record<Subject, string> = {
 function ContactForm() {
   const t = useTranslations("marketing.contactPage");
   const locale = useLocale();
-  const submitMessage = useMutation(gateway.contact.submit);
+  const submitMessage = useMutation({
+    mutationFn: useConvexMutation(gateway.contact.submit),
+  });
 
   const [form, setForm] = React.useState({
     name: "",
@@ -117,7 +120,6 @@ function ContactForm() {
     message?: string;
     submit?: string;
   }>({});
-  const [sending, setSending] = React.useState(false);
   const [sent, setSent] = React.useState(false);
 
   const set =
@@ -137,9 +139,8 @@ function ContactForm() {
     setErrors(er);
     if (Object.keys(er).length > 0) return;
 
-    setSending(true);
     try {
-      await submitMessage({
+      await submitMessage.mutateAsync({
         name: form.name,
         email: form.email,
         subject: form.subject,
@@ -149,8 +150,6 @@ function ContactForm() {
       setSent(true);
     } catch {
       setErrors({ submit: t("errorSubmit") });
-    } finally {
-      setSending(false);
     }
   };
 
@@ -262,7 +261,7 @@ function ContactForm() {
       <Button
         type="submit"
         variant="brand"
-        disabled={sending}
+        disabled={submitMessage.isPending}
         className="mt-[22px] w-full h-11 text-[15px]"
       >
         {t("submit")}

--- a/docs/superpowers/plans/2026-07-02-tanstack-query-migration.md
+++ b/docs/superpowers/plans/2026-07-02-tanstack-query-migration.md
@@ -1,0 +1,54 @@
+# TanStack Query Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Task 3 is executed with the Workflow tool per the user's explicit multi-agent opt-in.
+
+**Goal:** Route every Convex read/write in apps/web through `@convex-dev/react-query` per the frozen cookbook in `docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md`; kill all manual busy flags in favor of `isPending`.
+
+**Architecture:** Behavior-preserving refactor. Foundation locks the recipe on two exemplars; a Workflow fan-out applies it across disjoint file batches; a sequential wrap-up proves completeness adversarially.
+
+**Tech Stack:** @tanstack/react-query 5, @convex-dev/react-query 0.1, TanStack Start.
+
+**Branch:** `refactor/tanstack-query-migration` (stacked on `feat/admin-redesign`; spec committed).
+
+---
+
+### Task 0: Branch check
+
+- [ ] `git fetch origin && git log origin/feat/admin-redesign --oneline -1` — if feat/admin-redesign moved, rebase this branch onto it. Working tree clean.
+
+### Task 1: Foundation — router defaults + two exemplars (sequential subagent)
+
+**Files:** Modify `apps/web/src/router.tsx`; Convert `apps/web/src/components/admin/moderation/activity-log.tsx` (query-heavy exemplar) and `apps/web/src/hooks/use-favorites.ts` (optimistic-mutation exemplar); consumers of use-favorites adjust if its return shape changes (it should NOT — keep the hook's public API identical).
+
+- [ ] **1.1:** Read the installed bridge README (`node_modules/.pnpm/@convex-dev+react-query*/node_modules/@convex-dev/react-query/README.md`) and typings. Apply its recommended query defaults to `router.tsx`'s `QueryClient` (expected: long/Infinity `staleTime` because the subscription-backed queryFn keeps data fresh; keep default `gcTime` unless the README says otherwise). Comment each default with WHY.
+- [ ] **1.2:** Convert `activity-log.tsx`: `useQuery` from `@tanstack/react-query` + `convexQuery(gateway.admin.getModerationActivity, {})`; `activity === undefined` loading check becomes `isPending`; `.data` destructured. Rendering identical.
+- [ ] **1.3:** Convert `use-favorites.ts`: `useConvexMutation(...).withOptimisticUpdate(...)` as mutationFn inside `useMutation`; queries via `convexQuery` incl. any "skip"; the hook's exported API (names/shapes) unchanged — verify its consumers compile untouched.
+- [ ] **1.4:** `pnpm nx run-many -t type-check lint test -p @jigswap/web --skip-nx-cache` green. Prettier. Commit: `refactor(web): tanstack-query foundation — router defaults + exemplar conversions`.
+- [ ] **1.5:** Report any cookbook adjustment discovered (e.g. exact skip typing quirks); the controller amends the spec's cookbook if needed. After this, the cookbook is FROZEN.
+
+### Task 2: Batch inventory (controller, inline)
+
+- [ ] **2.1:** Generate the worklist: `grep -rln 'from "convex/react"' apps/web/src` minus the sanctioned exceptions (`usePaginatedQuery` files: `components/puzzles/puzzle-client.tsx`?, verify; `useConvexAuth`-only files; the raw `useConvex` file) minus Task 1's exemplars. For files mixing sanctioned + migratable hooks: they're IN the worklist (convert the migratable hooks, keep the exception with its comment).
+- [ ] **2.2:** Partition into batches of ≤8 files grouped by directory. Save as JSON for the workflow args.
+
+### Task 3: Workflow fan-out (Workflow tool — user opt-in)
+
+- [ ] **3.1:** Run a workflow: one agent per batch (parallel, shared checkout, NO commits, disjoint files). Each agent prompt contains: the frozen cookbook table verbatim (from the spec, plus any Task-1 amendment), the busy-state rule, the exceptions rule, its exact file list, and instructions to (a) convert every `convex/react` hook usage per cookbook, (b) replace manual busy flags with per-action `isPending` (compose ORs only where a shared disable exists today), (c) run prettier on each file, (d) NOT run nx (racy in parallel), (e) return per file: converted hook count, busy flags removed, any site it could NOT convert mechanically (escalate, don't improvise).
+- [ ] **3.2:** Collect reports; controller triages escalated sites (fix inline or dispatch a focused fixer).
+
+### Task 4: Wrap-up verification (sequential)
+
+- [ ] **4.1:** Full `pnpm nx run-many -t type-check lint test arch-check -p @jigswap/backend @jigswap/domain @jigswap/gateway @jigswap/web @jigswap/contracts --skip-nx-cache`. Fix loop until green (type errors from missed call-site shape changes are expected here — fix them per cookbook).
+- [ ] **4.2:** Adversarial completeness check (script): every `from "convex/react"` import in apps/web/src names ONLY sanctioned hooks (`usePaginatedQuery`, `useConvexAuth`, `useConvex`) and carries the exception comment; zero `useState` busy/saving flags whose only writes bracket a mutation call (grep candidates `busy|saving|isSubmitting` and inspect each); zero `"skip"` passed to convex/react useQuery (all skips now inside convexQuery).
+- [ ] **4.3:** Commit: `refactor(web): migrate all Convex call sites to the tanstack-query bridge`.
+
+### Task 5: Review + PR
+
+- [ ] **5.1:** Dispatch one review subagent over the full branch diff: cookbook conformance sampling (≥10 random files), the 3 optimistic-update files traced end-to-end, busy→isPending correctness (no lost disable states), exceptions documented, no behavior drift (spot-render logic).
+- [ ] **5.2:** Fix loop; push `-u`; `gh pr create` with base `feat/admin-redesign`, title `refactor(web): route all Convex data access through TanStack Query`; body: spec link, counts (files/hooks/busy-flags), the remount-caching win, exceptions list, note it auto-retargets to main when #33 merges. Claude Code footer.
+
+## Self-review notes
+
+- Cookbook lives in the spec (single source); plan references, never restates beyond Task 3's prompt requirement.
+- Parallel-safety: agents share a checkout but disjoint files, no commits, no nx runs — single committer in Task 4.
+- Risk: call sites reading `undefined`-as-loading are the main breakage class; Task 4.1 owns it explicitly.

--- a/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
+++ b/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
@@ -24,6 +24,13 @@ live — cache-and-invalidate semantics without manual invalidation.
 | `.withOptimisticUpdate(...)` (3 files) | `useConvexMutation(fn).withOptimisticUpdate(...)` as the mutationFn (existing messaging pattern)  |
 | `useAction(fn)`                        | `useMutation({ mutationFn: useConvexAction(fn) })`                                                |
 
+**Busy-state rule v2 (owner refinement, 2026-07-02 late):** multi-step async sequences
+(Clerk calls, raw fetch uploads, browser permission flows around mutations) are wrapped WHOLE
+as the `mutationFn` of one `useMutation` — `isPending` then spans the entire sequence natively,
+eliminating the previously-sanctioned manual flags. Per-row busy states use the
+`mutation.variables`-while-pending idiom (see trades.tsx). The only justified survivor is a
+state machine that carries result data as exported API (use-puzzle-import), assessed on merit.
+
 **Busy-state rule (owner decision):** ALL manual busy flags (`busy`, `saving`, `isSubmitting`
 useState around mutations) are removed in favor of `isPending`. Each distinct action gets its own
 `useMutation` object; where a shared disable is genuinely wanted (e.g. the moderation console

--- a/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
+++ b/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
@@ -32,7 +32,8 @@ reject.isPending || ...`. No new shared flags.
 
 **Sanctioned exceptions (stay on `convex/react`, one-line comment each):**
 `usePaginatedQuery` (2 files — no bridge equivalent), `useConvexAuth` (4 files — auth state),
-raw `useConvex` client (1 file).
+raw `useConvex` client (1 file), and the `Authenticated`/`Unauthenticated` auth-state components
+(marketing header).
 
 **Cache posture:** foundation task reads the installed bridge README and locks the recommended
 `staleTime`/`gcTime` defaults in `router.tsx` (subscription-backed queryFn; unmounted data kept

--- a/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
+++ b/docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md
@@ -1,0 +1,66 @@
+# TanStack Query migration — route all Convex reads/writes through the bridge (design)
+
+**Date:** 2026-07-02
+**Status:** approved design, pre-implementation
+**Branch:** `refactor/tanstack-query-migration`, stacked on `feat/admin-redesign` (PR bases there;
+auto-retargets to main when #33 merges).
+
+## Problem
+
+`router.tsx` wires the full `@convex-dev/react-query` integration (ConvexQueryClient queryFn/
+hashFn + `connect()`), but only `lib/marketing-queries.ts` uses it. The other ~87 files use plain
+`convex/react` hooks: live while mounted, but the subscription result is forgotten on unmount, so
+every remount (tab switches, navigation) shows a loading flash. TanStack's cache keeps data for
+`gcTime`, so remounts render instantly from cache while the re-established subscription keeps it
+live — cache-and-invalidate semantics without manual invalidation.
+
+## Conversion cookbook
+
+| From (`convex/react`)                  | To                                                                                                |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `useQuery(fn, args)`                   | `useQuery(convexQuery(fn, args))` (`@tanstack/react-query`); read `.data`, loading = `.isPending` |
+| `useQuery(fn, cond ? {} : "skip")`     | `useQuery(convexQuery(fn, cond ? {} : "skip"))` — native skip (verified in bridge typings)        |
+| `useMutation(fn)`                      | `useMutation({ mutationFn: useConvexMutation(fn) })`                                              |
+| `.withOptimisticUpdate(...)` (3 files) | `useConvexMutation(fn).withOptimisticUpdate(...)` as the mutationFn (existing messaging pattern)  |
+| `useAction(fn)`                        | `useMutation({ mutationFn: useConvexAction(fn) })`                                                |
+
+**Busy-state rule (owner decision):** ALL manual busy flags (`busy`, `saving`, `isSubmitting`
+useState around mutations) are removed in favor of `isPending`. Each distinct action gets its own
+`useMutation` object; where a shared disable is genuinely wanted (e.g. the moderation console
+disabling all actions during any decision), compose it: `const busy = approve.isPending ||
+reject.isPending || ...`. No new shared flags.
+
+**Sanctioned exceptions (stay on `convex/react`, one-line comment each):**
+`usePaginatedQuery` (2 files — no bridge equivalent), `useConvexAuth` (4 files — auth state),
+raw `useConvex` client (1 file).
+
+**Cache posture:** foundation task reads the installed bridge README and locks the recommended
+`staleTime`/`gcTime` defaults in `router.tsx` (subscription-backed queryFn; unmounted data kept
+for gcTime so remounts are instant).
+
+## Execution architecture (user-opted multi-agent)
+
+1. **Foundation (sequential subagent):** verify bridge capabilities against installed typings/
+   README; set router defaults; convert two exemplars (one query-heavy file, one
+   optimistic-mutation file); full verify; the cookbook is then FROZEN — fan-out agents follow
+   it verbatim.
+2. **Workflow fan-out:** remaining files partitioned into ~8 disjoint-directory batches; parallel
+   agents convert per cookbook, editing the shared checkout WITHOUT committing (disjoint file
+   lists; single committer). Each agent returns changed files + any site it could not convert
+   mechanically (escalation list, not improvisation).
+3. **Wrap-up (sequential):** full 5-project verify + fix loop; adversarial completeness check
+   (grep: zero `useQuery|useMutation|useAction` imports from `convex/react` outside the
+   documented exceptions; zero remaining manual busy flags around mutations); final review; one
+   commit; stacked PR.
+
+## Testing / verification
+
+Behavior-preserving refactor: no UI, i18n, or backend changes. Full
+`type-check`/`lint`/`test`/`arch-check` across the 5 projects (`--skip-nx-cache`). Existing web
+tests (91) must stay green; pure-helper tests are unaffected. Loading-state call sites that
+checked `x === undefined` are adjusted to `.isPending`/`.data` with identical rendering.
+
+## Out of scope
+
+Route-loader prefetching (`ensureQueryData`) — a natural follow-up once call sites are on the
+bridge; pagination migration; any behavioral change.


### PR DESCRIPTION
## Summary

Every Convex read/write in apps/web now flows through the `@convex-dev/react-query` bridge that `router.tsx` had wired since the redesign but only the marketing queries used. The practical win: **remounted views render instantly from the TanStack cache** (gcTime) while Convex's push subscriptions keep everything live — no more loading flash when returning to a tab or page, no manual invalidation ever.

- **Design:** [`docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md`](docs/superpowers/specs/2026-07-02-tanstack-query-migration-design.md) (frozen conversion cookbook + busy-state rule)
- **Plan:** [`docs/superpowers/plans/2026-07-02-tanstack-query-migration.md`](docs/superpowers/plans/2026-07-02-tanstack-query-migration.md)

### Numbers

**80 files** converted (2 foundation exemplars + 78 via a 10-batch parallel workflow), **196 hooks** migrated (`useQuery`→`convexQuery`, `useMutation`→`useConvexMutation`, `useAction`→`useConvexAction`), **29 manual busy flags** replaced by per-action `isPending`. `staleTime: Infinity` set per the bridge README (results are pushed, never stale).

### Deliberate survivors

- **Sanctioned `convex/react` exceptions** (each carries an in-code comment): `usePaginatedQuery` ×2 (no bridge equivalent), `useConvexAuth` ×4, raw `useConvex` ×1, `Authenticated`/`Unauthenticated` components, provider infrastructure.
- **7 busy flags kept**: each brackets multi-step async beyond one mutation (raw `fetch` uploads between mutations, the push-permission flow, a Clerk profile update, a per-row keyed busy, one exported state machine) where composed `isPending` would gap mid-sequence and re-enable buttons.
- All three `withOptimisticUpdate` flows (messaging composer, favorites, category reorder) traced end-to-end — updaters stay on the Convex localStore, which the bridge mirrors into the QueryClient.

### Review catch worth knowing

TanStack returns query errors in `.error` instead of throwing to error boundaries. The final review caught the one real casualty — the messages deep-link 404 flow (stale thread id → eternal skeleton) — fixed with `throwOnError: true` on that query. **Posture decision for a follow-up:** other converted queries now show loading states on error instead of reaching `DefaultCatchBoundary`; a global `throwOnError: true` in the router defaults would restore full convex/react parity if preferred.

### Verification

Full `type-check`/`lint`/`test`/`arch-check` across all 5 projects (`--skip-nx-cache`); 92 web tests green; adversarial completeness check proves zero non-sanctioned `convex/react` hooks and zero unsanctioned busy flags remain.

**Stacked on `feat/admin-redesign` (#33)** — GitHub retargets this PR to main automatically when #33 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)