### PR TITLE
feat: admin review notifications + navigation & admin-console polish

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1458,6 +1458,8 @@
       "puzzle_rejected": "Puzzle rejected",
       "proposal_approved": "Suggestion approved",
       "proposal_rejected": "Suggestion declined",
+      "admin_proposal_filed": "Suggestion to review",
+      "admin_definition_submitted": "Submission to moderate",
       "photo_removed": "Photo removed",
       "goal_achieved": "Goal achieved"
     },
@@ -1518,6 +1520,14 @@
         "title": "Suggestion declined",
         "message": "Your suggested edit was declined."
       },
+      "admin_proposal_filed": {
+        "title": "Suggestion to review",
+        "message": "A member suggested an edit to a catalogue puzzle."
+      },
+      "admin_definition_submitted": {
+        "title": "Submission to moderate",
+        "message": "A new puzzle submission awaits moderation."
+      },
       "photo_removed": {
         "title": "Photo removed",
         "message": "One of your puzzle photos was removed by a moderator."
@@ -1555,6 +1565,8 @@
       "puzzle_rejected": "When a puzzle you submitted is rejected.",
       "proposal_approved": "When an edit you suggested to a catalogue puzzle is approved.",
       "proposal_rejected": "When an edit you suggested to a catalogue puzzle is declined.",
+      "admin_proposal_filed": "When a member suggests an edit that needs review (admins only).",
+      "admin_definition_submitted": "When a new puzzle submission awaits moderation (admins only).",
       "photo_removed": "When a moderator removes one of your puzzle photos.",
       "goal_achieved": "When you reach a solving goal."
     },

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1458,6 +1458,8 @@
       "puzzle_rejected": "Puzzel afgewezen",
       "proposal_approved": "Wijzigingsvoorstel goedgekeurd",
       "proposal_rejected": "Wijzigingsvoorstel afgewezen",
+      "admin_proposal_filed": "Voorstel om te beoordelen",
+      "admin_definition_submitted": "Inzending om te modereren",
       "photo_removed": "Foto verwijderd",
       "goal_achieved": "Doel behaald"
     },
@@ -1518,6 +1520,14 @@
         "title": "Wijzigingsvoorstel afgewezen",
         "message": "Jouw voorgestelde wijziging is afgewezen."
       },
+      "admin_proposal_filed": {
+        "title": "Voorstel om te beoordelen",
+        "message": "Een lid heeft een wijziging voor een cataloguspuzzel voorgesteld."
+      },
+      "admin_definition_submitted": {
+        "title": "Inzending om te modereren",
+        "message": "Een nieuwe puzzelinzending wacht op moderatie."
+      },
       "photo_removed": {
         "title": "Foto verwijderd",
         "message": "Een van je puzzelfoto's is door een moderator verwijderd."
@@ -1555,6 +1565,8 @@
       "puzzle_rejected": "Wanneer een puzzel die je hebt ingediend is afgewezen.",
       "proposal_approved": "Wanneer een wijziging die je voor een cataloguspuzzel voorstelde wordt goedgekeurd.",
       "proposal_rejected": "Wanneer een wijziging die je voor een cataloguspuzzel voorstelde wordt afgewezen.",
+      "admin_proposal_filed": "Wanneer een lid een wijziging voorstelt die beoordeling vereist (alleen beheerders).",
+      "admin_definition_submitted": "Wanneer een nieuwe puzzelinzending op moderatie wacht (alleen beheerders).",
       "photo_removed": "Wanneer een moderator een van je puzzelfoto's verwijdert.",
       "goal_achieved": "Wanneer je een puzzeldoel behaalt."
     },

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1458,6 +1458,8 @@
       "puzzle_rejected": "Puzzle rejected",
       "proposal_approved": "Suggestion approved",
       "proposal_rejected": "Suggestion declined",
+      "admin_proposal_filed": "Suggestion to review",
+      "admin_definition_submitted": "Submission to moderate",
       "photo_removed": "Photo removed",
       "goal_achieved": "Goal achieved"
     },
@@ -1518,6 +1520,14 @@
         "title": "Suggestion declined",
         "message": "Your suggested edit was declined."
       },
+      "admin_proposal_filed": {
+        "title": "Suggestion to review",
+        "message": "A member suggested an edit to a catalogue puzzle."
+      },
+      "admin_definition_submitted": {
+        "title": "Submission to moderate",
+        "message": "A new puzzle submission awaits moderation."
+      },
       "photo_removed": {
         "title": "Photo removed",
         "message": "One of your puzzle photos was removed by a moderator."
@@ -1555,6 +1565,8 @@
       "puzzle_rejected": "When a puzzle you submitted is rejected.",
       "proposal_approved": "When an edit you suggested to a catalogue puzzle is approved.",
       "proposal_rejected": "When an edit you suggested to a catalogue puzzle is declined.",
+      "admin_proposal_filed": "When a member suggests an edit that needs review (admins only).",
+      "admin_definition_submitted": "When a new puzzle submission awaits moderation (admins only).",
       "photo_removed": "When a moderator removes one of your puzzle photos.",
       "goal_achieved": "When you reach a solving goal."
     },

--- a/apps/web/src/components/dashboard-layout/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard-layout/app-sidebar.tsx
@@ -10,6 +10,7 @@ import { useUser } from "@/compat/clerk";
 import { Link } from "@/compat/link";
 import { usePathname } from "@/compat/navigation";
 import { useCurrentMember } from "@/components/dashboard-home/use-current-member";
