### PR TITLE
feat(web): Find-people directory tab (friend discovery, phase 4)

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1438,7 +1438,26 @@
     "swapsLabel": "swaps",
     "activity": "Activity",
     "emptyTitle": "No members in your network yet",
-    "emptySub": "Follow fellow puzzlers to build your network."
+    "emptySub": "Follow fellow puzzlers to build your network.",
+    "tabs": {
+      "network": "Your network",
+      "find": "Find people"
+    },
+    "find": {
+      "searchPlaceholder": "Search by name or @username",
+      "minChars": "Type at least 2 characters to search for members.",
+      "resultsLabel": "Search results",
+      "recentlyJoined": "Recently joined",
+      "recentlyJoinedEmptyTitle": "No new members to show yet",
+      "recentlyJoinedEmptySub": "Know a fellow puzzler? Show them your QR code.",
+      "noResultsTitle": "Can't find them?",
+      "noResultsSub": "Ask for their profile link — or scan their QR."
+    },
+    "discoverableNotice": {
+      "body": "Your profile is discoverable — other members can find you by name in Find people.",
+      "review": "Review visibility",
+      "dismiss": "Dismiss"
+    }
   },
   "follow": {
     "follow": "Follow",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1454,7 +1454,7 @@
       "noResultsSub": "Ask for their profile link — or scan their QR."
     },
     "discoverableNotice": {
-      "body": "Your profile is discoverable — other members can find you by name in Find people.",
+      "body": "JigSwap now has a Find people directory. Members with a public profile can be found by name — check or change who can find you.",
       "review": "Review visibility",
       "dismiss": "Dismiss"
     }

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -281,9 +281,18 @@
     "createNewAccount": "Create a new account"
   },
   "activity": {
-    "completion": "A member completed a puzzle",
-    "acquisition": "A member added a puzzle",
-    "exchange": "A member settled an exchange",
+    "completion": {
+      "you": "You finished a puzzle",
+      "other": "<strong>{name}</strong> finished a puzzle"
+    },
+    "acquisition": {
+      "you": "You added a puzzle to your shelf",
+      "other": "<strong>{name}</strong> added a puzzle to their shelf"
+    },
+    "exchange": {
+      "you": "You completed a swap",
+      "other": "<strong>{name}</strong> completed a swap"
+    },
     "empty": "No recent activity yet",
     "emptyHint": "Follow other members to see what they are up to."
   },
@@ -1441,7 +1450,8 @@
     "emptySub": "Follow fellow puzzlers to build your network.",
     "tabs": {
       "network": "Your network",
-      "find": "Find people"
+      "find": "Find people",
+      "activity": "Activity"
     },
     "find": {
       "searchPlaceholder": "Search by name or @username",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1438,7 +1438,26 @@
     "swapsLabel": "ruilen",
     "activity": "Activiteit",
     "emptyTitle": "Nog geen leden in je netwerk",
-    "emptySub": "Volg medepuzzelaars om je netwerk op te bouwen."
+    "emptySub": "Volg medepuzzelaars om je netwerk op te bouwen.",
+    "tabs": {
+      "network": "Jouw netwerk",
+      "find": "Mensen vinden"
+    },
+    "find": {
+      "searchPlaceholder": "Zoek op naam of @gebruikersnaam",
+      "minChars": "Typ minstens 2 tekens om leden te zoeken.",
+      "resultsLabel": "Zoekresultaten",
+      "recentlyJoined": "Recent lid geworden",
+      "recentlyJoinedEmptyTitle": "Nog geen nieuwe leden om te tonen",
+      "recentlyJoinedEmptySub": "Ken je een medepuzzelaar? Laat je QR-code zien.",
+      "noResultsTitle": "Kun je ze niet vinden?",
+      "noResultsSub": "Vraag om hun profiellink — of scan hun QR-code."
+    },
+    "discoverableNotice": {
+      "body": "Je profiel is vindbaar — andere leden kunnen je op naam vinden via Mensen vinden.",
+      "review": "Zichtbaarheid bekijken",
+      "dismiss": "Sluiten"
+    }
   },
   "follow": {
     "follow": "Volgen",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1454,7 +1454,7 @@
       "noResultsSub": "Vraag om hun profiellink — of scan hun QR-code."
     },
     "discoverableNotice": {
-      "body": "Je profiel is vindbaar — andere leden kunnen je op naam vinden via Mensen vinden.",
+      "body": "JigSwap heeft nu een Mensen vinden-overzicht. Leden met een openbaar profiel zijn op naam te vinden — bekijk of wijzig wie jou kan vinden.",
       "review": "Zichtbaarheid bekijken",
       "dismiss": "Sluiten"
     }

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -281,9 +281,18 @@
     "createNewAccount": "Maak een nieuw account"
   },
   "activity": {
-    "completion": "Een lid heeft een puzzel voltooid",
-    "acquisition": "Een lid heeft een puzzel toegevoegd",
-    "exchange": "Een lid heeft een ruil afgerond",
+    "completion": {
+      "you": "Je hebt een puzzel afgemaakt",
+      "other": "<strong>{name}</strong> heeft een puzzel afgemaakt"
+    },
+    "acquisition": {
+      "you": "Je hebt een puzzel op je plank gezet",
+      "other": "<strong>{name}</strong> heeft een puzzel op de plank gezet"
+    },
+    "exchange": {
+      "you": "Je hebt een ruil afgerond",
+      "other": "<strong>{name}</strong> heeft een ruil afgerond"
+    },
     "empty": "Nog geen recente activiteit",
     "emptyHint": "Volg andere leden om te zien wat zij doen."
   },
@@ -1441,7 +1450,8 @@
     "emptySub": "Volg medepuzzelaars om je netwerk op te bouwen.",
     "tabs": {
       "network": "Jouw netwerk",
-      "find": "Mensen vinden"
+      "find": "Mensen vinden",
+      "activity": "Activiteit"
     },
     "find": {
       "searchPlaceholder": "Zoek op naam of @gebruikersnaam",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1438,7 +1438,26 @@
     "swapsLabel": "swaps",
     "activity": "Activity",
     "emptyTitle": "No members in your network yet",
-    "emptySub": "Follow fellow puzzlers to build your network."
+    "emptySub": "Follow fellow puzzlers to build your network.",
+    "tabs": {
+      "network": "Your network",
+      "find": "Find people"
+    },
+    "find": {
+      "searchPlaceholder": "Search by name or @username",
+      "minChars": "Type at least 2 characters to search for members.",
+      "resultsLabel": "Search results",
+      "recentlyJoined": "Recently joined",
+      "recentlyJoinedEmptyTitle": "No new members to show yet",
+      "recentlyJoinedEmptySub": "Know a fellow puzzler? Show them your QR code.",
+      "noResultsTitle": "Can't find them?",
+      "noResultsSub": "Ask for their profile link — or scan their QR."
+    },
+    "discoverableNotice": {
+      "body": "Your profile is discoverable — other members can find you by name in Find people.",
+      "review": "Review visibility",
+      "dismiss": "Dismiss"
+    }
   },
   "follow": {
     "follow": "Follow",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1454,7 +1454,7 @@
       "noResultsSub": "Ask for their profile link — or scan their QR."
     },
     "discoverableNotice": {
-      "body": "Your profile is discoverable — other members can find you by name in Find people.",
+      "body": "JigSwap now has a Find people directory. Members with a public profile can be found by name — check or change who can find you.",
       "review": "Review visibility",
       "dismiss": "Dismiss"
     }

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -281,9 +281,18 @@
     "createNewAccount": "Create a new account"
   },
   "activity": {
-    "completion": "A member completed a puzzle",
-    "acquisition": "A member added a puzzle",
-    "exchange": "A member settled an exchange",
+    "completion": {
+      "you": "You finished a puzzle",
+      "other": "<strong>{name}</strong> finished a puzzle"
+    },
+    "acquisition": {
+      "you": "You added a puzzle to your shelf",
+      "other": "<strong>{name}</strong> added a puzzle to their shelf"
+    },
+    "exchange": {
+      "you": "You completed a swap",
+      "other": "<strong>{name}</strong> completed a swap"
+    },
     "empty": "No recent activity yet",
     "emptyHint": "Follow other members to see what they are up to."
   },
