### PR TITLE
fix(web): plank boxes stay draggable after arranging the shelf

### DIFF
--- a/apps/web/src/components/common/puzzle-plank-3d/body-refs.test.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/body-refs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { reconcileBodyRefs } from "./body-refs";
+
+// Regression: @react-three/rapier's RigidBody writes the forwarded ref ONCE, at
+// body creation. If the refs array is rebuilt with fresh objects when the box
+// count changes, every already-mounted RigidBody is left holding a ref that is
+// permanently null — its box still collides but can never be grabbed again
+// (onPointerDown early-returns on the null body). Surviving indexes must
+// therefore keep their EXACT ref objects; only new indexes get fresh refs.
+describe("reconcileBodyRefs", () => {
+  test("growing preserves the existing ref objects by identity", () => {
+    const prev = reconcileBodyRefs<string>([], 3);
+    prev[0]!.current = "body-0";
+    const next = reconcileBodyRefs(prev, 5);
+    expect(next).toHaveLength(5);
+    expect(next[0]).toBe(prev[0]);
+    expect(next[1]).toBe(prev[1]);
+    expect(next[2]).toBe(prev[2]);
+    expect(next[0]!.current).toBe("body-0");
+  });
+
+  test("growing mints fresh null refs for the new indexes only", () => {
+    const prev = reconcileBodyRefs<string>([], 2);
+    const next = reconcileBodyRefs(prev, 4);
+    expect(next[2]!.current).toBeNull();
+    expect(next[3]!.current).toBeNull();
+    expect(next[2]).not.toBe(next[3]);
+    expect(prev).not.toContain(next[2]);
+  });
+
+  test("shrinking keeps the surviving prefix by identity", () => {
+    const prev = reconcileBodyRefs<string>([], 4);
+    const next = reconcileBodyRefs(prev, 2);
+    expect(next).toHaveLength(2);
+    expect(next[0]).toBe(prev[0]);
+    expect(next[1]).toBe(prev[1]);
+  });
+
+  test("same count returns refs with identical identity", () => {
+    const prev = reconcileBodyRefs<string>([], 3);
+    const next = reconcileBodyRefs(prev, 3);
+    expect(next.map((ref) => ref)).toEqual(prev.map((ref) => ref));
+    next.forEach((ref, i) => expect(ref).toBe(prev[i]));
+  });
+});

--- a/apps/web/src/components/common/puzzle-plank-3d/body-refs.ts
+++ b/apps/web/src/components/common/puzzle-plank-3d/body-refs.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+// @react-three/rapier's RigidBody writes the forwarded ref exactly once, when
+// the physics body is created (its useForwardedRef only backfills a NEW ref
+// object from an internal ref that never held the body). A ref object handed
+// to an already-mounted RigidBody therefore stays null forever. When the box
+// count changes, surviving indexes MUST keep their original ref objects —
+// only new indexes may get fresh refs.
+export function reconcileBodyRefs<T>(
+  prev: React.RefObject<T | null>[],
+  count: number,
+): React.RefObject<T | null>[] {
+  return Array.from(
+    { length: count },
+    (_, i) => prev[i] ?? React.createRef<T>(),
+  );
+}

--- a/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
+++ b/apps/web/src/components/common/puzzle-plank-3d/scene-physics.tsx
@@ -27,6 +27,7 @@ import {
 import { easing } from "maath";
 import * as React from "react";
 import * as THREE from "three";
+import { reconcileBodyRefs } from "./body-refs";
 import { clampThrowVelocity } from "./drag-math";
 import { layoutRow } from "./layout";
 import type { PlankSceneProps } from "./scene";
@@ -438,12 +439,17 @@ function PhysicsArrangement({
   const visibleW = contentH * aspect;
   const shelfW = Math.max(visibleW * 0.95, rowWidth + 0.4);
 
-  // Per-box rigid body refs for the drag hook
-  const rigidBodyRefs = React.useMemo(
-    () => boxes.map(() => React.createRef<RapierRigidBody>()),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [boxes.length],
-  );
+  // Per-box rigid body refs for the drag hook. Rapier writes a forwarded ref
+  // only at body creation, so when the box count changes (arrange-shelf), the
+  // refs of already-mounted bodies must be kept by IDENTITY — a rebuilt ref
+  // would stay null forever and its box would silently become ungrabbable.
+  // Render-time reconcile is idempotent; the array identity changes exactly
+  // when the count does, which is what the drag hook's deps key on.
+  const refsStore = React.useRef<React.RefObject<RapierRigidBody | null>[]>([]);
+  if (refsStore.current.length !== boxes.length) {
+    refsStore.current = reconcileBodyRefs(refsStore.current, boxes.length);
+  }
+  const rigidBodyRefs = refsStore.current;
 
   // Lowest each box center may be dragged (its half-height), so a held box never
   // sinks below the shelf top (y = 0).


### PR DESCRIPTION
## Problem

After changing the shelf via the Arrange dialog, boxes rendered by `RigidBody` components that survived the change still collided but no longer responded to pointer drag. With `key={i}` data-shifting, this surfaced as "the added puzzles won't react to drag events".

## Root cause

`@react-three/rapier` writes a forwarded ref **exactly once, at body creation**: `getRigidBody()` does `rigidBodyRef.current = rigidBody`, and `useForwardedRef` only backfills a *new* ref object from an internal ref that never held the body. None of our props are in `immutableRigidBodyOptions` (`args`, `colliders`, `canSleep`), so a surviving `RigidBody` also never re-creates its body.

`scene-physics.tsx` rebuilt the entire `rigidBodyRefs` array with fresh `createRef()`s whenever `boxes.length` changed. Every already-mounted box was handed a ref that stays `null` forever, and `onPointerDown` silently early-returns on `if (!body) return` — the box collides (its body exists) but can never be grabbed.

## Fix

`reconcileBodyRefs`: surviving indexes keep their **exact** ref objects (which hold their bodies); only new indexes get fresh refs (written by rapier at their body's creation). The array identity still changes exactly when the count does, so the drag hook's dependency behavior is unchanged.

## Verification

- New `body-refs.test.ts` (TDD: red → green) covers identity preservation on grow/shrink/same-count.
- Full web suite: 96/96 passing. No new type-check errors (the `admin/users` route errors on a stale local `routeTree.gen.ts` are pre-existing noise).
- Manual check recommended: profile → Arrange shelf → add a puzzle → confirm every box (old and new) can be grabbed. I can't drive a browser in this environment.

## Known limitation (pre-existing, out of scope)

Boxes are keyed by index, so re-ordering shifts puzzle art across physics bodies (a box keeps its old physical position while showing different art). Keying by a stable copy id would address that; not touched here to keep the fix surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)