+import { usePageHeaderContent } from "@/components/dashboard-layout/page-header-slot";
 import { formatUnreadCount } from "@/components/messaging/format";
 import {
   Sidebar,
@@ -108,7 +109,12 @@ function NavLink({ item }: { item: ShellNavItem }) {
   const t = useTranslations("shell");
   const tMessages = useTranslations("messages");
   const pathname = usePathname();
-  const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+  // A page can override the pathname-derived highlight (e.g. a copy page highlights
+  // My Puzzles or Browse depending on ownership, neither of which matches /copies/$id).
+  const { activeNavKey } = usePageHeaderContent();
+  const active = activeNavKey
+    ? activeNavKey === item.key
+    : pathname === item.href || pathname.startsWith(`${item.href}/`);
   const title = t(`pages.${item.key}.title`);
 
   // Live unread-messages total, subscribed for the Messages item only (every

--- a/apps/web/src/components/dashboard-layout/nav-context.test.ts
+++ b/apps/web/src/components/dashboard-layout/nav-context.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { parseNavContext } from "./nav-context";
+
+describe("parseNavContext", () => {
+  it("parses a collection context", () => {
+    expect(parseNavContext("collection:abc123")).toEqual({
+      kind: "collection",
+      id: "abc123",
+    });
+  });
+  it.each(["", "collection:", "puzzle:x", "collection", undefined])(
+    "returns null for %s",
+    (value) => {
+      expect(parseNavContext(value)).toBeNull();
+    },
+  );
+});

--- a/apps/web/src/components/dashboard-layout/nav-context.ts
+++ b/apps/web/src/components/dashboard-layout/nav-context.ts
@@ -1,0 +1,17 @@
+// Typed parser for the `?from=` navigation-context search param (UX: breadcrumbs are
+// canonical by default and contextual ONLY when the arriving link carries explicit
+// context — see the copies page). Currently only collections; extend the union as
+// new contexts appear.
+export interface NavContext {
+  kind: "collection";
+  id: string;
+}
+
+export const parseNavContext = (
+  value: string | undefined,
+): NavContext | null => {
+  if (!value) return null;
+  const [kind, id] = value.split(":", 2);
+  if (kind === "collection" && id) return { kind, id };
+  return null;
+};

--- a/apps/web/src/components/dashboard-layout/page-header-slot.tsx
+++ b/apps/web/src/components/dashboard-layout/page-header-slot.tsx
@@ -34,6 +34,8 @@ export type PageHeaderContent = {
   crumbs?: PageHeaderCrumb[];
   /** Meta + primary action node shown to the right of the title. */
   actions?: ReactNode;
+  /** Overrides the sidebar's pathname-based highlight with this nav item key. */
+  activeNavKey?: string;
 };
 
 type PageHeaderSlot = {

--- a/apps/web/src/components/notifications/channel-matrix.tsx
+++ b/apps/web/src/components/notifications/channel-matrix.tsx
@@ -1,13 +1,18 @@
+import { useUser } from "@/compat/clerk";
 import {
-  type NotificationChannel,
+  ADMIN_NOTIFICATION_TYPES,
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
   notificationAccent,
   notificationIcon,
+  type NotificationChannel,
 } from "@/components/notifications/notification-meta";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 type Toggles = Record<string, Partial<Record<NotificationChannel, boolean>>>;
@@ -37,6 +42,17 @@ export function ChannelMatrix({
   onToggle,
 }: ChannelMatrixProps) {
   const t = useTranslations("notifications");
+  const { user } = useUser();
+
+  // Admin-only types (e.g. "a proposal awaits review") are hidden from members who
+  // aren't admins — they'd never receive them. While isAdmin is loading, treat as
+  // false so the admin rows simply appear once it resolves rather than flashing.
+  const { data: isAdmin } = useQuery(
+    convexQuery(gateway.identity.isAdmin, user?.id ? {} : "skip"),
+  );
+  const visibleTypes = NOTIFICATION_TYPES.filter(
+    (type) => !ADMIN_NOTIFICATION_TYPES.has(type) || isAdmin === true,
+  );
 
   return (
     <>
@@ -69,7 +85,7 @@ export function ChannelMatrix({
         </div>
 
         <div className="divide-border divide-y">
-          {NOTIFICATION_TYPES.map((type) => {
+          {visibleTypes.map((type) => {
             const Icon = notificationIcon(type);
             const row = preferences[type] ?? {};
             return (
@@ -120,7 +136,7 @@ export function ChannelMatrix({
 
       {/* Mobile: stacked per-type groups with labelled switches */}
       <div className="divide-border divide-y sm:hidden">
-        {NOTIFICATION_TYPES.map((type) => {
+        {visibleTypes.map((type) => {
           const Icon = notificationIcon(type);
           const row = preferences[type] ?? {};
           return (

--- a/apps/web/src/components/notifications/notification-meta.ts
+++ b/apps/web/src/components/notifications/notification-meta.ts
@@ -4,6 +4,8 @@ import {
   CheckCircle2,
   Heart,
   ImageOff,
+  Inbox,
+  Lightbulb,
   type LucideIcon,
   MessageSquare,
   Star,
@@ -30,7 +32,9 @@ export type NotificationType =
   | "exchange_proposed"
   | "exchange_disputed"
   | "proposal_approved"
-  | "proposal_rejected";
+  | "proposal_rejected"
+  | "admin_proposal_filed"
+  | "admin_definition_submitted";
 
 export const NOTIFICATION_TYPES: NotificationType[] = [
   "trade_request",
@@ -49,7 +53,15 @@ export const NOTIFICATION_TYPES: NotificationType[] = [
   "goal_achieved",
   "proposal_approved",
   "proposal_rejected",
+  "admin_proposal_filed",
+  "admin_definition_submitted",
 ];
+
+// Types only admins ever receive; hidden from non-admin preference matrices.
+export const ADMIN_NOTIFICATION_TYPES: ReadonlySet<NotificationType> = new Set([
+  "admin_proposal_filed",
+  "admin_definition_submitted",
+]);
 
 export type NotificationChannel = "inApp" | "email" | "push";
 
@@ -125,6 +137,10 @@ export function notificationIcon(type: string): LucideIcon {
       return CheckCircle2;
     case "proposal_rejected":
       return XCircle;
+    case "admin_proposal_filed":
+      return Lightbulb;
+    case "admin_definition_submitted":
+      return Inbox;
     default:
       return Bell;
   }
@@ -153,6 +169,9 @@ export function notificationAccent(type: string): string {
       return "text-pink-500";
     case "message_received":
       return "text-blue-500";
+    case "admin_proposal_filed":
+    case "admin_definition_submitted":
+      return "text-primary";
     default:
       return "text-primary";
   }
@@ -192,6 +211,12 @@ export function notificationHref(row: NotificationRow): string | null {
     case "proposal_approved":
     case "proposal_rejected":
       return relatedId ? `/puzzles/${relatedId}` : "/puzzles";
+    case "admin_proposal_filed":
+      return relatedId
+        ? `/admin/puzzles/proposals/${relatedId}`
+        : "/admin/puzzles/proposals";
+    case "admin_definition_submitted":
+      return "/admin/moderation";
     default:
       return null;
   }

--- a/apps/web/src/components/ui/puzzle-card.tsx
+++ b/apps/web/src/components/ui/puzzle-card.tsx
@@ -66,6 +66,8 @@ interface PuzzleCardProps {
    * "/my-puzzles" so the owner sees their own gated copy route.
    */
   viewBasePath?: string;
+  /** Appended verbatim to the view link (e.g. `?from=collection:<id>`) for contextual breadcrumbs. */
+  viewSearch?: string;
   /** Cover image fit: "cover" crops (default), "contain" shows the full image. */
   imageFit?: "cover" | "contain";
   onDelete?: (puzzleId: Id<"ownedPuzzles">) => void;
@@ -243,6 +245,7 @@ export function PuzzleCard({
   onEdit,
   onView: _onView,
   viewBasePath = "/copies",
+  viewSearch,
   imageFit,
   onDelete,
   onRemove,
@@ -456,7 +459,7 @@ export function PuzzleCard({
       // selection action, so a navigating cover link would hijack it.
       imageHref={
         variant !== "selection" && variant !== "pick" && viewBasePath && ownedId
-          ? `${viewBasePath}/${ownedId}`
+          ? `${viewBasePath}/${ownedId}${viewSearch ?? ""}`
           : undefined
       }
       imageFit={imageFit}

--- a/apps/web/src/routes/_dashboard/admin/puzzles/$puzzleId/index.tsx
+++ b/apps/web/src/routes/_dashboard/admin/puzzles/$puzzleId/index.tsx
@@ -3,7 +3,6 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { PuzzleLifecycleAction } from "@/components/admin/puzzles/puzzle-lifecycle-action";
 import { QueueEmpty } from "@/components/admin/queue-empty";
-import { StatTile } from "@/components/admin/stat-tile";
 import { AuditList } from "@/components/admin/users/audit-list";
 import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { ChangedFieldChips } from "@/components/suggest-edit/changed-field-chips";
@@ -96,7 +95,7 @@ function AdminPuzzleDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-xl border bg-card p-6">
+      <div>
         <div className="flex flex-wrap items-start gap-4">
           {definition.image ? (
             <img
@@ -173,21 +172,49 @@ function AdminPuzzleDetailPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-        <StatTile label={t("detail.stats.owners")} value={stats.ownerCount} />
-        <StatTile label={t("detail.stats.copies")} value={stats.copies.total} />
-        <StatTile
-          label={t("detail.stats.forTrade")}
-          value={stats.copies.forTrade}
-        />
-        <StatTile
-          label={t("detail.stats.forSale")}
-          value={stats.copies.forSale}
-        />
-        <StatTile
-          label={t("detail.stats.forLend")}
-          value={stats.copies.forLend}
-        />
+      <div className="rounded-xl border bg-card p-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+          <div>
+            <div className="text-2xl font-semibold tabular-nums">
+              {stats.ownerCount}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("detail.stats.owners")}
+            </div>
+          </div>
+          <div>
+            <div className="text-2xl font-semibold tabular-nums">
+              {stats.copies.total}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("detail.stats.copies")}
+            </div>
+          </div>
+          <div>
+            <div className="text-2xl font-semibold tabular-nums">
+              {stats.copies.forTrade}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("detail.stats.forTrade")}
+            </div>
+          </div>
+          <div>
+            <div className="text-2xl font-semibold tabular-nums">
+              {stats.copies.forSale}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("detail.stats.forSale")}
+            </div>
+          </div>
+          <div>
+            <div className="text-2xl font-semibold tabular-nums">
+              {stats.copies.forLend}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("detail.stats.forLend")}
+            </div>
+          </div>
+        </div>
       </div>
 
       <section className="space-y-2">

--- a/apps/web/src/routes/_dashboard/collections/$id/index.tsx
+++ b/apps/web/src/routes/_dashboard/collections/$id/index.tsx
@@ -378,6 +378,7 @@ function CollectionDetailPage() {
               puzzle={puzzle}
               variant="collection"
               onRemove={handleRemovePuzzle}
+              viewSearch={`?from=collection:${id}`}
             />
           ))}
         </PuzzleViewProvider>

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -215,6 +215,10 @@ function CopyInstanceDetail({
           {t("actions.edit")}
         </Button>
       ) : null,
+      // Neither /copies/$id nor /my-puzzles/$id matches a nav item's href, so the
+      // sidebar's pathname-prefix match would highlight nothing; override with the
+      // nav item that frames this copy for the current viewer.
+      activeNavKey: copy.viewerIsOwner ? "myPuzzles" : "browse",
     }),
     [snapshot.title, owned, copy.viewerIsOwner, t, tShell],
   );

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -7,6 +7,10 @@ import { useRouter } from "@/compat/navigation";
 import { availabilityToSharing } from "@/components/add-puzzle";
 import { EditCopyDialog } from "@/components/copies/edit-copy-dialog";
 import { PhotoLightbox } from "@/components/copies/photo-lightbox";
+import {
+  parseNavContext,
+  type NavContext,
+} from "@/components/dashboard-layout/nav-context";
 import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { ImageEditorDialog } from "@/components/image-editor/image-editor-dialog";
 import { EmptyState } from "@/components/library/empty-state";
@@ -53,12 +57,26 @@ export const Route = createFileRoute("/_dashboard/copies/$id")({
   head: ({ match }) => ({
     meta: [{ title: pageTitle(match.context, "copyInstance") }],
   }),
+  // The page reads ?from off the URL — a typed navigation-context param set by
+  // links that want contextual breadcrumbs (e.g. a collection's puzzle grid).
+  // Unknown/malformed values parse to null downstream and the page falls back
+  // to its canonical breadcrumb trail.
+  validateSearch: (search: Record<string, unknown>): { from?: string } => ({
+    from: typeof search.from === "string" ? search.from : undefined,
+  }),
   component: CopyInstancePage,
 });
 
 function CopyInstancePage() {
   const { id } = Route.useParams();
-  return <CopyInstanceScreen copyId={id} owned={false} />;
+  const { from } = Route.useSearch();
+  return (
+    <CopyInstanceScreen
+      copyId={id}
+      owned={false}
+      navContext={parseNavContext(from)}
+    />
+  );
 }
 
 // Shared copy-detail screen used by BOTH the public route (/copies/$id, owned=false)
@@ -68,9 +86,12 @@ function CopyInstancePage() {
 export function CopyInstanceScreen({
   copyId,
   owned,
+  navContext = null,
 }: {
   copyId: string;
   owned: boolean;
+  /** Parsed `?from=` context (e.g. arrived from a collection); null when absent/malformed. */
+  navContext?: NavContext | null;
 }) {
   const router = useRouter();
   const { data: copy, isPending: copyPending } = useQuery(
@@ -92,7 +113,14 @@ export function CopyInstanceScreen({
     return <CopyInstanceNotFound />;
   }
 
-  return <CopyInstanceDetail copy={copy} copyId={copyId} owned={owned} />;
+  return (
+    <CopyInstanceDetail
+      copy={copy}
+      copyId={copyId}
+      owned={owned}
+      navContext={navContext}
+    />
+  );
 }
 
 function CopyInstanceSkeleton() {
@@ -151,10 +179,12 @@ function CopyInstanceDetail({
   copy,
   copyId,
   owned,
+  navContext,
 }: {
   copy: CopyInstanceView;
   copyId: string;
   owned: boolean;
+  navContext: NavContext | null;
 }) {
   const router = useRouter();
   const t = useTranslations("copyInstance");
@@ -195,20 +225,45 @@ function CopyInstanceDetail({
     }
   };
 
+  // When the arriving link carried `?from=collection:<id>`, resolve that collection so the
+  // page head can show contextual breadcrumbs instead of the canonical trail below. Skipped
+  // (no query) when there's no context; unreadable/missing collections resolve to null and
+  // the canonical trail applies exactly as if there were no context at all.
+  const { data: navCollection } = useQuery(
+    convexQuery(
+      gateway.collections.byId,
+      navContext
+        ? { collectionId: navContext.id as Id<"collections"> }
+        : "skip",
+    ),
+  );
+
   // Publish the page head: the puzzle name as the title (replacing the generic
   // "Owned copy"), the breadcrumb trail, and the owner-only Edit action. For the
   // owner route (owned) the crumbs are left to the shell's auto trail (My Library ›
   // My Puzzles › <name>, since /my-puzzles/$id's pageKey matches the nav item);
   // the public route publishes an explicit Community › Owned Copies › <name> trail.
+  // A readable `?from=collection:<id>` context overrides both with My Library ›
+  // Collections › <name> and highlights Collections in the sidebar; no context (or an
+  // unreadable/malformed one) falls back to the behavior above, byte-identical.
   usePageHeader(
     () => ({
       title: snapshot.title,
-      crumbs: owned
-        ? undefined
-        : [
-            { label: tShell("groups.community.label"), href: "/community" },
-            { label: tShell("crumbs.ownedCopies"), href: "/browse" },
-          ],
+      crumbs: navCollection
+        ? [
+            { label: tShell("groups.library.label"), href: "/library" },
+            { label: tShell("pages.collections.title"), href: "/collections" },
+            {
+              label: navCollection.name,
+              href: `/collections/${navContext?.id}`,
+            },
+          ]
+        : owned
+          ? undefined
+          : [
+              { label: tShell("groups.community.label"), href: "/community" },
+              { label: tShell("crumbs.ownedCopies"), href: "/browse" },
+            ],
       actions: copy.viewerIsOwner ? (
         <Button variant="outline" onClick={() => setEditOpen(true)}>
           <Edit className="h-4 w-4" />
@@ -217,10 +272,23 @@ function CopyInstanceDetail({
       ) : null,
       // Neither /copies/$id nor /my-puzzles/$id matches a nav item's href, so the
       // sidebar's pathname-prefix match would highlight nothing; override with the
-      // nav item that frames this copy for the current viewer.
-      activeNavKey: copy.viewerIsOwner ? "myPuzzles" : "browse",
+      // nav item that frames this copy for the current viewer (or Collections when
+      // arriving from one via the resolved nav context).
+      activeNavKey: navCollection
+        ? "collections"
+        : copy.viewerIsOwner
+          ? "myPuzzles"
+          : "browse",
     }),
-    [snapshot.title, owned, copy.viewerIsOwner, t, tShell],
+    [
+      snapshot.title,
+      owned,
+      copy.viewerIsOwner,
+      t,
+      tShell,
+      navContext?.id,
+      navCollection,
+    ],
   );
 
   const formatDay = (timestamp: number) =>

--- a/docs/superpowers/plans/2026-07-09-change-proposals-polish.md
+++ b/docs/superpowers/plans/2026-07-09-change-proposals-polish.md
@@ -1,0 +1,316 @@
+# Change Proposals — Polish Round Implementation Plan (PR 5, stacked)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four owner-feedback items: (1) admins get in-app/push notifications when there is something to review (a new change proposal, a new definition submission); (2) the admin puzzle-definition detail page drops from 9 bounded card surfaces to 4 (UI-designer memo); (3) `/copies/<id>` highlights the right sidebar item (ownership-dependent, via a new `activeNavKey` page-header-slot override); (4) navigating collection → copy shows a contextual `My Library › Collections › [Collection] › [Copy]` breadcrumb via a typed `?from=collection:<id>` search param (UX-architect memo: canonical by default, contextual only when the link carries explicit context — collection membership is many-to-many so no canonical parent exists).
+
+**Architecture:** The notification work introduces the first role-targeted fan-out: a `by_role` index on `users` (the Clerk role mirror — display + notification targeting ONLY, never authorization, which stays JWT-based via `isAdmin`), two admin-facing `NotificationType`s (`admin_proposal_filed`, `admin_definition_submitted`) run through the full sync-point checklist, subscriber cases for `ChangeProposalFiled`/`PuzzleDefinitionSubmitted` fanning out to admins (excluding the actor), and first `/admin/*` deep links in both href resolvers. It also fixes the ROOT CAUSE preference gap: `NotificationPreference.allows()` treats a type absent from a stored toggles map as OFF, silently suppressing every newly added type for members with pre-existing preference rows — changed to fall back to the type's default toggles (this also retroactively fixes `proposal_approved`/`proposal_rejected` for existing members). Admin-only types are hidden from non-admins' preference matrix. Items 2-4 are web-only and follow the two specialist memos verbatim.
+
+**Tech Stack:** Convex (convex-test), vitest, TanStack Router `validateSearch`, use-intl EN/NL.
+
+---
+
+## Executor setup & non-negotiable constraints
+
+- [ ] **The worktree already exists** — work in `/home/sander/Documenten/Projects/SanderVerkuil/JigSwap/.claude/worktrees/change-proposals-polish`, branch `feat/change-proposals-polish`, branched from `feat/change-proposals-image-editor` at `552ad5487`. Deps installed.
+- [ ] First commit: this plan (`docs: change-proposals polish plan (PR 5)`).
+
+**STACKED-PR RULES:** base = `feat/change-proposals-image-editor`; controller opens the PR with that base.
+
+**Baselines:** web 127 / backend 589 / domain 1101, all green at `552ad5487`. Backend tests at `convex/` root; web pure-helper tests only (node env). `_generated/api.d.ts` hand-edits required for any NEW Convex function modules (none planned — verify before assuming). routeTree regenerates via web vitest.
+
+**Guardrails:**
+
+- Authorization is NEVER gated on `users.role` — it stays display + notification-targeting; every admin surface keeps its JWT `isAdmin` gate. Update the schema comment to say exactly that.
+- `ChangeProposalEdited` does NOT notify (noise; the queue reflects edits live).
+- The admin fan-out excludes the acting member (an admin filing a proposal must not self-notify).
+- Items 2-4 must not change any data reads/mutations — layout/navigation only.
+
+---
+
+### Task 1 — Preference-gap fix: absent type ⇒ default toggles (domain, TDD)
+
+**Files:**
+
+- Modify: `packages/domain/src/notifications/domain/notification-preference.ts` (`allows()`)
+- Modify: its colocated spec (find it: `notification-preference.spec.ts`)
+
+**Steps:**
+
+- [ ] Read `notification-preference.ts` fully. Current: `allows(type, channel)` returns `this.state.toggles[type]?.[channel] === true` — a stored row created before a type existed suppresses that type forever.
+- [ ] Write the failing test in the spec (mirror its existing style): rehydrate/construct a preference whose `toggles` map LACKS a type (e.g. only `trade_request` present), then assert `allows("puzzle_approved", "inApp") === true` (the default for every type is `{ inApp: true, email: false, push: false }` per `defaultToggles()`), and `allows("puzzle_approved", "email") === false`. Also assert an EXPLICITLY disabled stored toggle still wins (`toggles: { puzzle_approved: { inApp: false, ... } }` → false).
+- [ ] Run → fail. Implement: in `allows()`, fall back to the default when the type is absent from the stored map:
+
+```ts
+  allows(type: NotificationType, channel: Channel): boolean {
+    const stored = this.state.toggles[type];
+    if (stored) return stored[channel] === true;
+    // A type added AFTER this preference row was created has no stored entry; absent
+    // means "never asked", not "opted out" — fall back to the type's default toggles.
+    return defaultToggles()[type][channel] === true;
+  }
+```
+
+(adapt names to the real code; `defaultToggles` may be module-private — it is defined in this file.)
+
+- [ ] Run: spec green; full domain suite (1101 + new = report). Any other spec asserting the old absent⇒false behavior must be updated deliberately (report which).
+- [ ] Prettier; commit: `fix(domain): absent notification-preference types fall back to default toggles`
+
+---
+
+### Task 2 — Admin notification types end-to-end (backend, TDD)
+
+**Files:**
+
+- Modify: `packages/backend/convex/schema.ts` (users `by_role` index + role-field comment; `notifications.type` union)
+- Modify: `packages/domain/src/notifications/domain/notification-type.ts` (+ its spec)
+- Modify: `packages/backend/convex/notifications/updateNotificationPreference.ts` (validator)
+- Modify: `packages/backend/convex/notifications/subscriber.ts` (2 new cases + admin fan-out helper)
+- Modify: `packages/backend/convex/notifications/adapters/webPush.ts` (admin URLs)
+- Create: `packages/backend/convex/adminReviewNotifications.test.ts`
+
+**Steps:**
+
+- [ ] `schema.ts` users table: add `.index("by_role", ["role"])` after `by_username`, and extend the role-field comment's last line to: `// ... DISPLAY + NOTIFICATION TARGETING only: authorization always reads the JWT via identity/isAdmin — never gate on this field.`
+- [ ] Add the two types through every sync point (kinds in this order, after `proposal_rejected`): `admin_proposal_filed`, `admin_definition_submitted`.
+  1. Domain union + `NOTIFICATION_TYPES` array (+ comments: `// Catalog: ChangeProposalFiled — admins are asked to review a suggested edit` / `// Catalog: PuzzleDefinitionSubmitted — admins are asked to moderate a new submission`).
+  2. `notification-type.spec.ts` hardcoded array.
+  3. `schema.ts` `notifications.type` union.
+  4. `updateNotificationPreference.ts` validator.
+- [ ] Subscriber: add a helper above `translate` and two cases in the Catalog section:
+
+```ts
+// Fan a review-request out to every admin except the acting member. Reads the users
+// table's Clerk role MIRROR via by_role — acceptable for informational notifications
+// (authorization stays JWT-only); a drifted mirror can only mis-route a notification,
+// never grant access.
+const adminRecipients = async (
+  ctx: MutationCtx,
+  excludeUserId: string,
+): Promise<Doc<"users">[]> => {
+  const admins = await ctx.db
+    .query("users")
+    .withIndex("by_role", (q) => q.eq("role", "admin"))
+    .collect();
+  return admins.filter((admin) => (admin._id as string) !== excludeUserId);
+};
+```
+
+cases:
+
+```ts
+    case "ChangeProposalFiled": {
+      const puzzle = await loadPuzzle(ctx, p.puzzleDefinitionId as string);
+      const admins = await adminRecipients(ctx, p.proposedBy as string);
+      return admins.map((admin) =>
+        cmd(
+          admin._id,
+          "admin_proposal_filed",
+          "Suggestion to Review",
+          puzzle
+            ? `A member suggested an edit to "${puzzle.title}"`
+            : "A member suggested an edit to a catalogue puzzle",
+          p.changeProposalId as string, // the review route's param — no lookup needed
+        ),
+      );
+    }
+    case "PuzzleDefinitionSubmitted": {
+      const admins = await adminRecipients(ctx, p.submittedBy as string);
+      const puzzle = await loadPuzzle(ctx, p.puzzleDefinitionId as string);
+      return admins.map((admin) =>
+        cmd(
+          admin._id,
+          "admin_definition_submitted",
+          "Submission to Moderate",
+          puzzle
+            ? `"${puzzle.title}" awaits moderation`
+            : "A new puzzle submission awaits moderation",
+          puzzle?._id ?? (p.puzzleDefinitionId as string),
+        ),
+      );
+    }
+```
+
+- [ ] `webPush.ts` `notificationUrl`: add before the default:
+
+```ts
+    // Admin review deep links (first /admin destinations in this switch).
+    case "admin_proposal_filed":
+      return relatedId
+        ? `/admin/puzzles/proposals/${relatedId}`
+        : "/admin/puzzles/proposals";
+    case "admin_definition_submitted":
+      return "/admin/moderation";
+```
+
+(and extend the existing `webPush.test.ts` `notificationUrl` describe with the two cases, mirroring its style.)
+
+- [ ] Create `packages/backend/convex/adminReviewNotifications.test.ts` (helper block copied from `changeProposalNotifications.test.ts` incl. `flushScheduled` + `notificationsFor`; seed a THIRD user with `role: "admin"` directly in the seed helper — note `asAdmin` identity impersonation doesn't write the role mirror; the seeded users row must carry `role: "admin"` explicitly for the fan-out to find it). Tests:
+  1. Filing a proposal notifies the seeded admin (`admin_proposal_filed`, message contains the puzzle title, `relatedId` = the proposal aggregate id) and does NOT notify the proposer or another regular member.
+  2. Submitting a definition notifies the admin (`admin_definition_submitted`) and not the submitter.
+  3. Actor exclusion: when the ADMIN user themself submits a definition, no `admin_definition_submitted` lands for them.
+  4. Editing a pending proposal produces NO admin notification.
+- [ ] Run: new file green; full backend suite (589 + additions = report; webPush.test grows by 2); domain suite green (spec array updated).
+- [ ] Prettier; commit: `feat(backend): notify admins when proposals or submissions await review`
+
+---
+
+### Task 3 — Admin notifications: web rendering + preference-matrix scoping
+
+**Files:**
+
+- Modify: `apps/web/src/components/notifications/notification-meta.ts`
+- Modify: `apps/web/src/components/notifications/channel-matrix.tsx`
+- Modify: `apps/web/locales/en.json`, `nl.json`, `source.json`
+
+**Steps:**
+
+- [ ] `notification-meta.ts`: add both types to the union + `NOTIFICATION_TYPES` (tail, matching the file's append convention); `notificationIcon`: `admin_proposal_filed` → `Lightbulb` (import if absent), `admin_definition_submitted` → `Inbox` (import if absent — check what the moderation console uses and reuse); `notificationAccent`: both → the accent used by informational types (check `trade_request`'s accent and match); `notificationHref`:
+
+```ts
+    case "admin_proposal_filed":
+      return relatedId
+        ? `/admin/puzzles/proposals/${relatedId}`
+        : "/admin/puzzles/proposals";
+    case "admin_definition_submitted":
+      return "/admin/moderation";
+```
+
+Also export the audience set:
+
+```ts
+// Types only admins ever receive; hidden from non-admin preference matrices.
+export const ADMIN_NOTIFICATION_TYPES: ReadonlySet<NotificationType> = new Set([
+  "admin_proposal_filed",
+  "admin_definition_submitted",
+]);
+```
+
+- [ ] `channel-matrix.tsx`: read the file; it iterates `NOTIFICATION_TYPES` for the rows. Add an `isAdmin` query (`convexQuery(gateway.identity.isAdmin, {})` — the same op the admin route gate uses; verify its gateway name) and filter: `const visibleTypes = NOTIFICATION_TYPES.filter((type) => !ADMIN_NOTIFICATION_TYPES.has(type) || isAdmin === true);` used by both the desktop and mobile renderings. While `isAdmin` is loading treat as false (rows appear when it resolves).
+- [ ] Locales (three parallel maps × three files, after `proposal_rejected`):
+  - `notifications.types`: en+source `"admin_proposal_filed": "Suggestion to review"`, `"admin_definition_submitted": "Submission to moderate"`; nl `"Voorstel om te beoordelen"`, `"Inzending om te modereren"`.
+  - `notifications.copy`: en+source `admin_proposal_filed: { title: "Suggestion to review", message: "A member suggested an edit to a catalogue puzzle." }`, `admin_definition_submitted: { title: "Submission to moderate", message: "A new puzzle submission awaits moderation." }`; nl `{ "title": "Voorstel om te beoordelen", "message": "Een lid heeft een wijziging voor een cataloguspuzzel voorgesteld." }`, `{ "title": "Inzending om te modereren", "message": "Een nieuwe puzzelinzending wacht op moderatie." }`.
+  - `notifications.typeDesc`: en+source `"When a member suggests an edit that needs review (admins only)."`, `"When a new puzzle submission awaits moderation (admins only)."`; nl `"Wanneer een lid een wijziging voorstelt die beoordeling vereist (alleen beheerders)."`, `"Wanneer een nieuwe puzzelinzending op moderatie wacht (alleen beheerders)."`.
+- [ ] Verify: web vitest 127; web tsc clean; JSON parse + en==source.
+- [ ] Prettier; commit: `feat(web): render admin review notifications + scope them to admin preference matrices`
+
+---
+
+### Task 4 — Admin detail page: 9 cards → 4 (UI-designer memo, verbatim)
+
+**Files:**
+
+- Modify: `apps/web/src/routes/_dashboard/admin/puzzles/$puzzleId/index.tsx`
+
+**Steps:**
+
+- [ ] Apply the designer's AFTER skeleton exactly:
+  1. Header (currently `rounded-xl border bg-card p-6`): drop the card classes — plain `<div>`; inner flex-wrap row (image / identity block / actions) UNCHANGED; the dates row becomes `mt-4 flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground` (hairline rule, not a card).
+  2. Stats: replace the 5× `StatTile` grid with ONE `rounded-xl border bg-card p-4` panel containing `grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5`, each cell `\n<div><div className="text-2xl font-semibold tabular-nums">{value}</div><div className="text-xs text-muted-foreground">{label}</div></div>` for owners / copies.total / forTrade / forSale / forLend with the existing `t("detail.stats.*")` keys. Remove the now-orphaned `StatTile` import (the component file itself is untouched — the users page still uses it).
+  3. Owners / Proposals / Audit sections: UNTOUCHED.
+- [ ] No i18n changes, no query/action changes — verify by diff that only layout classes/JSX structure moved.
+- [ ] Verify: web vitest 127; tsc clean; lint no new.
+- [ ] Prettier; commit: `refactor(web): flatten admin puzzle detail to four bounded surfaces`
+
+---
+
+### Task 5 — Sidebar highlight override (`activeNavKey`, UX memo Q1)
+
+**Files:**
+
+- Modify: `apps/web/src/components/dashboard-layout/page-header-slot.tsx`
+- Modify: `apps/web/src/components/dashboard-layout/app-sidebar.tsx`
+- Modify: `apps/web/src/routes/_dashboard/copies/$id.tsx`
+
+**Steps:**
+
+- [ ] `page-header-slot.tsx`: add to `PageHeaderContent`:
+
+```ts
+  /** Overrides the sidebar's pathname-based highlight with this nav item key. */
+  activeNavKey?: string;
+```
+
+- [ ] `app-sidebar.tsx`: find the `NavLink` active computation (`pathname === item.href || pathname.startsWith(...)`). Read the component structure first — the override must come from `usePageHeaderContent()` (the sidebar renders inside the provider; verified in `shell.tsx`):
+
+```ts
+const { activeNavKey } = usePageHeaderContent();
+const active = activeNavKey
+  ? activeNavKey === item.key
+  : pathname === item.href || pathname.startsWith(`${item.href}/`);
+```
+
+(if `NavLink` doesn't receive `item.key`, thread it — read how items are mapped.)
+
+- [ ] `copies/$id.tsx`: in the existing `usePageHeader` call (its deps already include `copy.viewerIsOwner`), add `activeNavKey: copy.viewerIsOwner ? "myPuzzles" : "browse",` (keys as they appear in `NAV_GROUPS` — verify both key strings in `route-meta.ts`).
+- [ ] Verify: web vitest 127; tsc clean. Grep that no OTHER page publishes `activeNavKey` accidentally (only copies).
+- [ ] Prettier; commit: `feat(web): ownership-aware sidebar highlight for copy pages`
+
+---
+
+### Task 6 — Contextual collection crumbs (`?from=collection:<id>`, UX memo Q2; TDD for the parser)
+
+**Files:**
+
+- Create: `apps/web/src/components/dashboard-layout/nav-context.ts` + `nav-context.test.ts`
+- Modify: `apps/web/src/routes/_dashboard/copies/$id.tsx`
+- Modify: `apps/web/src/components/ui/puzzle-card.tsx` (optional `viewSearch` prop)
+- Modify: `apps/web/src/routes/_dashboard/collections/$id/index.tsx` (pass it)
+
+**Steps:**
+
+- [ ] TDD the tiny parser. `nav-context.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { parseNavContext } from "./nav-context";
+
+describe("parseNavContext", () => {
+  it("parses a collection context", () => {
+    expect(parseNavContext("collection:abc123")).toEqual({
+      kind: "collection",
+      id: "abc123",
+    });
+  });
+  it.each(["", "collection:", "puzzle:x", "collection", undefined])(
+    "returns null for %s",
+    (value) => {
+      expect(parseNavContext(value)).toBeNull();
+    },
+  );
+});
+```
+
+`nav-context.ts`:
+
+```ts
+// Typed parser for the `?from=` navigation-context search param (UX: breadcrumbs are
+// canonical by default and contextual ONLY when the arriving link carries explicit
+// context — see the copies page). Currently only collections; extend the union as
+// new contexts appear.
+export interface NavContext {
+  kind: "collection";
+  id: string;
+}
+
+export const parseNavContext = (
+  value: string | undefined,
+): NavContext | null => {
+  if (!value) return null;
+  const [kind, id] = value.split(":", 2);
+  if (kind === "collection" && id) return { kind, id };
+  return null;
+};
+```
+
+- [ ] `copies/$id.tsx`: add `validateSearch` to the route options (mirror `my-puzzles/add/new.tsx`'s pattern) returning `{ from?: string }`; parse via `parseNavContext`; when it yields a collection, `convexQuery` the collection (find the existing by-id read the collections detail page uses — likely `gateway.collections.byId` or similar; verify in `packages/gateway/src/operations.ts`; pass `"skip"` when no context — check how the repo skips conditional convexQuery calls, e.g. other pages' patterns, and mirror). In the existing `usePageHeader`, branch: valid resolved collection ⇒ `crumbs: [ {tShell("groups.library.label") → "/library"}, {tShell("pages.collections.title") → "/collections"}, {collection.name → `/collections/${id}`} ]` + `activeNavKey: "collections"`; otherwise the existing owned/non-owned logic (+ Task 5's ownership `activeNavKey`). Deps extended with the context id + collection name.
+- [ ] `puzzle-card.tsx`: add optional `viewSearch?: string` appended to the internally built view href (read how `imageHref`/`viewBasePath` compose; append verbatim when provided). Only the collections page passes it.
+- [ ] `collections/$id/index.tsx`: pass `viewSearch={`?from=collection:${id}`}` to its `PuzzleCard`s.
+- [ ] Verify: web vitest 127 + 2 new = 129; tsc clean; deep-link fallback sanity (no `from` → behavior identical; malformed → canonical). Lint no new.
+- [ ] Prettier; commit: `feat(web): contextual collection breadcrumbs on copy pages via typed from-param`
+
+---
+
+### Task 7 — Full sweep
+
+- [ ] Standard sweep (`nx run-many -t type-check|test|lint --skip-nx-cache`, `prettier --check .`, backend suite, web suite, domain suite) — report all counts. The controller pushes and opens the stacked PR.

--- a/packages/backend/convex/adminReviewNotifications.test.ts
+++ b/packages/backend/convex/adminReviewNotifications.test.ts
@@ -1,0 +1,162 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+// Admin review notifications: ChangeProposalFiled and PuzzleDefinitionSubmitted fan out to every
+// admin (excluding the acting member) so there is an inbox for "things awaiting review". Editing a
+// pending proposal must NOT notify (the review queue already reflects edits live).
+
+const seedMembers = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    const mkUser = (clerkId: string, name: string, role?: string) =>
+      ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name,
+        isActive: true,
+        role,
+        createdAt: now,
+        updatedAt: now,
+      });
+    return {
+      alice: await mkUser("clerk_alice", "Alice"),
+      bob: await mkUser("clerk_bob", "Bob"),
+      // The role mirror must be written explicitly on the seeded row — asAdmin below only
+      // impersonates the JWT claim, it never touches this row, and the fan-out reads the mirror
+      // via by_role.
+      admin: await mkUser("clerk_admin", "Admin", "admin"),
+    };
+  });
+
+const asAlice = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+const asBob = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_bob" });
+const asAdmin = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_admin", metadata: { role: "admin" } });
+
+// Submit (as alice) + approve (as admin), returning an APPROVED definition's aggregateId.
+const submitApproved = async (t: ReturnType<typeof convexTest>) => {
+  const id = await asAlice(t).mutation(
+    api.catalog.submitPuzzleDefinition.submitPuzzleDefinition,
+    { title: "Mountain Vista", pieceCount: 1000 },
+  );
+  await asAdmin(t).mutation(
+    api.catalog.approvePuzzleDefinition.approvePuzzleDefinition,
+    { puzzleDefinitionId: id as string },
+  );
+  return id as string;
+};
+
+const fileAsBob = async (t: ReturnType<typeof convexTest>) => {
+  const definitionId = await submitApproved(t);
+  const proposalId = await asBob(t).mutation(
+    api.catalog.proposeDefinitionChange.proposeDefinitionChange,
+    {
+      puzzleDefinitionId: definitionId,
+      title: "Mountain Vista (Panorama)",
+      pieceCount: 500,
+    },
+  );
+  return { definitionId, proposalId: proposalId as string };
+};
+
+// Drain the async event dispatcher: yield a macrotask so the pending runAfter(0) job fires,
+// then await any in-progress jobs — looped a few times to settle the chain.
+const flushScheduled = async (t: ReturnType<typeof convexTest>) => {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await t.finishInProgressScheduledFunctions();
+  }
+};
+
+const notificationsFor = (
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+) =>
+  t.run((ctx) =>
+    ctx.db
+      .query("notifications")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect(),
+  );
+
+describe("admin review notifications", () => {
+  test("filing a proposal notifies the admin, not the proposer or another member", async () => {
+    const t = convexTest(schema, modules);
+    const { alice, bob, admin } = await seedMembers(t);
+    const { proposalId } = await fileAsBob(t);
+    await flushScheduled(t);
+
+    const isFiled = (n: { type: string }) => n.type === "admin_proposal_filed";
+    const adminNotifications = (await notificationsFor(t, admin)).filter(
+      isFiled,
+    );
+    expect(adminNotifications).toHaveLength(1);
+    expect(adminNotifications[0]?.message).toContain("Mountain Vista");
+    expect(adminNotifications[0]?.relatedId).toBe(proposalId);
+
+    expect((await notificationsFor(t, bob)).filter(isFiled)).toEqual([]);
+    expect((await notificationsFor(t, alice)).filter(isFiled)).toEqual([]);
+  });
+
+  test("submitting a definition notifies the admin, not the submitter", async () => {
+    const t = convexTest(schema, modules);
+    const { bob, admin } = await seedMembers(t);
+    await asBob(t).mutation(
+      api.catalog.submitPuzzleDefinition.submitPuzzleDefinition,
+      { title: "Desert Ruins", pieceCount: 750 },
+    );
+    await flushScheduled(t);
+
+    const isSubmitted = (n: { type: string }) =>
+      n.type === "admin_definition_submitted";
+    const adminNotifications = (await notificationsFor(t, admin)).filter(
+      isSubmitted,
+    );
+    expect(adminNotifications).toHaveLength(1);
+    expect(adminNotifications[0]?.message).toContain("Desert Ruins");
+
+    expect((await notificationsFor(t, bob)).filter(isSubmitted)).toEqual([]);
+  });
+
+  test("actor exclusion: the admin submitting a definition does not self-notify", async () => {
+    const t = convexTest(schema, modules);
+    const { admin } = await seedMembers(t);
+    await asAdmin(t).mutation(
+      api.catalog.submitPuzzleDefinition.submitPuzzleDefinition,
+      { title: "Admin's Own Submission", pieceCount: 300 },
+    );
+    await flushScheduled(t);
+
+    expect(
+      (await notificationsFor(t, admin)).filter(
+        (n) => n.type === "admin_definition_submitted",
+      ),
+    ).toEqual([]);
+  });
+
+  test("editing a pending proposal produces no admin notification", async () => {
+    const t = convexTest(schema, modules);
+    const { admin } = await seedMembers(t);
+    const { proposalId } = await fileAsBob(t);
+    await flushScheduled(t);
+
+    const isFiled = (n: { type: string }) => n.type === "admin_proposal_filed";
+    expect((await notificationsFor(t, admin)).filter(isFiled)).toHaveLength(1);
+
+    await asBob(t).mutation(api.catalog.editChangeProposal.editChangeProposal, {
+      changeProposalId: proposalId,
+      title: "Mountain Vista (Wide Panorama)",
+    });
+    await flushScheduled(t);
+
+    expect((await notificationsFor(t, admin)).filter(isFiled)).toHaveLength(1);
+  });
+});

--- a/packages/backend/convex/adminReviewNotifications.test.ts
+++ b/packages/backend/convex/adminReviewNotifications.test.ts
@@ -31,6 +31,10 @@ const seedMembers = async (t: ReturnType<typeof convexTest>) =>
       // impersonates the JWT claim, it never touches this row, and the fan-out reads the mirror
       // via by_role.
       admin: await mkUser("clerk_admin", "Admin", "admin"),
+      // A second admin, used as a positive control in the actor-exclusion test: it proves
+      // the fan-out actually fired (admin2 gets notified) rather than the whole dispatch
+      // silently no-oping, while confirming the acting admin specifically was dropped.
+      admin2: await mkUser("clerk_admin2", "Admin Two", "admin"),
     };
   });
 
@@ -126,20 +130,23 @@ describe("admin review notifications", () => {
     expect((await notificationsFor(t, bob)).filter(isSubmitted)).toEqual([]);
   });
 
-  test("actor exclusion: the admin submitting a definition does not self-notify", async () => {
+  test("actor exclusion: the admin submitting a definition does not self-notify, but another admin does", async () => {
     const t = convexTest(schema, modules);
-    const { admin } = await seedMembers(t);
+    const { admin, admin2 } = await seedMembers(t);
     await asAdmin(t).mutation(
       api.catalog.submitPuzzleDefinition.submitPuzzleDefinition,
       { title: "Admin's Own Submission", pieceCount: 300 },
     );
     await flushScheduled(t);
 
+    const isSubmitted = (n: { type: string }) =>
+      n.type === "admin_definition_submitted";
+    // Positive control: admin2 DID receive it, proving the fan-out fired.
     expect(
-      (await notificationsFor(t, admin)).filter(
-        (n) => n.type === "admin_definition_submitted",
-      ),
-    ).toEqual([]);
+      (await notificationsFor(t, admin2)).filter(isSubmitted),
+    ).toHaveLength(1);
+    // The acting admin specifically was excluded.
+    expect((await notificationsFor(t, admin)).filter(isSubmitted)).toEqual([]);
   });
 
   test("editing a pending proposal produces no admin notification", async () => {

--- a/packages/backend/convex/notifications/adapters/webPush.ts
+++ b/packages/backend/convex/notifications/adapters/webPush.ts
@@ -108,6 +108,13 @@ export const notificationUrl = (type: string, relatedId?: string): string => {
     case "proposal_approved":
     case "proposal_rejected":
       return relatedId ? `/puzzles/${relatedId}` : "/puzzles";
+    // Admin review deep links (first /admin destinations in this switch).
+    case "admin_proposal_filed":
+      return relatedId
+        ? `/admin/puzzles/proposals/${relatedId}`
+        : "/admin/puzzles/proposals";
+    case "admin_definition_submitted":
+      return "/admin/moderation";
     default:
       return "/notifications";
   }

--- a/packages/backend/convex/notifications/subscriber.ts
+++ b/packages/backend/convex/notifications/subscriber.ts
@@ -69,6 +69,20 @@ const loadPuzzle = (
     .withIndex("by_aggregate_id", (q) => q.eq("aggregateId", aggregateId))
     .unique();
 
+// Fan a review-request out to every admin except the acting member. Reads the users table's Clerk
+// role MIRROR via by_role — acceptable for informational notifications (authorization stays
+// JWT-only); a drifted mirror can only mis-route a notification, never grant access.
+const adminRecipients = async (
+  ctx: MutationCtx,
+  excludeUserId: string,
+): Promise<Doc<"users">[]> => {
+  const admins = await ctx.db
+    .query("users")
+    .withIndex("by_role", (q) => q.eq("role", "admin"))
+    .collect();
+  return admins.filter((admin) => (admin._id as string) !== excludeUserId);
+};
+
 // Map a recorded event to zero or more NotifyMember commands. Unmapped events are a no-op (most
 // events have no member-facing notification yet). The `payload` carries the event's data fields
 // (branded id strings + epoch-millis dates) as serialised by recordAndSchedule.
@@ -277,6 +291,36 @@ const translate = async (
           puzzle._id,
         ),
       ];
+    }
+    case "ChangeProposalFiled": {
+      const puzzle = await loadPuzzle(ctx, p.puzzleDefinitionId as string);
+      const admins = await adminRecipients(ctx, p.proposedBy as string);
+      return admins.map((admin) =>
+        cmd(
+          admin._id,
+          "admin_proposal_filed",
+          "Suggestion to Review",
+          puzzle
+            ? `A member suggested an edit to "${puzzle.title}"`
+            : "A member suggested an edit to a catalogue puzzle",
+          p.changeProposalId as string, // the review route's param — no lookup needed
+        ),
+      );
+    }
+    case "PuzzleDefinitionSubmitted": {
+      const admins = await adminRecipients(ctx, p.submittedBy as string);
+      const puzzle = await loadPuzzle(ctx, p.puzzleDefinitionId as string);
+      return admins.map((admin) =>
+        cmd(
+          admin._id,
+          "admin_definition_submitted",
+          "Submission to Moderate",
+          puzzle
+            ? `"${puzzle.title}" awaits moderation`
+            : "A new puzzle submission awaits moderation",
+          puzzle?._id ?? (p.puzzleDefinitionId as string),
+        ),
+      );
     }
 
     default:

--- a/packages/backend/convex/notifications/updateNotificationPreference.ts
+++ b/packages/backend/convex/notifications/updateNotificationPreference.ts
@@ -32,6 +32,8 @@ const notificationType = v.union(
   v.literal("exchange_disputed"),
   v.literal("proposal_approved"),
   v.literal("proposal_rejected"),
+  v.literal("admin_proposal_filed"),
+  v.literal("admin_definition_submitted"),
 );
 
 const channel = v.union(

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -58,8 +58,9 @@ export default defineSchema({
     preferredLanguage: v.optional(v.string()),
     isActive: v.boolean(),
     // Mirror of the Clerk publicMetadata.role claim, synced by the user webhook
-    // (users.updateOrCreateUser) and the one-shot backfillUserRoles action. DISPLAY-ONLY:
-    // authorization always reads the JWT via identity/isAdmin — never gate on this field.
+    // (users.updateOrCreateUser) and the one-shot backfillUserRoles action. DISPLAY +
+    // NOTIFICATION TARGETING only: authorization always reads the JWT via identity/isAdmin —
+    // never gate on this field.
     role: v.optional(v.string()),
     // Absent or false means the user's avatar image must never appear on public
     // marketing surfaces — initials only. Opt-in; defaults to NOT consented.
@@ -74,6 +75,7 @@ export default defineSchema({
     .index("by_clerk_id", ["clerkId"])
     .index("by_email", ["email"])
     .index("by_username", ["username"])
+    .index("by_role", ["role"])
     .searchIndex("by_searchable_name", {
       searchField: "searchableName",
     }),
@@ -722,6 +724,8 @@ export default defineSchema({
       v.literal("exchange_disputed"),
       v.literal("proposal_approved"),
       v.literal("proposal_rejected"),
+      v.literal("admin_proposal_filed"),
+      v.literal("admin_definition_submitted"),
     ),
     title: v.string(),
     message: v.string(),

--- a/packages/backend/convex/webPush.test.ts
+++ b/packages/backend/convex/webPush.test.ts
@@ -75,6 +75,24 @@ describe("notificationUrl", () => {
     expect(notificationUrl("totally_unknown")).toBe("/notifications");
   });
 
+  test("deep-links an admin proposal review by relatedId, else the proposals queue", () => {
+    expect(notificationUrl("admin_proposal_filed", "cp-1")).toBe(
+      "/admin/puzzles/proposals/cp-1",
+    );
+    expect(notificationUrl("admin_proposal_filed")).toBe(
+      "/admin/puzzles/proposals",
+    );
+  });
+
+  test("routes an admin submission review to the moderation console", () => {
+    expect(notificationUrl("admin_definition_submitted", "pz-1")).toBe(
+      "/admin/moderation",
+    );
+    expect(notificationUrl("admin_definition_submitted")).toBe(
+      "/admin/moderation",
+    );
+  });
+
   test("deep-links a proposal outcome to the targeted definition, else the catalog", () => {
     expect(notificationUrl("proposal_approved", "pz-1")).toBe("/puzzles/pz-1");
     expect(notificationUrl("proposal_rejected", "pz-1")).toBe("/puzzles/pz-1");

--- a/packages/domain/src/notifications/domain/notification-preference.spec.ts
+++ b/packages/domain/src/notifications/domain/notification-preference.spec.ts
@@ -91,10 +91,24 @@ describe("NotificationPreference with a sparse (rehydrated) toggle map", () => {
       updatedAt: NOW,
     });
 
-  it("treats an absent type as disabled without throwing (allows reads safely)", () => {
+  it("falls back to the type's default toggles when the type is absent from the stored map", () => {
     const pref = sparse();
-    expect(pref.allows("trade_request", "inApp")).toBe(false);
+    // A type added after this preference row was created has no stored entry; absent means
+    // "never asked", not "opted out" -- trade_request's default toggles apply (inApp on, off elsewhere).
+    expect(pref.allows("trade_request", "inApp")).toBe(true);
     expect(pref.allows("trade_request", "email")).toBe(false);
+  });
+
+  it("still honours an explicitly stored disablement even though it disagrees with the default", () => {
+    const pref = NotificationPreference.rehydrate({
+      id,
+      memberId: alice,
+      toggles: {
+        puzzle_approved: { inApp: false, email: false, push: false },
+      },
+      updatedAt: NOW,
+    });
+    expect(pref.allows("puzzle_approved", "inApp")).toBe(false);
   });
 
   it("seeds an all-off channel map when first toggling an absent type", () => {

--- a/packages/domain/src/notifications/domain/notification-preference.ts
+++ b/packages/domain/src/notifications/domain/notification-preference.ts
@@ -58,9 +58,15 @@ export class NotificationPreference {
     });
   }
 
-  // Does this member accept a notification of `type` on `channel`? Absent ⇒ false.
+  // Does this member accept a notification of `type` on `channel`? A type absent from the stored
+  // map falls back to that type's default toggles (see `defaultToggles`) -- absent means "never
+  // asked", not "opted out". An explicitly stored value, even a disabled one, always wins.
   allows(type: NotificationType, channel: Channel): boolean {
-    return this.state.toggles[type]?.[channel] === true;
+    const stored = this.state.toggles[type];
+    if (stored) {
+      return stored[channel] === true;
+    }
+    return defaultToggles()[type][channel] === true;
   }
 
   // Turn a (type, channel) delivery on. Records PreferenceChanged only when it actually changed.

--- a/packages/domain/src/notifications/domain/notification-type.spec.ts
+++ b/packages/domain/src/notifications/domain/notification-type.spec.ts
@@ -20,6 +20,8 @@ describe("NOTIFICATION_TYPES", () => {
       "exchange_disputed",
       "proposal_approved",
       "proposal_rejected",
+      "admin_proposal_filed",
+      "admin_definition_submitted",
     ]);
   });
 });

--- a/packages/domain/src/notifications/domain/notification-type.ts
+++ b/packages/domain/src/notifications/domain/notification-type.ts
@@ -21,7 +21,9 @@ export type NotificationType =
   | "exchange_proposed" // Exchange: ExchangeProposed (distinct generic exchange, not only "trade")
   | "exchange_disputed" // Exchange: DisputeRaised
   | "proposal_approved" // Catalog: ChangeProposalApproved (member's suggested edit applied)
-  | "proposal_rejected"; // Catalog: suggested edit declined
+  | "proposal_rejected" // Catalog: suggested edit declined
+  | "admin_proposal_filed" // Catalog: ChangeProposalFiled — admins are asked to review a suggested edit
+  | "admin_definition_submitted"; // Catalog: PuzzleDefinitionSubmitted — admins are asked to moderate a new submission
 
 // All notification types, for iteration (e.g. seeding default preferences). Kept in sync with the
 // union above by construction.
@@ -42,4 +44,6 @@ export const NOTIFICATION_TYPES: readonly NotificationType[] = [
   "exchange_disputed",
   "proposal_approved",
   "proposal_rejected",
+  "admin_proposal_filed",
+  "admin_definition_submitted",
 ];


### PR DESCRIPTION
## Summary

PR 5 of the change-proposals stack (**stacked on #45** — merge order #42 → #43 → #44 → #45 → this). Four owner-feedback items:

- **Admins are notified when there's something to review**: new `admin_proposal_filed` (deep-links to the proposal review screen) and `admin_definition_submitted` (deep-links to the moderation console) notification types, fanned out to all admins except the actor. This is the first role-targeted fan-out: it reads the Clerk role **mirror** via a new `users.by_role` index for recipient selection only — authorization stays JWT-based everywhere (schema comment updated to say exactly that). Admin-only types are hidden from non-admins' notification-preference matrix.
- **Root-cause preference fix**: `NotificationPreference.allows()` treated a type absent from a stored toggles map as opted-out, silently suppressing every newly added type for members with pre-existing preference rows (including long-standing admins — exactly who the new types are for). Absent now falls back to the type's default toggles; explicit stored choices still win. Retroactively fixes `proposal_approved`/`proposal_rejected` delivery for existing members too.
- **Admin puzzle detail flattened 9 → 4 bounded surfaces** (per UI-designer review): header and five stat tiles flattened/merged into the page flow + one figures panel; the three record lists (owners, proposals, audit) keep intentional cards. Layout-only.
- **Navigation fixes** (per UX-architect review): `/copies/:id` now highlights the right sidebar item — **My Puzzles** when you own the copy, **Browse** otherwise — via a new `activeNavKey` page-header-slot override (the sidebar previously matched pathname only, and nothing owns `/copies`). And collection → copy navigation now shows `My Library › Collections › [Collection] › [Copy]` via a typed `?from=collection:<id>` param: canonical crumbs by default (deep links unchanged), contextual only when the arriving link carries explicit context — collection membership is many-to-many, so no canonical parent exists. The visibility-gated collection read means a forged param can't leak a private collection's name.

## Test Plan
- [x] Backend: 595 passing (4 admin-notification tests incl. a second-admin positive control for actor exclusion; 2 webPush deep-link tests)
- [x] Domain: 1088 passing (preference-fallback TDD); Web: 133 passing (6 nav-context parser tests, TDD)
- [x] Full `nx run-many -t type-check / test / lint --skip-nx-cache` + `prettier --check .` green
- [ ] Preview: file a proposal as a member → admin bell shows "Suggestion to review" linking into the review screen; submit a definition → "Submission to moderate"; check the flattened admin puzzle page; open a copy you own (sidebar highlights My Puzzles) and via a collection (contextual breadcrumb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)