### PR TITLE
feat(web): image-diff lightbox for proposal review — side-by-side + wipe overlay

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2991,6 +2991,14 @@
       "comment": "Proposer's note",
       "current": "Current",
       "proposed": "Proposed",
+      "imageCompare": {
+        "title": "Compare images",
+        "description": "Left is the current image, right is the proposed replacement.",
+        "open": "Compare",
+        "sideBySide": "Side by side",
+        "overlay": "Overlay",
+        "handleAria": "Drag to compare current and proposed image"
+      },
       "wasWhenProposed": "Was {value} when proposed",
       "none": "—",
       "review": "Review",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2991,6 +2991,14 @@
       "comment": "Toelichting van de indiener",
       "current": "Huidig",
       "proposed": "Voorgesteld",
+      "imageCompare": {
+        "title": "Afbeeldingen vergelijken",
+        "description": "Links de huidige afbeelding, rechts de voorgestelde vervanging.",
+        "open": "Vergelijken",
+        "sideBySide": "Naast elkaar",
+        "overlay": "Overlappend",
+        "handleAria": "Sleep om huidige en voorgestelde afbeelding te vergelijken"
+      },
       "wasWhenProposed": "Was {value} bij indienen",
       "none": "—",
       "review": "Beoordelen",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2991,6 +2991,14 @@
       "comment": "Proposer's note",
       "current": "Current",
       "proposed": "Proposed",
+      "imageCompare": {
+        "title": "Compare images",
+        "description": "Left is the current image, right is the proposed replacement.",
+        "open": "Compare",
+        "sideBySide": "Side by side",
+        "overlay": "Overlay",
+        "handleAria": "Drag to compare current and proposed image"
+      },
       "wasWhenProposed": "Was {value} when proposed",
       "none": "—",
       "review": "Review",

--- a/apps/web/src/components/admin/proposals/image-compare.test.ts
+++ b/apps/web/src/components/admin/proposals/image-compare.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { wipePercentFromPointer } from "./image-compare";
+
+describe("wipePercentFromPointer", () => {
+  it("returns 50 at the center of the rect", () => {
+    expect(wipePercentFromPointer(150, 100, 100)).toBe(50);
+  });
+
+  it("clamps to 0 at and beyond the left edge", () => {
+    expect(wipePercentFromPointer(100, 100, 100)).toBe(0);
+    expect(wipePercentFromPointer(50, 100, 100)).toBe(0);
+  });
+
+  it("clamps to 100 at and beyond the right edge", () => {
+    expect(wipePercentFromPointer(200, 100, 100)).toBe(100);
+    expect(wipePercentFromPointer(250, 100, 100)).toBe(100);
+  });
+
+  it("returns a proportional value for interior points", () => {
+    expect(wipePercentFromPointer(125, 100, 100)).toBe(25);
+  });
+
+  it("returns 50 for a degenerate zero-width rect", () => {
+    expect(wipePercentFromPointer(120, 100, 0)).toBe(50);
+  });
+});

--- a/apps/web/src/components/admin/proposals/image-compare.ts
+++ b/apps/web/src/components/admin/proposals/image-compare.ts
@@ -1,0 +1,11 @@
+// Pure math for the image-diff overlay: map a pointer's clientX inside the compare
+// container to a wipe percentage, clamped to [0, 100].
+export const wipePercentFromPointer = (
+  clientX: number,
+  rectLeft: number,
+  rectWidth: number,
+): number => {
+  if (rectWidth <= 0) return 50;
+  const percent = ((clientX - rectLeft) / rectWidth) * 100;
+  return Math.min(100, Math.max(0, percent));
+};

