### PR TITLE
fix(catalog): URL-import image formats — candidate filtering + magic-byte sniffing

### DIFF
--- a/packages/backend/convex/catalog/importPuzzleImage.ts
+++ b/packages/backend/convex/catalog/importPuzzleImage.ts
@@ -1,5 +1,5 @@
 "use node";
-import { isPrivateIp } from "@jigswap/domain";
+import { isPrivateIp, sniffImageType } from "@jigswap/domain";
 import { ConvexError, v } from "convex/values";
 import { lookup as dnsLookup } from "node:dns/promises";
 import type { Id } from "../_generated/dataModel";
@@ -80,10 +80,6 @@ export const importPuzzleImage = action({
     if (!response.ok)
       throw new ConvexError(`Image fetch failed: ${response.status}`);
 
-    const contentType = response.headers.get("content-type") ?? "";
-    if (!ALLOWED_TYPES.some((t) => contentType.startsWith(t))) {
-      throw new ConvexError("Unsupported image type");
-    }
     const declaredLength = Number(
       response.headers.get("content-length") ?? "0",
     );
@@ -92,6 +88,17 @@ export const importPuzzleImage = action({
     const buffer = await response.arrayBuffer();
     if (buffer.byteLength > MAX_BYTES) throw new ConvexError("Image too large");
 
-    return await ctx.storage.store(new Blob([buffer], { type: contentType }));
+    // Effective type: trust an allowed content-type header; otherwise fall back to magic-byte
+    // sniffing — CDNs routinely serve real JPEGs as application/octet-stream (or nothing). The
+    // sniffer only ever yields the allowed raster formats, so a mislabeled SVG/HTML body can
+    // never smuggle through: it sniffs to null and is rejected.
+    const contentType = response.headers.get("content-type") ?? "";
+    const headerAllowed = ALLOWED_TYPES.some((t) => contentType.startsWith(t));
+    const effectiveType = headerAllowed
+      ? contentType
+      : sniffImageType(new Uint8Array(buffer));
+    if (!effectiveType) throw new ConvexError("Unsupported image type");
+
+    return await ctx.storage.store(new Blob([buffer], { type: effectiveType }));
   },
 });

--- a/packages/domain/src/catalog/domain/extract-puzzle-draft.spec.ts
+++ b/packages/domain/src/catalog/domain/extract-puzzle-draft.spec.ts
@@ -440,3 +440,25 @@ describe("extractPuzzleDraft", () => {
     });
   });
 });
+
+describe("buildImages format filtering", () => {
+  it("drops candidates with extensions the import action always rejects", () => {
+    const draft = extractPuzzleDraft(
+      {
+        ...empty,
+        ogImages: [
+          "https://cdn.shop.example/logo.svg",
+          "https://cdn.shop.example/box.jpg",
+          "https://cdn.shop.example/fav.ico?v=3",
+          "https://cdn.shop.example/i/no-extension",
+        ],
+      },
+      "https://shop.example/puzzle",
+    );
+    expect(draft.images).toEqual([
+      "https://cdn.shop.example/box.jpg",
+      "https://cdn.shop.example/i/no-extension",
+    ]);
+    expect(draft.imageUrl).toBe("https://cdn.shop.example/box.jpg");
+  });
+});

--- a/packages/domain/src/catalog/domain/extract-puzzle-draft.ts
+++ b/packages/domain/src/catalog/domain/extract-puzzle-draft.ts
@@ -1,5 +1,6 @@
 // packages/domain/src/catalog/domain/extract-puzzle-draft.ts
 import { cleanPuzzleTitle } from "./clean-puzzle-title";