@@ -1441,7 +1450,8 @@
     "emptySub": "Follow fellow puzzlers to build your network.",
     "tabs": {
       "network": "Your network",
-      "find": "Find people"
+      "find": "Find people",
+      "activity": "Activity"
     },
     "find": {
       "searchPlaceholder": "Search by name or @username",

--- a/apps/web/src/components/social/activity-feed.tsx
+++ b/apps/web/src/components/social/activity-feed.tsx
@@ -27,6 +27,7 @@ export function ActivityFeed() {
   const t = useTranslations("activity");
   const format = useFormatter();
   const { data: feed } = useQuery(convexQuery(gateway.social.activityFeed, {}));
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
 
   if (feed === undefined) {
     return (
@@ -47,6 +48,7 @@ export function ActivityFeed() {
       {feed.map((entry, index) => {
         const meta = META[entry.kind as ActivityKind];
         const Icon = meta.icon;
+        const isYou = me != null && entry.memberId === me._id;
         return (
           <div
             key={`${entry.ref}-${entry.memberId}-${entry.occurredAt}`}
@@ -60,7 +62,12 @@ export function ActivityFeed() {
             </span>
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">
-                {t(entry.kind as ActivityKind)}
+                {isYou
+                  ? t(`${entry.kind}.you`)
+                  : t.rich(`${entry.kind}.other`, {
+                      name: entry.actorName,
+                      strong: (chunks) => <strong>{chunks}</strong>,
+                    })}
               </p>
               <p className="text-muted-foreground text-xs">
                 {format.relativeTime(new Date(entry.occurredAt))}

--- a/apps/web/src/components/social/find-people.tsx
+++ b/apps/web/src/components/social/find-people.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+// The Find-people tab: search-first member discovery. A debounced search box
+// (2-character minimum, mirrored server-side in identity/searchUsers) over the
+// privacy-gated member search; while idle, a small "Recently joined" seed of
+// public profiles. Both empty states route to the QR fallback — the answer to
+// "can't find them" is always "ask for their link or QR". Discovery tiles hide
+// location (stats build trust with strangers; street-level context doesn't).
+
+import { EmptyState } from "@/components/community/primitives";
+import { SectionHead } from "@/components/dashboard-home/section-head";
+import {
+  MemberTile,
+  MemberTileSkeleton,
+} from "@/components/social/member-tile";
+import { QrDialog } from "@/components/social/qr-dialog";
+import { Input } from "@/components/ui/input";
+import { gateway, Id } from "@/gateway";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { Search, UserPlus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslations } from "use-intl";
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 300;
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export function FindPeople() {
+  const t = useTranslations("people.find");
+  const [term, setTerm] = useState("");
+  const debounced = useDebouncedValue(term.trim(), DEBOUNCE_MS);
+  const searching = debounced.length >= MIN_QUERY_LENGTH;
+
+  const { data: results } = useQuery({
+    ...convexQuery(gateway.identity.search, { searchTerm: debounced }),
+    enabled: searching,
+  });
+  const { data: recent } = useQuery(
+    convexQuery(gateway.identity.recentPublicMembers, {}),
+  );
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
+
+  // Phase 3's self-contained trigger-button + fullscreen dialog; reused at all
+  // three "can't find them" surfaces below.
+  const qrButton = me ? (
+    <QrDialog
+      memberId={me._id}
+      displayName={me.name}
+      username={me.username}
+      avatarUrl={me.avatar}
+    />
+  ) : null;
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+          <Input
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder={t("searchPlaceholder")}
+            className="pl-9"
+            aria-label={t("searchPlaceholder")}
+          />
+        </div>
+        {qrButton}
+      </div>
+
+      {term.trim().length > 0 && !searching ? (
+        <p className="text-muted-foreground text-sm">{t("minChars")}</p>
+      ) : searching ? (
+        results === undefined ? (
+          <div className="flex flex-col gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <MemberTileSkeleton key={i} />
+            ))}
+          </div>
+        ) : results.length === 0 ? (
+          <EmptyState
+            title={t("noResultsTitle")}
+            sub={t("noResultsSub")}
+            action={qrButton}
+          />
+        ) : (
+          <div
+            className="flex flex-col gap-4"
+            role="list"
+            aria-label={t("resultsLabel")}
+          >
+            {results.map((member) => (
+              <MemberTile
+                key={member._id}
+                memberId={member._id as Id<"users">}
+                followsYou={false}
+                hideLocation
+              />
+            ))}
+          </div>
+        )
+      ) : (
+        <section>
+          <SectionHead title={t("recentlyJoined")} icon={UserPlus} />
+          {recent === undefined ? (
+            <div className="flex flex-col gap-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <MemberTileSkeleton key={i} />
+              ))}
+            </div>
+          ) : recent.length === 0 ? (
+            <EmptyState
+              title={t("recentlyJoinedEmptyTitle")}
+              sub={t("recentlyJoinedEmptySub")}
+              action={qrButton}
+            />
+          ) : (
+            <div className="flex flex-col gap-4">
+              {recent.map((member) => (
+                <MemberTile
+                  key={member._id}
+                  memberId={member._id as Id<"users">}
+                  followsYou={false}
+                  hideLocation
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/social/find-people.tsx
+++ b/apps/web/src/components/social/find-people.tsx
@@ -61,8 +61,8 @@ export function FindPeople() {
   ) : null;
 
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
-      <div className="flex items-center gap-2">
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex max-w-xl items-center gap-2">
         <div className="relative flex-1">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
           <Input
@@ -80,7 +80,7 @@ export function FindPeople() {
         <p className="text-muted-foreground text-sm">{t("minChars")}</p>
       ) : searching ? (
         results === undefined ? (
-          <div className="flex flex-col gap-4">
+          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
             {Array.from({ length: 3 }).map((_, i) => (
               <MemberTileSkeleton key={i} />
             ))}
@@ -93,7 +93,7 @@ export function FindPeople() {
           />
         ) : (
           <div
-            className="flex flex-col gap-4"
+            className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]"
             role="list"
             aria-label={t("resultsLabel")}
           >
@@ -111,7 +111,7 @@ export function FindPeople() {
         <section>
           <SectionHead title={t("recentlyJoined")} icon={UserPlus} />
           {recent === undefined ? (
-            <div className="flex flex-col gap-4">
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
               {Array.from({ length: 3 }).map((_, i) => (
                 <MemberTileSkeleton key={i} />
               ))}
@@ -123,7 +123,7 @@ export function FindPeople() {
               action={qrButton}
             />
           ) : (
-            <div className="flex flex-col gap-4">
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
               {recent.map((member) => (
                 <MemberTile
                   key={member._id}

--- a/apps/web/src/components/social/invite-redeemer.tsx
+++ b/apps/web/src/components/social/invite-redeemer.tsx
@@ -67,8 +67,11 @@ export function InviteRedeemer() {
       toast(t("didSomeoneInviteTitle"), {
         description: t("didSomeoneInviteBody"),
         action: (
-          // Phase 4 will deep-link this to /people?tab=find; plain /people for now.
-          <Link to="/people" className="text-sm font-medium underline">
+          <Link
+            to="/people"
+            search={{ tab: "find" }}
+            className="text-sm font-medium underline"
+          >
             {t("findThem")}
           </Link>
         ),

--- a/apps/web/src/components/social/member-tile.tsx
+++ b/apps/web/src/components/social/member-tile.tsx
@@ -35,9 +35,13 @@ export function MemberTileSkeleton() {
 export function MemberTile({
   memberId,
   followsYou,
+  hideLocation = false,
 }: {
   memberId: Id<"users">;
   followsYou: boolean;
+  // Discovery surfaces (Find people) omit the location line: stats build trust with
+  // strangers, street-level context doesn't. Defaults off so network tiles are unchanged.
+  hideLocation?: boolean;
 }) {
   const t = useTranslations("people");
   const { data: member } = useQuery(
@@ -76,7 +80,7 @@ export function MemberTile({
             </Badge>
           )}
         </div>
-        {member.location && (
+        {!hideLocation && member.location && (
           <div className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
             <MapPin className="h-3 w-3 shrink-0" />
             <span className="truncate">{member.location}</span>

--- a/apps/web/src/components/ui/underline-tabs.tsx
+++ b/apps/web/src/components/ui/underline-tabs.tsx
@@ -1,0 +1,21 @@
+// Shared underline-style restyle of the boxed shadcn Tabs primitive: a transparent
+// `TabsList` with a bottom border, and the active `TabsTrigger` gets a primary
+// underline instead of the default boxed/shadowed look. `TabCount` is the small
+// pill that follows a trigger's active state, for tabs that carry a live count.
+// Used by the moderation console and the People page so both underline tab bars
+// stay visually identical — extracted here rather than duplicated.
+
+export const UNDERLINE_TABS_LIST_CLASS =
+  "h-auto w-full justify-start gap-1 rounded-none border-b bg-transparent p-0";
+
+export const TAB_TRIGGER_CLASS =
+  "group -mb-px flex-none gap-2 rounded-none border-0 border-b-2 border-transparent px-4 py-2.5 font-semibold text-muted-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-primary dark:data-[state=active]:bg-transparent";
+
+export function TabCount({ count }: { count: number | undefined }) {
+  if (count === undefined) return null;
+  return (
+    <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-xs font-bold text-muted-foreground group-data-[state=active]:bg-primary group-data-[state=active]:text-primary-foreground">
+      {count}
+    </span>
+  );
+}

--- a/apps/web/src/routes/_dashboard/admin/moderation.tsx
+++ b/apps/web/src/routes/_dashboard/admin/moderation.tsx
@@ -23,6 +23,11 @@ import {
 import { QueueEmpty } from "@/components/admin/queue-empty";
 import { PageLoading } from "@/components/ui/loading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  TAB_TRIGGER_CLASS,
+  TabCount,
+  UNDERLINE_TABS_LIST_CLASS,
+} from "@/components/ui/underline-tabs";
 import { gateway } from "@/gateway";
 import { cn } from "@/lib/utils";
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
@@ -38,21 +43,6 @@ export const Route = createFileRoute("/_dashboard/admin/moderation")({
   }),
   component: ModerationPage,
 });
-
-// Underline-style restyle of the boxed shadcn tabs primitive (transparent list
-// with a bottom border; the active trigger gets a primary underline).
-const TAB_TRIGGER_CLASS =
-  "group -mb-px flex-none gap-2 rounded-none border-0 border-b-2 border-transparent px-4 py-2.5 font-semibold text-muted-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:border-primary dark:data-[state=active]:bg-transparent";
-
-// Count pill on the queue tabs; follows the trigger's active state.
-function TabCount({ count }: { count: number | undefined }) {
-  if (count === undefined) return null;
-  return (
-    <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-xs font-bold text-muted-foreground group-data-[state=active]:bg-primary group-data-[state=active]:text-primary-foreground">
-      {count}
-    </span>
-  );
-}
 
 // The moderation console: KPI week row + three underline tabs. Submissions is
 // the live queue (list+detail split with approve / edit&approve / reject),
@@ -199,7 +189,7 @@ function ModerationPage() {
       <KpiRow />
 
       <Tabs defaultValue="submissions" className="gap-4">
-        <TabsList className="h-auto w-full justify-start gap-1 rounded-none border-b bg-transparent p-0">
+        <TabsList className={UNDERLINE_TABS_LIST_CLASS}>
           <TabsTrigger value="submissions" className={TAB_TRIGGER_CLASS}>
             <Inbox aria-hidden />
             {t("tabs.submissions")}

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -12,26 +12,34 @@ import {
   MemberTile,
   MemberTileSkeleton,
 } from "@/components/social/member-tile";
-import { ProfileEditDialog } from "@/components/social/profile-edit-dialog";
 import { QrDialog } from "@/components/social/qr-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  TAB_TRIGGER_CLASS,
+  TabCount,
+  UNDERLINE_TABS_LIST_CLASS,
+} from "@/components/ui/underline-tabs";
 import { gateway, Id } from "@/gateway";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
-import { Bell, X } from "lucide-react";
+import { Bell, Search, Users, X } from "lucide-react";
 import { useState, useSyncExternalStore } from "react";
 import { useTranslations } from "use-intl";
 
-type PeopleTab = "network" | "find";
+type PeopleTab = "network" | "find" | "activity";
 
 export const Route = createFileRoute("/_dashboard/people")({
   // URL-addressable tabs: /people?tab=find deep-links straight into discovery
   // (used by notifications and QR empty states). `tab` is optional so the
   // default (network) keeps a clean /people URL and existing bare `to="/people"`
   // links stay valid — the UI falls back to "network" when it's absent.
-  validateSearch: (search: Record<string, unknown>): { tab?: "find" } => ({
-    tab: search.tab === "find" ? "find" : undefined,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: "find" | "activity" } => ({
+    tab:
+      search.tab === "find" || search.tab === "activity"
+        ? search.tab
+        : undefined,
   }),
   head: ({ match }) => ({
     meta: [{ title: pageTitle(match.context, "people") }],
@@ -100,10 +108,10 @@ function DiscoverabilityNotice() {
 }
 
 // Your-network tab body: the pending follow-request strip above the deduped
-// follower/following grid, then the activity feed — the pre-tabs page content.
-// The network is computed by the parent (which also publishes the count into
-// the page header) and passed down, so the count and grid stay in sync without
-// duplicating the follow queries.
+// follower/following grid — the pre-tabs page content. The network is computed
+// by the parent (which also publishes the count into the page header) and
+// passed down, so the count and grid stay in sync without duplicating the
+// follow queries.
 function NetworkTab({
   members,
   loading,
@@ -114,39 +122,43 @@ function NetworkTab({
   const t = useTranslations("people");
 
   return (
-    <div className="flex flex-col gap-10">
-      <section className="flex flex-col gap-4">
-        <FollowRequestsStrip />
-        {loading ? (
-          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <MemberTileSkeleton key={i} />
-            ))}
-          </div>
-        ) : members.length === 0 ? (
-          <EmptyState title={t("emptyTitle")} sub={t("emptySub")} />
-        ) : (
-          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
-            {members.map(([memberId, { followsYou }]) => (
-              <MemberTile
-                key={memberId}
-                memberId={memberId as Id<"users">}
-                followsYou={followsYou}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+    <section className="flex flex-col gap-4">
+      <FollowRequestsStrip />
+      {loading ? (
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <MemberTileSkeleton key={i} />
+          ))}
+        </div>
+      ) : members.length === 0 ? (
+        <EmptyState title={t("emptyTitle")} sub={t("emptySub")} />
+      ) : (
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
+          {members.map(([memberId, { followsYou }]) => (
+            <MemberTile
+              key={memberId}
+              memberId={memberId as Id<"users">}
+              followsYou={followsYou}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
 
-      <section>
-        <SectionHead
-          title={t("activity")}
-          icon={Bell}
-          action={<ProfileEditDialog />}
-        />
-        <ActivityFeed />
-      </section>
-    </div>
+// Activity tab body: its own top-level tab (promoted out of NetworkTab so the
+// activity feed isn't buried under the network grid, and so the misplaced
+// profile-edit action that used to sit on this SectionHead is gone for good —
+// profile editing lives on /profile).
+function ActivityTab() {
+  const t = useTranslations("people");
+
+  return (
+    <section>
+      <SectionHead title={t("activity")} icon={Bell} />
+      <ActivityFeed />
+    </section>
   );
 }
 
@@ -216,7 +228,9 @@ function PeoplePage() {
 
   const handleTabChange = (value: string) => {
     void navigate({
-      search: { tab: value === "find" ? "find" : undefined },
+      search: {
+        tab: value === "find" || value === "activity" ? value : undefined,
+      },
       replace: true,
     });
   };
@@ -226,16 +240,20 @@ function PeoplePage() {
       <DiscoverabilityNotice />
 
       <Tabs value={activeTab} onValueChange={handleTabChange}>
-        <TabsList>
-          <TabsTrigger value="network">
+        <TabsList className={UNDERLINE_TABS_LIST_CLASS}>
+          <TabsTrigger value="network" className={TAB_TRIGGER_CLASS}>
+            <Users aria-hidden />
             {t("tabs.network")}
-            {pendingCount > 0 && (
-              <Badge variant="secondary" className="ml-1">
-                {pendingCount}
-              </Badge>
-            )}
+            <TabCount count={pendingCount > 0 ? pendingCount : undefined} />
           </TabsTrigger>
-          <TabsTrigger value="find">{t("tabs.find")}</TabsTrigger>
+          <TabsTrigger value="find" className={TAB_TRIGGER_CLASS}>
+            <Search aria-hidden />
+            {t("tabs.find")}
+          </TabsTrigger>
+          <TabsTrigger value="activity" className={TAB_TRIGGER_CLASS}>
+            <Bell aria-hidden />
+            {t("tabs.activity")}
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="network" className="mt-4">
@@ -243,6 +261,9 @@ function PeoplePage() {
         </TabsContent>
         <TabsContent value="find" className="mt-4">
           <FindPeople />
+        </TabsContent>
+        <TabsContent value="activity" className="mt-4">
+          <ActivityTab />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -20,7 +20,7 @@ import { gateway, Id } from "@/gateway";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { Bell, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useTranslations } from "use-intl";
 
 type PeopleTab = "network" | "find";
@@ -44,28 +44,32 @@ export const Route = createFileRoute("/_dashboard/people")({
 // Info-toned (not a warning): tells members the directory can now surface
 // their (public-by-default) profile, with an inline path to the existing
 // visibility setting. Dismissal persists via safeStorage (bare localStorage
-// throws in private mode); lazy-initialised so it never reads storage during
-// SSR render.
+// throws in private mode).
 // ---------------------------------------------------------------------------
 const NOTICE_KEY = "jigswap.notice.discoverable";
+
+// Read the dismissal flag through useSyncExternalStore rather than an effect:
+// the server snapshot is "dismissed" (banner hidden), so SSR and the hydration
+// pass agree (no mismatch, no flash for a returning user), and the client
+// snapshot reads the real flag right after hydration. Reading storage in an
+// effect + setState would trip react-hooks/set-state-in-effect and re-render.
+const noopSubscribe = () => () => {};
 
 function DiscoverabilityNotice() {
   const t = useTranslations("people.discoverableNotice");
 
-  // Read the dismissal flag after mount, not during render: on the server
-  // safeStorage returns null (no window), so rendering the banner in the
-  // initial HTML and then reconciling on the client would flash for a user who
-  // already dismissed it. Start hidden; reveal only if still undismissed.
-  const [visible, setVisible] = useState(false);
-  useEffect(() => {
-    if (safeStorage.getItem("local", NOTICE_KEY) !== "1") setVisible(true);
-  }, []);
+  const dismissedInStorage = useSyncExternalStore(
+    noopSubscribe,
+    () => safeStorage.getItem("local", NOTICE_KEY) === "1",
+    () => true,
+  );
+  const [dismissedNow, setDismissedNow] = useState(false);
 
-  if (!visible) return null;
+  if (dismissedInStorage || dismissedNow) return null;
 
   const handleDismiss = () => {
     safeStorage.setItem("local", NOTICE_KEY, "1");
-    setVisible(false);
+    setDismissedNow(true);
   };
 
   return (

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -20,7 +20,7 @@ import { gateway, Id } from "@/gateway";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { Bell, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "use-intl";
 
 type PeopleTab = "network" | "find";
@@ -52,15 +52,20 @@ const NOTICE_KEY = "jigswap.notice.discoverable";
 function DiscoverabilityNotice() {
   const t = useTranslations("people.discoverableNotice");
 
-  const [dismissed, setDismissed] = useState<boolean>(
-    () => safeStorage.getItem("local", NOTICE_KEY) === "1",
-  );
+  // Read the dismissal flag after mount, not during render: on the server
+  // safeStorage returns null (no window), so rendering the banner in the
+  // initial HTML and then reconciling on the client would flash for a user who
+  // already dismissed it. Start hidden; reveal only if still undismissed.
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (safeStorage.getItem("local", NOTICE_KEY) !== "1") setVisible(true);
+  }, []);
 
-  if (dismissed) return null;
+  if (!visible) return null;
 
   const handleDismiss = () => {
     safeStorage.setItem("local", NOTICE_KEY, "1");
-    setDismissed(true);
+    setVisible(false);
   };
 
   return (

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -1,10 +1,12 @@
 import { pageTitle } from "@/lib/page-title";
-import { createFileRoute } from "@tanstack/react-router";
+import { safeStorage } from "@/lib/safe-storage";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 
 import { EmptyState } from "@/components/community/primitives";
 import { SectionHead } from "@/components/dashboard-home/section-head";
 import { usePageHeaderActions } from "@/components/dashboard-layout/page-header-slot";
 import { ActivityFeed } from "@/components/social/activity-feed";
+import { FindPeople } from "@/components/social/find-people";
 import { FollowRequestsStrip } from "@/components/social/follow-requests-strip";
 import {
   MemberTile,
@@ -12,82 +14,100 @@ import {
 } from "@/components/social/member-tile";
 import { ProfileEditDialog } from "@/components/social/profile-edit-dialog";
 import { QrDialog } from "@/components/social/qr-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { gateway, Id } from "@/gateway";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
-import { Bell } from "lucide-react";
+import { Bell, X } from "lucide-react";
+import { useState } from "react";
 import { useTranslations } from "use-intl";
 
+type PeopleTab = "network" | "find";
+
 export const Route = createFileRoute("/_dashboard/people")({
+  // URL-addressable tabs: /people?tab=find deep-links straight into discovery
+  // (used by notifications and QR empty states). `tab` is optional so the
+  // default (network) keeps a clean /people URL and existing bare `to="/people"`
+  // links stay valid — the UI falls back to "network" when it's absent.
+  validateSearch: (search: Record<string, unknown>): { tab?: "find" } => ({
+    tab: search.tab === "find" ? "find" : undefined,
+  }),
   head: ({ match }) => ({
     meta: [{ title: pageTitle(match.context, "people") }],
   }),
   component: PeoplePage,
 });
 
-// People (the Community social hub): the members in your network — everyone
-// you follow plus everyone following you, deduplicated — as a grid of member
-// tiles, then the full-width activity feed of you + the people you follow,
-// with a profile-edit dialog trigger beside the activity heading. The page
-// title renders in the shell head.
-function PeoplePage() {
+// ---------------------------------------------------------------------------
+// One-time discoverability notice
+// Info-toned (not a warning): tells members the directory can now surface
+// their (public-by-default) profile, with an inline path to the existing
+// visibility setting. Dismissal persists via safeStorage (bare localStorage
+// throws in private mode); lazy-initialised so it never reads storage during
+// SSR render.
+// ---------------------------------------------------------------------------
+const NOTICE_KEY = "jigswap.notice.discoverable";
+
+function DiscoverabilityNotice() {
+  const t = useTranslations("people.discoverableNotice");
+
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => safeStorage.getItem("local", NOTICE_KEY) === "1",
+  );
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    safeStorage.setItem("local", NOTICE_KEY, "1");
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="border-border bg-muted/60 text-muted-foreground flex items-start gap-3 rounded-lg border px-4 py-3 text-sm"
+    >
+      <span className="flex-1">
+        {t("body")}{" "}
+        <Link
+          to="/profile"
+          className="text-foreground font-medium underline underline-offset-2"
+        >
+          {t("review")}
+        </Link>
+      </span>
+      <button
+        type="button"
+        aria-label={t("dismiss")}
+        onClick={handleDismiss}
+        className="hover:bg-accent hover:text-foreground focus-visible:ring-ring shrink-0 rounded p-0.5 focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+// Your-network tab body: the pending follow-request strip above the deduped
+// follower/following grid, then the activity feed — the pre-tabs page content.
+// The network is computed by the parent (which also publishes the count into
+// the page header) and passed down, so the count and grid stay in sync without
+// duplicating the follow queries.
+function NetworkTab({
+  members,
+  loading,
+}: {
+  members: Array<[string, { followsYou: boolean }]>;
+  loading: boolean;
+}) {
   const t = useTranslations("people");
-
-  const { data: following } = useQuery(
-    convexQuery(gateway.social.following, {}),
-  );
-  const { data: followers } = useQuery(
-    convexQuery(gateway.social.followers, {}),
-  );
-  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
-
-  const loading = following === undefined || followers === undefined;
-
-  // Dedupe both follow directions into one network; remember who follows you
-  // so the tile can carry a "Follows you" badge.
-  const followerIds = new Set((followers ?? []).map((edge) => edge.memberId));
-  const network = new Map<string, { followsYou: boolean }>();
-  for (const edge of following ?? []) {
-    network.set(edge.memberId, { followsYou: followerIds.has(edge.memberId) });
-  }
-  for (const edge of followers ?? []) {
-    if (!network.has(edge.memberId)) {
-      network.set(edge.memberId, { followsYou: true });
-    }
-  }
-  const members = Array.from(network.entries());
-
-  // The page title ("People") lives in the shell page head; publish the network
-  // member count there too so the body carries no duplicate section header.
-  const headerMeta = loading
-    ? undefined
-    : t("memberCount", { count: members.length });
-  usePageHeaderActions(
-    () => (
-      <div className="flex items-center gap-3">
-        {me ? (
-          <QrDialog
-            memberId={me._id}
-            displayName={me.name}
-            username={me.username}
-            avatarUrl={me.avatar}
-          />
-        ) : null}
-        {headerMeta ? (
-          <span className="text-muted-foreground hidden text-sm sm:inline">
-            {headerMeta}
-          </span>
-        ) : null}
-      </div>
-    ),
-    [headerMeta, me],
-  );
 
   return (
     <div className="flex flex-col gap-10">
-      <FollowRequestsStrip />
-
-      <section>
+      <section className="flex flex-col gap-4">
+        <FollowRequestsStrip />
         {loading ? (
           <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
             {Array.from({ length: 3 }).map((_, i) => (
@@ -117,6 +137,105 @@ function PeoplePage() {
         />
         <ActivityFeed />
       </section>
+    </div>
+  );
+}
+
+function PeoplePage() {
+  const t = useTranslations("people");
+  const { tab } = Route.useSearch();
+  const activeTab: PeopleTab = tab ?? "network";
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const { data: following } = useQuery(
+    convexQuery(gateway.social.following, {}),
+  );
+  const { data: followers } = useQuery(
+    convexQuery(gateway.social.followers, {}),
+  );
+  const { data: me } = useQuery(convexQuery(gateway.identity.currentUser, {}));
+
+  // Incoming pending follow requests drive the count badge on the network tab.
+  const { data: incoming } = useQuery(
+    convexQuery(gateway.social.incomingFollowRequests, {}),
+  );
+  const pendingCount = incoming?.length ?? 0;
+
+  const loading = following === undefined || followers === undefined;
+
+  // Dedupe both follow directions into one network; remember who follows you
+  // so the tile can carry a "Follows you" badge.
+  const followerIds = new Set((followers ?? []).map((edge) => edge.memberId));
+  const network = new Map<string, { followsYou: boolean }>();
+  for (const edge of following ?? []) {
+    network.set(edge.memberId, { followsYou: followerIds.has(edge.memberId) });
+  }
+  for (const edge of followers ?? []) {
+    if (!network.has(edge.memberId)) {
+      network.set(edge.memberId, { followsYou: true });
+    }
+  }
+  const members = Array.from(network.entries());
+
+  // The page title ("People") lives in the shell page head; publish the QR
+  // dialog (self-service invite/QR) and the network member count there so the
+  // body carries no duplicate header. Kept in the always-mounted page so the
+  // header stays stable across tab switches.
+  const headerMeta = loading
+    ? undefined
+    : t("memberCount", { count: members.length });
+  usePageHeaderActions(
+    () => (
+      <div className="flex items-center gap-3">
+        {me ? (
+          <QrDialog
+            memberId={me._id}
+            displayName={me.name}
+            username={me.username}
+            avatarUrl={me.avatar}
+          />
+        ) : null}
+        {headerMeta ? (
+          <span className="text-muted-foreground hidden text-sm sm:inline">
+            {headerMeta}
+          </span>
+        ) : null}
+      </div>
+    ),
+    [headerMeta, me],
+  );
+
+  const handleTabChange = (value: string) => {
+    void navigate({
+      search: { tab: value === "find" ? "find" : undefined },
+      replace: true,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <DiscoverabilityNotice />
+
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList>
+          <TabsTrigger value="network">
+            {t("tabs.network")}
+            {pendingCount > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {pendingCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="find">{t("tabs.find")}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="network" className="mt-4">
+          <NetworkTab members={members} loading={loading} />
+        </TabsContent>
+        <TabsContent value="find" className="mt-4">
+          <FindPeople />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/src/routes/_dashboard/people.tsx
+++ b/apps/web/src/routes/_dashboard/people.tsx
@@ -3,7 +3,6 @@ import { safeStorage } from "@/lib/safe-storage";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 
 import { EmptyState } from "@/components/community/primitives";
-import { SectionHead } from "@/components/dashboard-home/section-head";
 import { usePageHeaderActions } from "@/components/dashboard-layout/page-header-slot";
 import { ActivityFeed } from "@/components/social/activity-feed";
 import { FindPeople } from "@/components/social/find-people";
@@ -152,14 +151,8 @@ function NetworkTab({
 // profile-edit action that used to sit on this SectionHead is gone for good —
 // profile editing lives on /profile).
 function ActivityTab() {
-  const t = useTranslations("people");
-
-  return (
-    <section>
-      <SectionHead title={t("activity")} icon={Bell} />
-      <ActivityFeed />
-    </section>
-  );
+  // No inner heading: the "Activity" tab trigger already labels this view.
+  return <ActivityFeed />;
 }
 
 function PeoplePage() {

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -128,6 +128,7 @@ import type * as identity_getUserById from "../identity/getUserById.js";
 import type * as identity_getUserStats from "../identity/getUserStats.js";
 import type * as identity_isAdmin from "../identity/isAdmin.js";
 import type * as identity_isCurrentUserAdmin from "../identity/isCurrentUserAdmin.js";
+import type * as identity_listRecentPublicMembers from "../identity/listRecentPublicMembers.js";
 import type * as identity_optionalActingMember from "../identity/optionalActingMember.js";
 import type * as identity_requireMember from "../identity/requireMember.js";
 import type * as identity_resolveMemberByHandle from "../identity/resolveMemberByHandle.js";
@@ -447,6 +448,7 @@ declare const fullApi: ApiFromModules<{
   "identity/getUserStats": typeof identity_getUserStats;
   "identity/isAdmin": typeof identity_isAdmin;
   "identity/isCurrentUserAdmin": typeof identity_isCurrentUserAdmin;
+  "identity/listRecentPublicMembers": typeof identity_listRecentPublicMembers;
   "identity/optionalActingMember": typeof identity_optionalActingMember;
   "identity/requireMember": typeof identity_requireMember;
   "identity/resolveMemberByHandle": typeof identity_resolveMemberByHandle;

--- a/packages/backend/convex/identity/listRecentPublicMembers.ts
+++ b/packages/backend/convex/identity/listRecentPublicMembers.ts
@@ -1,0 +1,35 @@
+import type { MemberView } from "@jigswap/contracts";
+import type { Id } from "../_generated/dataModel";
+import { query } from "../_generated/server";
+import { profileVisibilityOf } from "../social/privacy";
+import { requireMember } from "./requireMember";
+import { toMemberView } from "./toMemberView";
+
+// Identity read (thin adapter): the "Recently joined" seed for the Find-people tab — up to 5 of
+// the newest members, PUBLIC profiles only (the privacy chokepoint gates every candidate), never
+// the viewer themself, never inactive accounts. Newest-first via Convex's _creationTime ordering;
+// we over-scan a bounded window because private/inactive candidates get dropped by the gate.
+const LIMIT = 5;
+const SCAN_LIMIT = 50;
+
+export const listRecentPublicMembers = query({
+  args: {},
+  handler: async (ctx): Promise<MemberView[]> => {
+    const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
+
+    const candidates = await ctx.db
+      .query("users")
+      .order("desc")
+      .take(SCAN_LIMIT);
+
+    const results: MemberView[] = [];
+    for (const u of candidates) {
+      if (results.length >= LIMIT) break;
+      if (u._id === viewerId) continue;
+      if (u.isActive === false) continue;
+      if ((await profileVisibilityOf(ctx, u._id)) !== "public") continue;
+      results.push(toMemberView(u));
+    }
+    return results;
+  },
+});

--- a/packages/backend/convex/identity/searchUsers.ts
+++ b/packages/backend/convex/identity/searchUsers.ts
@@ -1,7 +1,11 @@
 import type { MemberView } from "@jigswap/contracts";
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
+import {
+  countKnownFollowersOf,
+  viewerFollowingSet,
+} from "../social/knownFollowers";
 import { areMutualFollowers, profileVisibilityOf } from "../social/privacy";
 import { requireMember } from "./requireMember";
 import { toMemberView } from "./toMemberView";
@@ -15,6 +19,24 @@ import { toMemberView } from "./toMemberView";
 // We over-fetch candidates from the search index (since some get dropped by the gate) and stop once
 // `limit` visible matches are collected, so dropped private rows are refilled toward `limit`.
 const CANDIDATE_LIMIT = 50;
+
+// Ranking (from UX research): name-match quality is PRIMARY (bucketed), known-follower count is
+// only a WITHIN-BUCKET tiebreaker — a better bucket ALWAYS outranks a worse one, so a brand-new
+// member with zero connections is still findable by exact name. 0 = exact (term equals name or
+// username), 1 = prefix (term is a startsWith of name or username), 2 = fuzzy (everything else the
+// search index surfaced).
+type MatchBucket = 0 | 1 | 2;
+
+const matchBucketOf = (
+  searchTerm: string,
+  user: Pick<Doc<"users">, "name" | "username">,
+): MatchBucket => {
+  const name = user.name.toLowerCase();
+  const username = user.username?.toLowerCase();
+  if (name === searchTerm || username === searchTerm) return 0;
+  if (name.startsWith(searchTerm) || username?.startsWith(searchTerm)) return 1;
+  return 2;
+};
 
 export const searchUsers = query({
   args: {
@@ -36,20 +58,46 @@ export const searchUsers = query({
       )
       .take(CANDIDATE_LIMIT);
 
-    const results: MemberView[] = [];
+    // Built ONCE per query (not per candidate) so ranking every candidate against this viewer
+    // doesn't re-scan `follows` by_follower CANDIDATE_LIMIT times.
+    const viewerFollowing = await viewerFollowingSet(ctx, viewerId);
+
+    const visible: {
+      user: Doc<"users">;
+      bucket: MatchBucket;
+      knownCount: number;
+    }[] = [];
     for (const u of candidates) {
-      if (results.length >= limit) break;
       // Privacy chokepoint: surface a member only if they are the searcher, their
       // profile is public, or they and the searcher are mutual followers. Mirrors
       // globalSearch and getProfile so a private member is not identifiable here.
-      const visible =
+      const isVisible =
         u._id === viewerId ||
         (await profileVisibilityOf(ctx, u._id)) === "public" ||
         (await areMutualFollowers(ctx, viewerId, u._id));
-      if (!visible) continue;
-      results.push(toMemberView(u));
+      if (!isVisible) continue;
+
+      // Bounded: at most CANDIDATE_LIMIT candidates survive the search index, each scanning its
+      // own (capped) follower list — fine at this scale, and needed since ranking requires a
+      // known-follower count for every visible candidate, not just the first `limit`.
+      const knownCount = await countKnownFollowersOf(
+        ctx,
+        viewerId,
+        viewerFollowing,
+        u._id,
+      );
+      visible.push({
+        user: u,
+        bucket: matchBucketOf(searchTerm, u),
+        knownCount,
+      });
     }
 
-    return results;
+    // Bucket ascending (better match first) is primary; known-follower count descending is only
+    // the within-bucket tiebreaker. Array.sort is stable, so equal (bucket, knownCount) pairs keep
+    // the search index's original relevance order.
+    visible.sort((a, b) => a.bucket - b.bucket || b.knownCount - a.knownCount);
+
+    return visible.slice(0, limit).map((v) => toMemberView(v.user));
   },
 });

--- a/packages/backend/convex/identity/searchUsers.ts
+++ b/packages/backend/convex/identity/searchUsers.ts
@@ -24,8 +24,10 @@ export const searchUsers = query({
   handler: async (ctx, args): Promise<MemberView[]> => {
     const viewerId = (await requireMember(ctx)) as unknown as Id<"users">;
     const limit = args.limit ?? 20;
+    // Server-enforced minimum (mirrors the Find-people UI): sub-2-character probes return
+    // nothing and never touch the search index — the cheap guard against enumeration scans.
     const searchTerm = args.searchTerm.trim().toLowerCase();
-    if (searchTerm.length === 0) return [];
+    if (searchTerm.length < 2) return [];
 
     const candidates = await ctx.db
       .query("users")

--- a/packages/backend/convex/identityQueries.test.ts
+++ b/packages/backend/convex/identityQueries.test.ts
@@ -452,6 +452,111 @@ describe("identity.searchUsers profile-visibility gating", () => {
   });
 });
 
+// Ranking (UX research): match-quality bucket (exact > prefix > fuzzy) is PRIMARY;
+// known-follower count only breaks ties WITHIN a bucket. See identity/searchUsers.ts.
+describe("identity.searchUsers ranking", () => {
+  const insertUser = (
+    t: ReturnType<typeof convexTest>,
+    clerkId: string,
+    name: string,
+    username: string,
+  ) =>
+    t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name,
+        username,
+        searchableName: `${name} ${username}`.toLowerCase(),
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+  const follow = (
+    t: ReturnType<typeof convexTest>,
+    followerId: Id<"users">,
+    followeeId: Id<"users">,
+  ) =>
+    t.run(async (ctx) => {
+      await ctx.db.insert("follows", { followerId, followeeId, createdAt: 1 });
+    });
+
+  const asClerk = (t: ReturnType<typeof convexTest>, clerkId: string) =>
+    t.withIdentity({ subject: clerkId });
+
+  test("within the same match bucket, more known-followers ranks first", async () => {
+    const t = convexTest(schema, modules);
+    const viewer = await insertUser(t, "clerk_viewer", "Vera Viewer", "vera");
+    const connectorA = await insertUser(t, "clerk_ca", "Connector A", "conna");
+    const connectorB = await insertUser(t, "clerk_cb", "Connector B", "connb");
+    // Both are exact matches for "henk" (same bucket) - henkA has 2 known-followers
+    // (two accounts the viewer follows also follow henkA), henkB has none.
+    const henkA = await insertUser(t, "clerk_henka", "Henk", "henka");
+    const henkB = await insertUser(t, "clerk_henkb", "Henk", "henkb");
+
+    await follow(t, viewer, connectorA);
+    await follow(t, viewer, connectorB);
+    await follow(t, connectorA, henkA);
+    await follow(t, connectorB, henkA);
+
+    const res = await asClerk(t, "clerk_viewer").query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "henk" },
+    );
+    const ids = res.map((u) => u._id);
+    expect(ids.indexOf(henkA)).toBeLessThan(ids.indexOf(henkB));
+  });
+
+  test("bucket dominates: an exact match with zero known-followers outranks a fuzzy match with many", async () => {
+    const t = convexTest(schema, modules);
+    const viewer = await insertUser(t, "clerk_viewer2", "Vera Viewer", "vera2");
+    const connectors = [
+      await insertUser(t, "clerk_c1", "Connector One", "conn1"),
+      await insertUser(t, "clerk_c2", "Connector Two", "conn2"),
+      await insertUser(t, "clerk_c3", "Connector Three", "conn3"),
+    ];
+    // Exact match on "henk", zero known-followers.
+    const exactHenk = await insertUser(t, "clerk_exact", "Henk", "henkexact");
+    // Fuzzy match only (neither name nor username equals/starts-with "henk" - "henk" is a
+    // middle search-index token of "Van Henk"/"vanhenk92"), but has 3 known-followers.
+    const fuzzyVanHenk = await insertUser(
+      t,
+      "clerk_fuzzy",
+      "Van Henk",
+      "vanhenk92",
+    );
+
+    for (const connector of connectors) {
+      await follow(t, viewer, connector);
+      await follow(t, connector, fuzzyVanHenk);
+    }
+
+    const res = await asClerk(t, "clerk_viewer2").query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "henk" },
+    );
+    const ids = res.map((u) => u._id);
+    expect(ids).toContain(exactHenk);
+    expect(ids).toContain(fuzzyVanHenk);
+    expect(ids.indexOf(exactHenk)).toBeLessThan(ids.indexOf(fuzzyVanHenk));
+  });
+
+  test("a zero-connection new member is still returned for an exact-name search", async () => {
+    const t = convexTest(schema, modules);
+    await insertUser(t, "clerk_viewer3", "Vera Viewer", "vera3");
+    const newMember = await insertUser(t, "clerk_new", "Zoltan", "zoltan");
+
+    const res = await asClerk(t, "clerk_viewer3").query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "zoltan" },
+    );
+    expect(res.map((u) => u._id)).toContain(newMember);
+  });
+});
+
 describe("insights.getGlobalStats", () => {
   test("counts members, catalog definitions and owned copies", async () => {
     const t = convexTest(schema, modules);

--- a/packages/backend/convex/listRecentPublicMembers.test.ts
+++ b/packages/backend/convex/listRecentPublicMembers.test.ts
@@ -1,0 +1,110 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+// Nine members inserted oldest-first (insert order fixes _creationTime order).
+// alice = the viewer; carol is private; dave is inactive; everyone else public.
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    const mkUser = (
+      clerkId: string,
+      name: string,
+      extra: Record<string, unknown> = {},
+    ) =>
+      ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name,
+        searchableName: name.toLowerCase(),
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        ...extra,
+      });
+
+    await mkUser("clerk_alice", "Alice");
+    await mkUser("clerk_bob", "Bob");
+    const carol = await mkUser("clerk_carol", "Carol");
+    await ctx.db.insert("profiles", {
+      memberId: carol,
+      displayName: "Carol",
+      visibility: "private",
+      updatedAt: now,
+    });
+    await mkUser("clerk_dave", "Dave", { isActive: false });
+    const eve = await mkUser("clerk_eve", "Eve");
+    // An explicit PUBLIC profile row must also pass the gate (not only "no row").
+    await ctx.db.insert("profiles", {
+      memberId: eve,
+      displayName: "Eve",
+      visibility: "public",
+      updatedAt: now,
+    });
+    await mkUser("clerk_frank", "Frank");
+    await mkUser("clerk_grace", "Grace");
+    await mkUser("clerk_henry", "Henry");
+    await mkUser("clerk_ivy", "Ivy");
+  });
+
+const asAlice = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+
+describe("listRecentPublicMembers", () => {
+  test("returns newest public members first, capped at 5", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const result = await asAlice(t).query(
+      api.identity.listRecentPublicMembers.listRecentPublicMembers,
+      {},
+    );
+    // Newest-first: ivy, henry, grace, frank, [dave skipped: inactive],
+    // [carol skipped: private], eve fills the 5th slot; bob dropped by the cap.
+    expect(result.map((m) => m.name)).toEqual([
+      "Ivy",
+      "Henry",
+      "Grace",
+      "Frank",
+      "Eve",
+    ]);
+  });
+
+  test("never surfaces private, inactive, or the viewer themself", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const result = await asAlice(t).query(
+      api.identity.listRecentPublicMembers.listRecentPublicMembers,
+      {},
+    );
+    const names = result.map((m) => m.name);
+    expect(names).not.toContain("Carol"); // private profile
+    expect(names).not.toContain("Dave"); // inactive
+    expect(names).not.toContain("Alice"); // the viewer
+  });
+
+  test("emits PII-free MemberView (no email, no clerkId)", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const result = await asAlice(t).query(
+      api.identity.listRecentPublicMembers.listRecentPublicMembers,
+      {},
+    );
+    expect(result.length).toBeGreaterThan(0);
+    for (const m of result) {
+      expect(m).not.toHaveProperty("email");
+      expect(m).not.toHaveProperty("clerkId");
+    }
+  });
+
+  test("rejects unauthenticated callers", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    await expect(
+      t.query(api.identity.listRecentPublicMembers.listRecentPublicMembers, {}),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/backend/convex/searchUsers.test.ts
+++ b/packages/backend/convex/searchUsers.test.ts
@@ -1,0 +1,52 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    for (const [clerkId, name] of [
+      ["clerk_alice", "Alice"],
+      ["clerk_bo", "Bo"],
+    ] as const) {
+      await ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.com`,
+        name,
+        searchableName: name.toLowerCase(),
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  });
+
+const asAlice = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+
+describe("searchUsers minimum query length", () => {
+  test("returns [] for empty and 1-character terms without hitting the index", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    for (const searchTerm of ["", " ", "b", " b "]) {
+      const result = await asAlice(t).query(
+        api.identity.searchUsers.searchUsers,
+        { searchTerm },
+      );
+      expect(result).toEqual([]);
+    }
+  });
+
+  test("still searches from 2 characters", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const result = await asAlice(t).query(
+      api.identity.searchUsers.searchUsers,
+      { searchTerm: "bo" },
+    );
+    expect(result.map((m) => m.name)).toContain("Bo");
+  });
+});

--- a/packages/backend/convex/social/getActivityFeed.ts
+++ b/packages/backend/convex/social/getActivityFeed.ts
@@ -97,9 +97,42 @@ export const getActivityFeed = query({
     const feed = buildActivityFeed(deduped, {
       limit: args.limit ?? DEFAULT_LIMIT,
     });
-    return feed.map(toActivityEntryView);
+
+    // Resolve each distinct actor's display name once (not per-entry) so a feed with repeat actors
+    // doesn't re-query the same profile/user rows.
+    const distinctActorIds = [
+      ...new Set(feed.map((e) => e.memberId as string)),
+    ];
+    const actorNames = new Map(
+      await Promise.all(
+        distinctActorIds.map(
+          async (id) => [id, await resolveActorName(ctx, id)] as const,
+        ),
+      ),
+    );
+
+    return feed.map((entry) =>
+      toActivityEntryView(entry, actorNames.get(entry.memberId as string)!),
+    );
   },
 });
+
+// Prefer the actor's Social profile display name, falling back to their account name (mirrors
+// `toFollowEdgeView`'s counterparty-name resolution) so an actor without a profile still renders.
+const resolveActorName = async (
+  ctx: QueryCtx,
+  memberId: string,
+): Promise<string> => {
+  const id = memberId as unknown as Id<"users">;
+  const [profile, user] = await Promise.all([
+    ctx.db
+      .query("profiles")
+      .withIndex("by_member", (q) => q.eq("memberId", id))
+      .unique(),
+    ctx.db.get(id),
+  ]);
+  return profile?.displayName ?? user?.name ?? "Member";
+};
 
 const asMember = (id: string): MemberId => toMemberId(id);
 
@@ -153,9 +186,13 @@ const loadExchange = (
     .withIndex("by_aggregate_id", (q) => q.eq("aggregateId", aggregateId))
     .unique();
 
-const toActivityEntryView = (entry: ActivityEntry): ActivityEntryView => ({
+const toActivityEntryView = (
+  entry: ActivityEntry,
+  actorName: string,
+): ActivityEntryView => ({
   memberId: entry.memberId as string,
   kind: entry.kind,
   occurredAt: entry.occurredAt.getTime(),
   ref: entry.ref,
+  actorName,
 });

--- a/packages/backend/convex/social/knownFollowers.ts
+++ b/packages/backend/convex/social/knownFollowers.ts
@@ -6,19 +6,45 @@ import type { QueryCtx } from "../_generated/server";
 // deliberately NOT plain mutual-followers (privacy.ts's areMutualFollowers, which asks whether
 // viewer and target follow EACH OTHER): it is personalized social proof, one direction only,
 // about accounts the viewer already trusts enough to follow. Reused by social/followersYouKnow
-// (profile social-proof row) and, on a later branch, by search ranking — keep this export clean
-// and dependency-free (no privacy/visibility gating here; callers gate as needed).
+// (profile social-proof row) and by identity/searchUsers (known-follower ranking tiebreak) — keep
+// this export clean and dependency-free (no privacy/visibility gating here; callers gate as needed).
 export const knownFollowerIds = async (
   ctx: QueryCtx,
   viewerId: Id<"users">,
   targetId: Id<"users">,
 ): Promise<Id<"users">[]> => {
+  const viewerFollowing = await viewerFollowingSet(ctx, viewerId);
+  return knownFollowerIdsOf(ctx, viewerId, viewerFollowing, targetId);
+};
+
+/** The count of `knownFollowerIds` — a trivial `.length`, exported so callers don't need the array. */
+export const countKnownFollowers = async (
+  ctx: QueryCtx,
+  viewerId: Id<"users">,
+  targetId: Id<"users">,
+): Promise<number> => (await knownFollowerIds(ctx, viewerId, targetId)).length;
+
+// The viewer's following set, built ONCE from `follows` `by_follower`. Callers ranking many
+// candidates against the same viewer (e.g. search-result ranking) build this once and pass it to
+// `knownFollowerIdsOf`/`countKnownFollowersOf` instead of paying the `by_follower` scan per candidate.
+export const viewerFollowingSet = async (
+  ctx: QueryCtx,
+  viewerId: Id<"users">,
+): Promise<Set<Id<"users">>> => {
   const followingRows = await ctx.db
     .query("follows")
     .withIndex("by_follower", (q) => q.eq("followerId", viewerId))
     .take(2000);
-  const viewerFollowing = new Set(followingRows.map((r) => r.followeeId));
+  return new Set(followingRows.map((r) => r.followeeId));
+};
 
+/** Same computation as `knownFollowerIds`, given a pre-built `viewerFollowingSet`. */
+export const knownFollowerIdsOf = async (
+  ctx: QueryCtx,
+  viewerId: Id<"users">,
+  viewerFollowing: Set<Id<"users">>,
+  targetId: Id<"users">,
+): Promise<Id<"users">[]> => {
   const targetFollowerRows = await ctx.db
     .query("follows")
     .withIndex("by_followee", (q) => q.eq("followeeId", targetId))
@@ -32,9 +58,11 @@ export const knownFollowerIds = async (
   return ids;
 };
 
-/** The count of `knownFollowerIds` — a trivial `.length`, exported so callers don't need the array. */
-export const countKnownFollowers = async (
+/** The count of `knownFollowerIdsOf` — a trivial `.length`, exported so callers don't need the array. */
+export const countKnownFollowersOf = async (
   ctx: QueryCtx,
   viewerId: Id<"users">,
+  viewerFollowing: Set<Id<"users">>,
   targetId: Id<"users">,
-): Promise<number> => (await knownFollowerIds(ctx, viewerId, targetId)).length;
+): Promise<number> =>
+  (await knownFollowerIdsOf(ctx, viewerId, viewerFollowing, targetId)).length;

--- a/packages/backend/convex/socialMutations.test.ts
+++ b/packages/backend/convex/socialMutations.test.ts
@@ -317,6 +317,9 @@ describe("activity feed projection", () => {
     expect(feed[0].kind).toBe("acquisition");
     expect(feed[0].memberId).toBe(bob as string);
     expect(feed[1].kind).toBe("completion");
+    // Neither Alice nor Bob has a Social profile, so actorName falls back to the account name.
+    expect(feed[0].actorName).toBe("clerk_bob");
+    expect(feed[1].actorName).toBe("clerk_alice");
   });
 
   test("ExchangeCompleted is attributed to both parties via the exchange row", async () => {
@@ -370,6 +373,7 @@ describe("activity feed projection", () => {
     expect(feed[0].kind).toBe("exchange");
     expect(feed[0].ref).toBe(exchangeAggregateId);
     expect(feed[0].memberId).toBe(alice as string);
+    expect(feed[0].actorName).toBe("clerk_alice");
   });
 
   test("a completed exchange appears once when the viewer is a party AND follows the counterparty", async () => {

--- a/packages/contracts/src/social/social.ts
+++ b/packages/contracts/src/social/social.ts
@@ -34,13 +34,17 @@ export interface FollowEdgeView {
 /**
  * One entry in a member's activity feed, mapped at the backend seam from foreign domain events
  * (CompletionRecorded / CopyAcquired / ExchangeCompleted) into Social's anti-corruption shape.
- * `ref` is an opaque pointer back to the originating record for the UI to deep-link.
+ * `ref` is an opaque pointer back to the originating record for the UI to deep-link. `actorName` is
+ * the actor's display name (their Social profile displayName, falling back to their account name) —
+ * resolved server-side so the UI can render "You"/"{name}" without an extra per-row lookup; the
+ * feed's audience is always self + followees, so every actor here is already visible to the viewer.
  */
 export interface ActivityEntryView {
   memberId: string;
   kind: "completion" | "acquisition" | "exchange";
   occurredAt: number;
   ref: string;
+  actorName: string;
 }
 
 /**

--- a/packages/gateway/src/operations.ts
+++ b/packages/gateway/src/operations.ts
@@ -181,6 +181,9 @@ export const gateway = {
     updateProfile: api.users.updateUserProfile,
     userStats: api.identity.getUserStats.getUserStats,
     search: api.identity.searchUsers.searchUsers,
+    // "Recently joined" seed for the Find-people tab: up to 5 newest PUBLIC members.
+    recentPublicMembers:
+      api.identity.listRecentPublicMembers.listRecentPublicMembers,
     // Whether the acting caller is an admin (fails closed). Backs the web /admin
     // route guard; the server-side gate on every admin function stays authoritative.
     isAdmin: api.identity.isCurrentUserAdmin.isCurrentUserAdmin,


### PR DESCRIPTION
## Summary

Phase 4 of the friend-discovery feature set (stacked on #51). The People page gains a search-first directory so members can find each other by name — the escape hatch when the QR/link flows aren't handy.

- **Two tabs on the People page:** "Your network" (default — the existing deduped follower/following grid, the Phase 2 follow-requests strip, and the activity feed, all preserved) and "Find people". URL-addressable via an optional `?tab=find` param, so bare `/people` stays clean and existing links keep working.
- **Find people:** search box (server-enforced 2-character minimum, muted helper below threshold, 300ms debounce), single-column results linking to `/members/$handle` with street-level location hidden (`hideLocation` on `MemberTile` — stats stay for trust), a "Recently joined" seed of up to 5 newest **public** profiles, and empty states that point to sharing your profile link or QR.
- **No browse-all**, per the approved search-first decision — a small trust-based community shouldn't feel enumerable.
- **Discoverability notice:** a one-time dismissible, info-toned banner announcing the directory launch and linking to the visibility setting. Reworded in review to a neutral directory-launch framing (the original asserted "others can find you by name" to everyone, false for already-private members) and mount-guarded so a returning user who dismissed it gets no hydration flash. Dismissal persists via Phase 3's crash-safe `safeStorage`.
- The Phase 3 invite fallback nudge now deep-links to `/people?tab=find`.

## Privacy

`listRecentPublicMembers` routes every candidate through the `profileVisibilityOf` chokepoint and admits only public profiles — private members can never appear in the seed (asserted in tests, verified by the sign-off). The 2-char search minimum narrows the enumeration surface without touching `searchUsers`' existing self/public/mutual-follower visibility gate.

## Review & sign-off

Per-task spec+quality review; a single risk-proportionate combined architecture+senior sign-off (this phase adds no domain logic and no auth-boundary changes) — **APPROVED**, with the notice-copy should-fix applied post-review.

## Verification

- Backend: 647 tests (6 new across the two query suites); domain: 1140 (unchanged)
- type-check all projects, web lint (0 errors), web SSR build, format:check, locale parity — all green, uncached
- No runtime browser verification here; flows covered by convex-test + code-trace review. Manual smoke recommended: tab switch, search, empty-state QR, notice dismissal persistence.

## Accepted notes

- `searchUsers` "rate-limited server-side" (spec wording) is realized as the 2-char enumeration guard + existing result caps + client debounce; a true counting limiter would need the `@convex-dev/rate-limiter` component (documented substitution — the visibility gate remains the real control).
- Two nominal `currentUser` subscriptions (page header + Find tab) dedupe to one via React Query's query-key cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)