--- a/apps/web/src/components/admin/proposals/image-diff-dialog.tsx
+++ b/apps/web/src/components/admin/proposals/image-diff-dialog.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { SegmentedPills } from "@/components/add-puzzle";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Slider } from "@/components/ui/slider";
+import { useState } from "react";
+import { useTranslations } from "use-intl";
+import { wipePercentFromPointer } from "./image-compare";
+
+type CompareMode = "side" | "overlay";
+
+export function ImageDiffDialog({
+  open,
+  onOpenChange,
+  currentUrl,
+  proposedUrl,
+  title,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentUrl: string | null | undefined;
+  proposedUrl: string | null | undefined;
+  title: string;
+}) {
+  const t = useTranslations("admin.proposals");
+  const [mode, setMode] = useState<CompareMode>("side");
+  const [percent, setPercent] = useState(50);
+  const [dragging, setDragging] = useState(false);
+  const bothExist = Boolean(currentUrl) && Boolean(proposedUrl);
+
+  const handlePointerMove = (
+    e: React.PointerEvent<HTMLDivElement>,
+    active: boolean,
+  ) => {
+    if (!active) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    setPercent(wipePercentFromPointer(e.clientX, rect.left, rect.width));
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setPercent(50);
+          setMode("side");
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t("imageCompare.title")}</DialogTitle>
+          <DialogDescription>{t("imageCompare.description")}</DialogDescription>
+        </DialogHeader>
+
+        {bothExist && (
+          <SegmentedPills
+            options={[
+              { value: "side", label: t("imageCompare.sideBySide") },
+              { value: "overlay", label: t("imageCompare.overlay") },
+            ]}
+            value={mode}
+            onChange={setMode}
+            ariaLabel={title}
+          />
+        )}
+
+        {mode === "side" || !bothExist ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <figure className="space-y-1">
+              <figcaption className="text-muted-foreground text-xs">
+                {t("current")}
+              </figcaption>
+              {currentUrl ? (
+                <img
+                  src={currentUrl}
+                  alt=""
+                  className="bg-muted max-h-[60vh] w-full rounded-lg border object-contain"
+                />
+              ) : (
+                <div className="bg-muted aspect-[4/3] w-full rounded-lg border" />
+              )}
+            </figure>
+            <figure className="space-y-1">
+              <figcaption className="text-muted-foreground text-xs">
+                {t("proposed")}
+              </figcaption>
+              {proposedUrl ? (
+                <img
+                  src={proposedUrl}
+                  alt=""
+                  className="bg-muted max-h-[60vh] w-full rounded-lg border object-contain"
+                />
+              ) : (
+                <div className="bg-muted aspect-[4/3] w-full rounded-lg border" />
+              )}
+            </figure>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div
+              className="bg-muted relative aspect-[4/3] w-full touch-none overflow-hidden rounded-lg border select-none"
+              onPointerDown={(e) => {
+                e.currentTarget.setPointerCapture(e.pointerId);
+                setDragging(true);
+                handlePointerMove(e, true);
+              }}
+              onPointerMove={(e) => handlePointerMove(e, dragging)}
+              onPointerUp={() => setDragging(false)}
+              onPointerCancel={() => setDragging(false)}
+            >
+              <img
+                src={currentUrl ?? undefined}
+                alt=""
+                className="absolute inset-0 h-full w-full object-contain"
+              />
+              <img
+                src={proposedUrl ?? undefined}
+                alt=""
+                className="absolute inset-0 h-full w-full object-contain"
+                style={{ clipPath: `inset(0 0 0 ${percent}%)` }}
+              />
+              <div
+                className="bg-primary absolute inset-y-0 w-0.5"
+                style={{ left: `${percent}%` }}
+              >
+                <div className="bg-primary absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white" />
+              </div>
+              <span className="bg-background/80 absolute top-2 left-2 rounded px-1.5 py-0.5 text-xs">
+                {t("current")}
+              </span>
+              <span className="bg-background/80 absolute top-2 right-2 rounded px-1.5 py-0.5 text-xs">
+                {t("proposed")}
+              </span>
+            </div>
+            <Slider
+              min={0}
+              max={100}
+              step={1}
+              value={[percent]}
+              onValueChange={([v]) => setPercent(v)}
+              aria-label={t("imageCompare.handleAria")}
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/proposals/image-diff-dialog.tsx
+++ b/apps/web/src/components/admin/proposals/image-diff-dialog.tsx
@@ -68,7 +68,7 @@ export function ImageDiffDialog({
             ]}
             value={mode}
             onChange={setMode}
-            ariaLabel={title}
+            ariaLabel={t("imageCompare.title")}
           />
         )}
 

--- a/apps/web/src/routes/_dashboard/admin/puzzles/proposals/$proposalId.tsx
+++ b/apps/web/src/routes/_dashboard/admin/puzzles/proposals/$proposalId.tsx
@@ -4,6 +4,7 @@ import {
   fieldDiffRows,
   type FieldDiffRow,
 } from "@/components/admin/proposals/field-diff";
+import { ImageDiffDialog } from "@/components/admin/proposals/image-diff-dialog";
 import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { EmptyState } from "@/components/library/empty-state";
 import {
@@ -119,6 +120,7 @@ function ProposalReview({
   const [confirmingApprove, setConfirmingApprove] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
   const [reason, setReason] = useState("");
+  const [compareOpen, setCompareOpen] = useState(false);
 
   const approve = useMutation({
     mutationFn: useConvexMutation(gateway.catalog.approveChangeProposal),
@@ -277,6 +279,14 @@ function ProposalReview({
                     <div className="bg-muted size-24 rounded-lg border" />
                   )}
                 </figure>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCompareOpen(true)}
+                >
+                  {t("imageCompare.open")}
+                </Button>
               </div>
             </div>
           ) : (
@@ -402,6 +412,14 @@ function ProposalReview({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ImageDiffDialog
+        open={compareOpen}
+        onOpenChange={setCompareOpen}
+        currentUrl={proposal.definitionImage}
+        proposedUrl={proposal.proposedImageUrl}
+        title={proposal.definitionTitle ?? ""}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PR 7 of the change-proposals stack (**stacked on #46** — merge order #42 → #43 → #44 → #45 → #46 → this). When a change proposal replaces the definition image, the review screen's thumbnails now open into a comparison lightbox via a "Compare" button:

- **Side by side** (default): both images large (`max-h-[60vh]`, object-contain), captioned current/proposed; gracefully renders a placeholder when one side is missing (image added or cleared).
- **Overlay wipe**: both images stacked in one frame with a draggable divider — **left of the divider shows the current image, right shows the proposed one** (clip-path on the proposed layer). Drag directly on the image (pointer capture, touch-safe) or use the accessible slider control beneath; mode and position reset on close. Overlay is only offered when both images exist.
- Pure wipe math (`wipePercentFromPointer`) unit-tested (TDD, 5 cases). Works on decided proposals' read-only view too. EN/NL i18n.

Reviewer verified the wipe orientation end-to-end (the classic inversion bug class) — correct. Known accepted tradeoff: differing aspect ratios letterbox independently within the shared frame.

## Test Plan
- [x] Web suite: 138 passing (5 new wipe-math tests)
- [x] tsc clean; lint delta is only the expected `<img>` warnings; prettier clean
- [ ] Preview: file a proposal with a replacement image → Review → Compare → toggle side-by-side/overlay, drag the divider (mouse + touch), keyboard-operate the slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)