+import { hasUnsupportedImageExtension } from "./image-format";
 import type {
   JsonLdProduct,
   PuzzleImportDraft,
@@ -44,6 +45,9 @@ const buildImages = (raw: RawProductPage): readonly string[] => {
       // entries in untrusted JSON-LD. Equivalent under the static string[] type, but real defense.
       typeof url === "string" &&
       HTTP_RE.test(url) &&
+      // Never offer a candidate the import action is guaranteed to reject (e.g. .svg logos
+      // JSON-LD/OG frequently carry). Extension-less URLs pass — the action stays authoritative.
+      !hasUnsupportedImageExtension(url) &&
       !seen.has(url) &&
       result.length < MAX_IMAGES
     ) {

--- a/packages/domain/src/catalog/domain/image-format.spec.ts
+++ b/packages/domain/src/catalog/domain/image-format.spec.ts
@@ -60,6 +60,11 @@ describe("sniffImageType", () => {
     expect(sniffImageType(bytes("RIFF", 0, 0, 0, 0, "WEBP"))).toBe(
       "image/webp",
     );
+    // Real-world regression: ravensburger.cloud serves valid WebP with NO
+    // content-type + nosniff (first 16 observed bytes: RIFF: ..WEBPVP8 ).
+    expect(
+      sniffImageType(bytes("RIFF", 0x3a, 0x20, 0x02, 0x00, "WEBPVP8 ")),
+    ).toBe("image/webp");
     expect(sniffImageType(bytes(0, 0, 0, 0x20, "ftypavif", 0, 0, 0, 0))).toBe(
       "image/avif",
     );

--- a/packages/domain/src/catalog/domain/image-format.spec.ts
+++ b/packages/domain/src/catalog/domain/image-format.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { hasUnsupportedImageExtension, sniffImageType } from "./image-format";
+
+describe("hasUnsupportedImageExtension", () => {
+  it("rejects extensions the import action can never accept", () => {
+    expect(hasUnsupportedImageExtension("https://a.b/logo.svg")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/x.SVG")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/scan.tiff")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/scan.tif")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/fav.ico")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/img.bmp")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/shot.heic")).toBe(true);
+    expect(hasUnsupportedImageExtension("https://a.b/doc.pdf")).toBe(true);
+  });
+
+  it("keeps supported and unknown/extension-less URLs (the action stays authoritative)", () => {
+    expect(hasUnsupportedImageExtension("https://a.b/box.jpg")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://a.b/box.jpeg")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://a.b/box.png")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://a.b/box.webp")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://a.b/box.avif")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://a.b/box.gif")).toBe(false);
+    expect(hasUnsupportedImageExtension("https://cdn.a.b/i/12345")).toBe(false);
+    expect(
+      hasUnsupportedImageExtension("https://a.b/img?fmt=svg"), // query only — path has no extension
+    ).toBe(false);
+  });
+
+  it("reads the extension from the pathname, ignoring query and fragment", () => {
+    expect(hasUnsupportedImageExtension("https://a.b/logo.svg?v=2#top")).toBe(
+      true,
+    );
+    expect(hasUnsupportedImageExtension("https://a.b/box.jpg?width=800")).toBe(
+      false,
+    );
+  });
+
+  it("treats unparseable URLs as not-unsupported (later guards own them)", () => {
+    expect(hasUnsupportedImageExtension("not a url")).toBe(false);
+  });
+});
+
+describe("sniffImageType", () => {
+  const bytes = (...values: (number | string)[]): Uint8Array => {
+    const out: number[] = [];
+    for (const v of values) {
+      if (typeof v === "string")
+        out.push(...[...v].map((c) => c.charCodeAt(0)));
+      else out.push(v);
+    }
+    return new Uint8Array(out);
+  };
+
+  it("identifies the supported raster formats by magic bytes", () => {
+    expect(sniffImageType(bytes(0xff, 0xd8, 0xff, 0xe0))).toBe("image/jpeg");
+    expect(sniffImageType(bytes(0x89, "PNG", 0x0d, 0x0a, 0x1a, 0x0a))).toBe(
+      "image/png",
+    );
+    expect(sniffImageType(bytes("GIF89a"))).toBe("image/gif");
+    expect(sniffImageType(bytes("RIFF", 0, 0, 0, 0, "WEBP"))).toBe(
+      "image/webp",
+    );
+    expect(sniffImageType(bytes(0, 0, 0, 0x20, "ftypavif", 0, 0, 0, 0))).toBe(
+      "image/avif",
+    );
+    expect(sniffImageType(bytes(0, 0, 0, 0x1c, "ftypavis", 0, 0, 0, 0))).toBe(
+      "image/avif",
+    );
+  });
+
+  it("returns null for anything else — including SVG/HTML lookalikes", () => {
+    expect(sniffImageType(bytes("<svg xmlns"))).toBeNull();
+    expect(sniffImageType(bytes("<!DOCTYPE html>"))).toBeNull();
+    expect(sniffImageType(bytes("RIFF", 0, 0, 0, 0, "WAVE"))).toBeNull(); // RIFF but not WebP
+    expect(sniffImageType(bytes(0, 0, 0, 0x18, "ftypmp42"))).toBeNull(); // ISO-BMFF but not AVIF
+    expect(sniffImageType(new Uint8Array(0))).toBeNull();
+    expect(sniffImageType(bytes(0x00, 0x01, 0x02))).toBeNull();
+  });
+});

--- a/packages/domain/src/catalog/domain/image-format.ts
+++ b/packages/domain/src/catalog/domain/image-format.ts
@@ -1,0 +1,78 @@
+// Image-format knowledge shared by the URL-import pipeline. The import action accepts only the
+// raster formats it can safely store (jpeg/png/webp/gif/avif — SVG is a stored-XSS vector and
+// stays banned). Two pure helpers keep both ends of the pipeline honest:
+// - hasUnsupportedImageExtension: scrape-time heuristic so buildImages never offers a candidate
+//   the action is guaranteed to reject (extensions we KNOW fail; extension-less URLs pass —
+//   the action stays authoritative).
+// - sniffImageType: magic-byte detection so a supported image served with a wrong/missing
+//   content-type (CDNs love application/octet-stream) is still importable, without ever
+//   trusting a header to smuggle in SVG/HTML.
+
+const UNSUPPORTED_IMAGE_EXTENSIONS = new Set([
+  "svg",
+  "ico",
+  "bmp",
+  "tif",
+  "tiff",
+  "heic",
+  "heif",
+  "pdf",
+]);
+
+export const hasUnsupportedImageExtension = (url: string): boolean => {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return false; // unparseable — later guards (URL validation in the action) own it
+  }
+  const lastSegment = pathname.split("/").pop() ?? "";
+  const dot = lastSegment.lastIndexOf(".");
+  if (dot === -1) return false;
+  return UNSUPPORTED_IMAGE_EXTENSIONS.has(
+    lastSegment.slice(dot + 1).toLowerCase(),
+  );
+};
+
+export type SniffedImageType =
+  | "image/jpeg"
+  | "image/png"
+  | "image/webp"
+  | "image/gif"
+  | "image/avif";
+
+const ascii = (bytes: Uint8Array, start: number, text: string): boolean => {
+  if (bytes.length < start + text.length) return false;
+  for (let i = 0; i < text.length; i++) {
+    if (bytes[start + i] !== text.charCodeAt(i)) return false;
+  }
+  return true;
+};
+
+export const sniffImageType = (bytes: Uint8Array): SniffedImageType | null => {
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (bytes.length >= 4 && bytes[0] === 0x89 && ascii(bytes, 1, "PNG")) {
+    return "image/png";
+  }
+  if (ascii(bytes, 0, "GIF8")) {
+    return "image/gif";
+  }
+  if (ascii(bytes, 0, "RIFF") && ascii(bytes, 8, "WEBP")) {
+    return "image/webp";
+  }
+  // ISO-BMFF: "ftyp" at offset 4, AVIF brands "avif"/"avis" at offset 8.
+  if (
+    ascii(bytes, 4, "ftyp") &&
+    (ascii(bytes, 8, "avif") || ascii(bytes, 8, "avis"))
+  ) {
+    return "image/avif";
+  }
+  return null;
+};

--- a/packages/domain/src/catalog/domain/index.ts
+++ b/packages/domain/src/catalog/domain/index.ts
@@ -6,6 +6,7 @@ export * from "./errors";
 export * from "./events";
 export * from "./extract-puzzle-draft";
 export * from "./ids";
+export * from "./image-format";
 export * from "./is-private-ip";
 export * from "./normalize-store-url";
 export * from "./piece-count";


### PR DESCRIPTION
## Root cause

Two failure classes behind the "Unsupported image type" ConvexError during URL import:

1. **The scraper offered guaranteed-rejects.** `buildImages` collected JSON-LD/OG image candidates with only an http(s) filter — store pages routinely carry `.svg` logos and placeholders in exactly those slots, and the import action (correctly) refuses SVG as a stored-XSS vector.
2. **Supported images with wrong labels.** `importPuzzleImage` trusted the `content-type` header alone; CDNs routinely serve real JPEGs as `application/octet-stream` (or nothing) → intermittent rejections of perfectly good images.

## Fix (both ends, pure-domain, TDD)

- **`hasUnsupportedImageExtension`** — extension deny-list (`svg/ico/bmp/tif/tiff/heic/heif/pdf`) applied in `buildImages`, so the picker never offers a candidate the action must reject. Extension-less URLs pass — the action stays authoritative.
- **`sniffImageType`** — magic-byte detection (jpeg/png/gif/webp/avif incl. `avis` brand) used by the action as a fallback when the header type isn't allowed. The sniffer can only yield the allowed raster formats, so a mislabeled SVG/HTML body still sniffs to `null` and is rejected — the security posture is unchanged.

Supported formats remain: **JPEG, PNG, WebP, GIF, AVIF** (SVG deliberately excluded per the earlier security review).

Both helpers live in `packages/domain` (the node action itself isn't testable under convex-test) with 6 sniffing/extension specs + a `buildImages` filtering spec. Domain + backend `type-check`/`lint`/`test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)