### PR TITLE
feat(web): public puzzle catalog + SEO (friend discovery, phase 5)

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2836,6 +2836,7 @@
     "reviews": "Reviews",
     "reviewPlaceholder": "Review {title}…",
     "rateOptional": "Rate this puzzle (optional)",
+    "reviewPublicNote": "Reviews also appear on the public puzzle catalogue.",
     "post": "Post",
     "reviewFailed": "Couldn't post review",
     "noReviews": "No reviews yet. Be the first.",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2118,6 +2118,7 @@
   "marketing": {
     "nav": {
       "howItWorks": "How it works",
+      "catalog": "Browse puzzles",
       "features": "Features",
       "about": "About",
       "docs": "Docs",
@@ -3242,6 +3243,42 @@
     }
   },
   "publicCatalog": {
-    "toSwap": "{count} to swap"
+    "title": "Puzzle catalogue",
+    "subtitle": "Every puzzle the JigSwap community collects, swaps and lends.",
+    "searchPlaceholder": "Search puzzles…",
+    "allBrands": "All brands",
+    "allPieces": "Any piece count",
+    "piecesLt500": "Under 500 pieces",
+    "pieces500": "500 – 999 pieces",
+    "pieces1000": "1,000 – 1,499 pieces",
+    "pieces1500": "1,500+ pieces",
+    "toSwap": "{count} to swap",
+    "loadMore": "Load more",
+    "noResults": "No puzzles match \"{query}\"",
+    "noResultsSub": "Try a brand name or fewer words",
+    "clearSearch": "Clear search",
+    "empty": "The catalogue is just getting started",
+    "emptySub": "Members add puzzles every day — check back soon.",
+    "joinCta": "Join JigSwap to request a swap",
+    "logIn": "Log in",
+    "availabilityTitle": "Available in the community",
+    "copiesAvailableNow": "{count, plural, one {copy available to swap right now} other {copies available to swap right now}}",
+    "joinToSeeWho": "Join to see who",
+    "ownersHaveIt": "{count, plural, one {# member has this in their collection} other {# members have this in their collection}}",
+    "chipSwap": "{count} swap",
+    "chipLend": "{count} lend",
+    "chipSale": "{count} sale",
+    "statAvailable": "Available to swap",
+    "statOwners": "Community owners",
+    "statCompletions": "Times completed",
+    "statAvgDays": "Avg. days to finish",
+    "communityRating": "Community rating",
+    "ratingsCount": "{count} ratings",
+    "reviews": "Reviews",
+    "noReviews": "No reviews yet.",
+    "anonymousReviewer": "A JigSwap member",
+    "logInToReview": "Log in to write a review",
+    "notFound": "Puzzle not found",
+    "notFoundSub": "This puzzle may have been removed from the catalogue."
   }
 }

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -3240,5 +3240,8 @@
         "auditReceivedEmpty": "No audit entries target this member."
       }
     }
+  },
+  "publicCatalog": {
+    "toSwap": "{count} to swap"
   }
 }

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -3240,5 +3240,8 @@
         "auditReceivedEmpty": "Geen auditvermeldingen voor dit lid."
       }
     }
+  },
+  "publicCatalog": {
+    "toSwap": "{count} te ruil"
   }
 }

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2118,6 +2118,7 @@
   "marketing": {
     "nav": {
       "howItWorks": "Hoe het werkt",
+      "catalog": "Puzzels bekijken",
       "features": "Functies",
       "about": "Over ons",
       "docs": "Documentatie",
@@ -3242,6 +3243,42 @@
     }
   },
   "publicCatalog": {
-    "toSwap": "{count} te ruil"
+    "title": "Puzzelcatalogus",
+    "subtitle": "Elke puzzel die de JigSwap-community verzamelt, ruilt en uitleent.",
+    "searchPlaceholder": "Zoek puzzels…",
+    "allBrands": "Alle merken",
+    "allPieces": "Elk aantal stukjes",
+    "piecesLt500": "Minder dan 500 stukjes",
+    "pieces500": "500 – 999 stukjes",
+    "pieces1000": "1.000 – 1.499 stukjes",
+    "pieces1500": "1.500+ stukjes",
+    "toSwap": "{count} te ruilen",
+    "loadMore": "Meer laden",
+    "noResults": "Geen puzzels gevonden voor \"{query}\"",
+    "noResultsSub": "Probeer een merknaam of minder woorden",
+    "clearSearch": "Zoekopdracht wissen",
+    "empty": "De catalogus is net begonnen",
+    "emptySub": "Leden voegen dagelijks puzzels toe — kom snel terug.",
+    "joinCta": "Word lid van JigSwap om te ruilen",
+    "logIn": "Inloggen",
+    "availabilityTitle": "Beschikbaar in de community",
+    "copiesAvailableNow": "{count, plural, one {exemplaar nu beschikbaar om te ruilen} other {exemplaren nu beschikbaar om te ruilen}}",
+    "joinToSeeWho": "Word lid om te zien wie",
+    "ownersHaveIt": "{count, plural, one {# lid heeft deze in de verzameling} other {# leden hebben deze in hun verzameling}}",
+    "chipSwap": "{count} ruilen",
+    "chipLend": "{count} lenen",
+    "chipSale": "{count} kopen",
+    "statAvailable": "Beschikbaar om te ruilen",
+    "statOwners": "Eigenaren in de community",
+    "statCompletions": "Keer gelegd",
+    "statAvgDays": "Gem. dagen om te leggen",
+    "communityRating": "Communitybeoordeling",
+    "ratingsCount": "{count} beoordelingen",
+    "reviews": "Reviews",
+    "noReviews": "Nog geen reviews.",
+    "anonymousReviewer": "Een JigSwap-lid",
+    "logInToReview": "Log in om een review te schrijven",
+    "notFound": "Puzzel niet gevonden",
+    "notFoundSub": "Deze puzzel is mogelijk uit de catalogus verwijderd."
   }
 }

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -2836,6 +2836,7 @@
     "reviews": "Reviews",
     "reviewPlaceholder": "Beoordeel {title}…",
     "rateOptional": "Beoordeel deze puzzel (optioneel)",
+    "reviewPublicNote": "Reviews verschijnen ook in de openbare puzzelcatalogus.",
     "post": "Plaatsen",
     "reviewFailed": "Kon review niet plaatsen",
     "noReviews": "Nog geen reviews. Wees de eerste.",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2836,6 +2836,7 @@
     "reviews": "Reviews",
     "reviewPlaceholder": "Review {title}…",
     "rateOptional": "Rate this puzzle (optional)",
+    "reviewPublicNote": "Reviews also appear on the public puzzle catalogue.",
     "post": "Post",
     "reviewFailed": "Couldn't post review",
     "noReviews": "No reviews yet. Be the first.",

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -2118,6 +2118,7 @@
   "marketing": {
     "nav": {
       "howItWorks": "How it works",
+      "catalog": "Browse puzzles",
       "features": "Features",
       "about": "About",
       "docs": "Docs",
@@ -3242,6 +3243,42 @@
     }
   },
   "publicCatalog": {
-    "toSwap": "{count} to swap"
+    "title": "Puzzle catalogue",
+    "subtitle": "Every puzzle the JigSwap community collects, swaps and lends.",
+    "searchPlaceholder": "Search puzzles…",
+    "allBrands": "All brands",
+    "allPieces": "Any piece count",
+    "piecesLt500": "Under 500 pieces",
+    "pieces500": "500 – 999 pieces",
+    "pieces1000": "1,000 – 1,499 pieces",
+    "pieces1500": "1,500+ pieces",
+    "toSwap": "{count} to swap",
+    "loadMore": "Load more",
+    "noResults": "No puzzles match \"{query}\"",
+    "noResultsSub": "Try a brand name or fewer words",
+    "clearSearch": "Clear search",
+    "empty": "The catalogue is just getting started",
+    "emptySub": "Members add puzzles every day — check back soon.",
+    "joinCta": "Join JigSwap to request a swap",
+    "logIn": "Log in",
+    "availabilityTitle": "Available in the community",
+    "copiesAvailableNow": "{count, plural, one {copy available to swap right now} other {copies available to swap right now}}",
+    "joinToSeeWho": "Join to see who",
+    "ownersHaveIt": "{count, plural, one {# member has this in their collection} other {# members have this in their collection}}",
+    "chipSwap": "{count} swap",
+    "chipLend": "{count} lend",
+    "chipSale": "{count} sale",
+    "statAvailable": "Available to swap",
+    "statOwners": "Community owners",
+    "statCompletions": "Times completed",
+    "statAvgDays": "Avg. days to finish",
+    "communityRating": "Community rating",
+    "ratingsCount": "{count} ratings",
+    "reviews": "Reviews",
+    "noReviews": "No reviews yet.",
+    "anonymousReviewer": "A JigSwap member",
+    "logInToReview": "Log in to write a review",
+    "notFound": "Puzzle not found",
+    "notFoundSub": "This puzzle may have been removed from the catalogue."
   }
 }

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -3240,5 +3240,8 @@
         "auditReceivedEmpty": "No audit entries target this member."
       }
     }
+  },
+  "publicCatalog": {
+    "toSwap": "{count} to swap"
   }
 }

--- a/apps/web/src/components/marketing/footer.tsx
+++ b/apps/web/src/components/marketing/footer.tsx
@@ -38,6 +38,7 @@ export function MarketingFooter() {
           </div>
           {col(t("footer.product"), [
             { href: "/how-it-works", label: t("nav.howItWorks") },
+            { href: "/catalog", label: t("nav.catalog") },
             { href: "/features", label: t("nav.features") },
             { href: "/docs", label: t("nav.docs") },
             { href: "/sign-up", label: t("nav.startTrading") },

--- a/apps/web/src/components/marketing/header.tsx
+++ b/apps/web/src/components/marketing/header.tsx
@@ -19,6 +19,7 @@ import { useLocale, useTranslations } from "use-intl";
 
 const NAV = [
   { href: "/how-it-works", key: "howItWorks" },
+  { href: "/catalog", key: "catalog" },
   { href: "/features", key: "features" },
   { href: "/about", key: "about" },
   { href: "/docs", key: "docs" },

--- a/apps/web/src/components/puzzles/definition-card.tsx
+++ b/apps/web/src/components/puzzles/definition-card.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { gateway } from "@/gateway";
+import type { FunctionReturnType } from "convex/server";
+import { Star } from "lucide-react";
+import { useTranslations } from "use-intl";
+import { PuzzleCardShell } from "./puzzle-card-shell";
+
+// One card in the public catalog list, derived from the paginated public-browse read this card is
+// fed by. Sibling of PuzzleCard (which renders an owned-copy DTO with owner actions) — this one is
+// deliberately member-free: no owner identities, no copy-level badges, just catalog facts +
+// community aggregates.
+type CatalogCard = FunctionReturnType<
+  typeof gateway.catalog.publicBrowse
+>["page"][number];
+
+export function DefinitionCard({ card }: { card: CatalogCard }) {
+  const t = useTranslations("publicCatalog");
+
+  const badges = (
+    <div className="mb-2 flex flex-wrap items-center gap-2">
+      {card.rating.count > 0 && (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+          {card.rating.value} ({card.rating.count})
+        </span>
+      )}
+      {card.availableToSwap > 0 && (
+        <Badge variant="outline" className="text-xs">
+          {t("toSwap", { count: card.availableToSwap })}
+        </Badge>
+      )}
+    </div>
+  );
+
+  return (
+    <PuzzleCardShell
+      puzzle={{
+        id: card._id,
+        title: card.title,
+        brand: card.brand,
+        pieceCount: card.pieceCount,
+        difficulty: card.difficulty,
+        imageUrl: card.image,
+      }}
+      badges={badges}
+      imageHref={`/catalog/${card._id}`}
+    />
+  );
+}

--- a/apps/web/src/routes/_dashboard/puzzles/$id/index.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/$id/index.tsx
@@ -544,6 +544,9 @@ function ReviewsSection({
             size="sm"
             label={t("rateOptional")}
           />
+          <p className="text-muted-foreground text-xs">
+            {t("reviewPublicNote")}
+          </p>
         </div>
       </div>
 

--- a/apps/web/src/routes/_dashboard/route.tsx
+++ b/apps/web/src/routes/_dashboard/route.tsx
@@ -13,6 +13,12 @@ import { requireAuth } from "@/lib/require-auth";
 // bar + transparent grouped sidebar + floating content card) lives in
 // components/dashboard-layout — page titles/subtitles/breadcrumbs come from
 // the central route-meta map there, so leaf routes don't touch the shell.
+// Static (non-$id) routes under /puzzles/ that must NOT be treated as a puzzle
+// id by the public-catalog handoff below. `/puzzles/` (the index) can't match
+// the single-segment regex, but `/puzzles/add` would — and has no public
+// equivalent, so it keeps the normal sign-in redirect.
+const STATIC_PUZZLE_ROUTES = new Set(["add"]);
+
 export const Route = createFileRoute("/_dashboard")({
   beforeLoad: ({ context, location }) => {
     // Public-catalog handoff (Phase 5 spec): an unauthenticated visit to a member puzzle page has a
@@ -20,7 +26,7 @@ export const Route = createFileRoute("/_dashboard")({
     // work for everyone. All other dashboard paths keep the sign-in redirect.
     if (!context.userId) {
       const puzzleDetail = location.pathname.match(/^\/puzzles\/([^/]+)\/?$/);
-      if (puzzleDetail) {
+      if (puzzleDetail && !STATIC_PUZZLE_ROUTES.has(puzzleDetail[1])) {
         throw redirect({ to: "/catalog/$id", params: { id: puzzleDetail[1] } });
       }
     }

--- a/apps/web/src/routes/_dashboard/route.tsx
+++ b/apps/web/src/routes/_dashboard/route.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 
 import { AppNotFound } from "@/components/NotFound";
 import { DashboardShell } from "@/components/dashboard-layout/shell";
@@ -14,7 +14,18 @@ import { requireAuth } from "@/lib/require-auth";
 // components/dashboard-layout — page titles/subtitles/breadcrumbs come from
 // the central route-meta map there, so leaf routes don't touch the shell.
 export const Route = createFileRoute("/_dashboard")({
-  beforeLoad: ({ context, location }) => requireAuth({ context, location }),
+  beforeLoad: ({ context, location }) => {
+    // Public-catalog handoff (Phase 5 spec): an unauthenticated visit to a member puzzle page has a
+    // public equivalent — send it there instead of the sign-in wall so member-shared puzzle links
+    // work for everyone. All other dashboard paths keep the sign-in redirect.
+    if (!context.userId) {
+      const puzzleDetail = location.pathname.match(/^\/puzzles\/([^/]+)\/?$/);
+      if (puzzleDetail) {
+        throw redirect({ to: "/catalog/$id", params: { id: puzzleDetail[1] } });
+      }
+    }
+    return requireAuth({ context, location });
+  },
   pendingComponent: () => <PageLoading message="Loading dashboard..." />,
   // 404 inside the app renders within the dashboard shell (this layout's Outlet).
   notFoundComponent: AppNotFound,

--- a/apps/web/src/routes/_public/catalog/$id.tsx
+++ b/apps/web/src/routes/_public/catalog/$id.tsx
@@ -1,0 +1,429 @@
+import { Image } from "@/compat/image";
+import { Link } from "@/compat/link";
+import { EmptyState } from "@/components/library/empty-state";
+import {
+  difficultyClasses,
+  MemberAvatar,
+  PuzzleCoverFallback,
+  SectionHead,
+  StarGlyph,
+  Stat,
+} from "@/components/puzzles/catalog-detail-parts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { StarRating } from "@/components/ui/star-rating";
+import { gateway, Id } from "@/gateway";
+import { cn } from "@/lib/utils";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import type { FunctionReturnType } from "convex/server";
+import { ArrowLeftRight, MessageCircle, UserRound } from "lucide-react";
+import { useState } from "react";
+import { useFormatter, useTranslations } from "use-intl";
+
+type View = NonNullable<
+  FunctionReturnType<typeof gateway.catalog.publicDefinitionView>
+>;
+type PublicReview = FunctionReturnType<
+  typeof gateway.social.listPublicPuzzleReviews
+>[number];
+
+const viewQuery = (id: string) =>
+  convexQuery(gateway.catalog.publicDefinitionView, {
+    puzzleId: id as Id<"puzzles">,
+  });
+const reviewsQuery = (id: string) =>
+  convexQuery(gateway.social.listPublicPuzzleReviews, {
+    puzzleId: id as Id<"puzzles">,
+  });
+
+export const Route = createFileRoute("/_public/catalog/$id")({
+  // Members always get the richer dashboard page (own actions, per-copy list): the spec's
+  // bidirectional redirect. The unauthenticated /puzzles/$id -> /catalog/$id half lives in
+  // _dashboard/route.tsx.
+  beforeLoad: ({ context, params }) => {
+    if (context.userId) {
+      throw redirect({ to: "/puzzles/$id", params: { id: params.id } });
+    }
+  },
+  loader: async ({ context, params }) => {
+    const [view] = await Promise.all([
+      context.queryClient.ensureQueryData(viewQuery(params.id)),
+      context.queryClient.ensureQueryData(reviewsQuery(params.id)),
+    ]);
+    return { view };
+  },
+  head: ({ loaderData }) => {
+    const d = loaderData?.view?.definition;
+    if (!d) return { meta: [{ title: "JigSwap" }] };
+    const title = `${d.title} — JigSwap`;
+    // English-only meta template: head() runs outside the intl render tree; acceptable for SEO.
+    const description = `${d.title}${d.brand ? ` by ${d.brand}` : ""} — ${d.pieceCount.toLocaleString("en")}-piece jigsaw puzzle. Community rating, reviews and swap availability on JigSwap.`;
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+        { property: "og:type", content: "website" },
+        ...(d.image ? [{ property: "og:image", content: d.image }] : []),
+      ],
+    };
+  },
+  component: PublicPuzzlePage,
+});
+
+function PublicPuzzlePage() {
+  const { id } = Route.useParams();
+  const t = useTranslations("publicCatalog");
+  const { data: view } = useQuery(viewQuery(id));
+
+  if (view === undefined) return null; // loader-prefetched; only a hard refetch passes here
+  if (view === null) {
+    return (
+      <main className="mx-auto w-full max-w-[1200px] px-6 py-10">
+        <EmptyState title={t("notFound")} sub={t("notFoundSub")} />
+      </main>
+    );
+  }
+  return <PublicPuzzleDetail view={view} puzzleId={id} />;
+}
+
+function swapChipClasses(type: "swap" | "lend" | "sale") {
+  switch (type) {
+    case "swap":
+      return "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200";
+    case "lend":
+      return "bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200";
+    default:
+      return "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200";
+  }
+}
+
+function PublicPuzzleDetail({
+  view,
+  puzzleId,
+}: {
+  view: View;
+  puzzleId: string;
+}) {
+  const t = useTranslations("publicCatalog");
+  const { definition, rating, stats, availability } = view;
+  const topics = [
+    ...(definition.categoryName ? [definition.categoryName] : []),
+    ...definition.tags,
+  ];
+  const chips = (
+    [
+      ["swap", availability.byType.swap],
+      ["lend", availability.byType.lend],
+      ["sale", availability.byType.sale],
+    ] as const
+  ).filter(([, n]) => n > 0);
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1200px] flex-col gap-10 px-6 py-10">
+      {/* Hero — mirrors the dashboard detail skeleton, minus member actions. */}
+      <section className="grid items-start gap-7 lg:grid-cols-[300px_minmax(0,1fr)]">
+        <div className="bg-muted relative aspect-square w-full max-w-[300px] overflow-hidden rounded-2xl shadow-sm">
+          {definition.image ? (
+            <Image
+              src={definition.image}
+              alt={definition.title}
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <PuzzleCoverFallback />
+          )}
+        </div>
+        <div className="min-w-0">
+          <div className="text-muted-foreground text-xs font-semibold uppercase tracking-[0.18em]">
+            {t("title")}
+          </div>
+          <h1 className="font-heading mt-2 text-3xl font-bold tracking-tight">
+            {definition.title}
+          </h1>
+          <p className="text-muted-foreground mt-1 text-base">
+            {definition.brand ? `${definition.brand} · ` : ""}
+            <span className="font-mono">
+              {definition.pieceCount.toLocaleString()}
+            </span>{" "}
+            pieces
+          </p>
+          <div className="mt-3.5 flex flex-wrap items-center gap-2.5">
+            {rating.count > 0 && (
+              <span className="flex items-center gap-1.5">
+                <StarRating value={Math.round(rating.rating)} size="sm" />
+                <span className="text-muted-foreground text-sm">
+                  {rating.rating} ({rating.count})
+                </span>
+              </span>
+            )}
+            {definition.difficulty && (
+              <Badge
+                className={cn(
+                  "rounded-full border-transparent px-2.5 py-0.5 text-xs font-semibold",
+                  difficultyClasses(definition.difficulty),
+                )}
+              >
+                {definition.difficulty}
+              </Badge>
+            )}
+            {topics.map((topic, i) => (
+              <span
+                key={`${topic}-${i}`}
+                className="border-border text-foreground inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
+          {definition.description && (
+            <p className="text-foreground/90 mt-4 text-sm leading-relaxed">
+              {definition.description}
+            </p>
+          )}
+          {/* ONE primary CTA (spec): join, with returnTo back to this page. */}
+          <div className="mt-5 flex flex-wrap gap-2.5">
+            <Button variant="brand" asChild>
+              <Link
+                href={`/sign-up?redirect_url=${encodeURIComponent(`/catalog/${puzzleId}`)}`}
+              >
+                {t("joinCta")}
+              </Link>
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link
+                href={`/sign-in?redirect_url=${encodeURIComponent(`/catalog/${puzzleId}`)}`}
+              >
+                {t("logIn")}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Stats strip — Available-to-swap FIRST (the hook); zero/absent stats are hidden, never
+          rendered as dashes (spec). */}
+      <div className="grid max-w-[760px] grid-cols-2 gap-y-6 sm:grid-cols-4">
+        {availability.total > 0 && (
+          <Stat value={availability.total} label={t("statAvailable")} />
+        )}
+        {stats.communityOwners > 0 && (
+          <Stat
+            value={stats.communityOwners}
+            label={t("statOwners")}
+            divided={availability.total > 0}
+          />
+        )}
+        {stats.totalCompletions > 0 && (
+          <Stat
+            value={stats.totalCompletions}
+            label={t("statCompletions")}
+            divided
+          />
+        )}
+        {stats.avgCompletionDays != null && stats.avgCompletionDays > 0 && (
+          <Stat
+            value={stats.avgCompletionDays}
+            label={t("statAvgDays")}
+            divided
+          />
+        )}
+      </div>
+
+      {/* Availability panel: aggregate only — no owner identities. Zero availability -> omit the
+          panel; show the softer owners line instead when anyone owns it (spec). */}
+      {availability.total > 0 ? (
+        <section>
+          <SectionHead
+            icon={<ArrowLeftRight className="h-4 w-4" />}
+            title={t("availabilityTitle")}
+          />
+          <div className="bg-jigsaw-primary/10 flex flex-wrap items-center gap-5 rounded-xl px-5 py-4">
+            <div className="font-heading text-4xl font-bold leading-none">
+              {availability.total}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium">
+                {t("copiesAvailableNow", { count: availability.total })}
+              </div>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {chips.map(([type, n]) => (
+                  <span
+                    key={type}
+                    className={cn(
+                      "rounded-full px-2.5 py-0.5 text-xs font-semibold",
+                      swapChipClasses(type),
+                    )}
+                  >
+                    {t(
+                      type === "swap"
+                        ? "chipSwap"
+                        : type === "lend"
+                          ? "chipLend"
+                          : "chipSale",
+                      { count: n },
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+            {/* Three generic, non-identifying avatar circles: signals people without naming them. */}
+            <div className="flex -space-x-2">
+              {[0, 1, 2].map((i) => (
+                <span
+                  key={i}
+                  className="bg-muted border-background text-muted-foreground flex h-8 w-8 items-center justify-center rounded-full border-2"
+                >
+                  <UserRound className="h-4 w-4" />
+                </span>
+              ))}
+            </div>
+            <Button variant="brand" size="sm" asChild>
+              <Link
+                href={`/sign-up?redirect_url=${encodeURIComponent(`/catalog/${puzzleId}`)}`}
+              >
+                {t("joinToSeeWho")}
+              </Link>
+            </Button>
+          </div>
+        </section>
+      ) : (
+        stats.communityOwners > 0 && (
+          <p className="text-muted-foreground text-sm">
+            {t("ownersHaveIt", { count: stats.communityOwners })}
+          </p>
+        )
+      )}
+
+      {/* Rating + reviews, two-column like the dashboard page. */}
+      <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
+        <section>
+          <SectionHead icon={<StarGlyph />} title={t("communityRating")} />
+          <div className="mb-3.5 flex items-end gap-3.5">
+            <div className="font-heading text-foreground text-4xl font-bold leading-none">
+              {rating.rating}
+            </div>
+            <div className="pb-0.5">
+              <StarRating value={Math.round(rating.rating)} size="sm" />
+              <div className="text-muted-foreground mt-1 text-xs">
+                {t("ratingsCount", { count: rating.count })}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {[5, 4, 3, 2, 1].map((star, i) => (
+              <div key={star} className="flex items-center gap-2.5">
+                <span className="text-muted-foreground inline-flex w-7 items-center justify-end gap-0.5 text-xs">
+                  {star}★
+                </span>
+                <span className="bg-muted h-1.5 flex-1 overflow-hidden rounded-full">
+                  <span
+                    className="block h-full rounded-full bg-amber-400"
+                    style={{ width: `${rating.percentages[i]}%` }}
+                  />
+                </span>
+                <span className="text-muted-foreground w-9 text-right font-mono text-xs">
+                  {rating.percentages[i]}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+        <PublicReviews puzzleId={puzzleId} />
+      </div>
+    </main>
+  );
+}
+
+function PublicReviews({ puzzleId }: { puzzleId: string }) {
+  const t = useTranslations("publicCatalog");
+  const format = useFormatter();
+  const { data: reviews } = useQuery(reviewsQuery(puzzleId));
+  const list = reviews ?? [];
+  // Fixed baseline for relative-time formatting — reading Date.now() during render is impure
+  // (react-hooks/purity); seed it once, matching the dashboard detail page.
+  const [now] = useState(() => Date.now());
+
+  return (
+    <section>
+      <SectionHead
+        icon={<MessageCircle className="h-4 w-4" />}
+        title={t("reviews")}
+        meta={String(list.length)}
+      />
+      <div className="flex flex-col">
+        {list.map((review, i) => (
+          <PublicReviewRow
+            key={review.id}
+            review={review}
+            relative={(ts) => format.relativeTime(new Date(ts), now)}
+            last={i === list.length - 1}
+          />
+        ))}
+        {list.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t("noReviews")}</p>
+        )}
+      </div>
+      {/* Read-only surface: in place of the composer, one muted line (spec). */}
+      <p className="text-muted-foreground mt-4 text-sm">
+        <Link
+          href={`/sign-in?redirect_url=${encodeURIComponent(`/catalog/${puzzleId}`)}`}
+          className="hover:underline"
+        >
+          {t("logInToReview")}
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+function PublicReviewRow({
+  review,
+  relative,
+  last,
+}: {
+  review: PublicReview;
+  relative: (timestamp: number) => string;
+  last: boolean;
+}) {
+  const t = useTranslations("publicCatalog");
+  const name = review.author?.name ?? t("anonymousReviewer");
+  return (
+    <div className={cn("flex gap-3 py-3.5", !last && "border-border border-b")}>
+      {review.author ? (
+        <MemberAvatar name={review.author.name} avatar={review.author.avatar} />
+      ) : (
+        <span className="bg-muted text-muted-foreground flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
+          <UserRound className="h-4 w-4" />
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "text-sm font-semibold",
+              review.author
+                ? "text-foreground"
+                : "text-muted-foreground italic",
+            )}
+          >
+            {name}
+          </span>
+          {review.rating != null && (
+            <StarRating value={review.rating} size="sm" />
+          )}
+          <span className="text-muted-foreground text-xs">
+            {relative(review.createdAt)}
+          </span>
+        </div>
+        <p className="text-foreground/90 mt-1 text-sm leading-relaxed">
+          {review.text}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_public/catalog/$id.tsx
+++ b/apps/web/src/routes/_public/catalog/$id.tsx
@@ -48,11 +48,18 @@ export const Route = createFileRoute("/_public/catalog/$id")({
     }
   },
   loader: async ({ context, params }) => {
-    const [view] = await Promise.all([
-      context.queryClient.ensureQueryData(viewQuery(params.id)),
-      context.queryClient.ensureQueryData(reviewsQuery(params.id)),
-    ]);
-    return { view };
+    // A malformed id fails `v.id("puzzles")` arg validation and rejects here. Rather than crash to
+    // the root error boundary, swallow it and let the component render the same friendly not-found
+    // a well-formed-but-nonexistent id shows (which resolves to `null`).
+    try {
+      const [view] = await Promise.all([
+        context.queryClient.ensureQueryData(viewQuery(params.id)),
+        context.queryClient.ensureQueryData(reviewsQuery(params.id)),
+      ]);
+      return { view };
+    } catch {
+      return { view: null };
+    }
   },
   head: ({ loaderData }) => {
     const d = loaderData?.view?.definition;
@@ -77,10 +84,11 @@ export const Route = createFileRoute("/_public/catalog/$id")({
 function PublicPuzzlePage() {
   const { id } = Route.useParams();
   const t = useTranslations("publicCatalog");
-  const { data: view } = useQuery(viewQuery(id));
+  const { data: view, isError } = useQuery(viewQuery(id));
 
-  if (view === undefined) return null; // loader-prefetched; only a hard refetch passes here
-  if (view === null) {
+  // A malformed id makes the query error (arg validation); treat it exactly like a nonexistent id.
+  if (view === undefined && !isError) return null; // loader-prefetched; only a hard refetch passes here
+  if (view === null || isError) {
     return (
       <main className="mx-auto w-full max-w-[1200px] px-6 py-10">
         <EmptyState title={t("notFound")} sub={t("notFoundSub")} />

--- a/apps/web/src/routes/_public/catalog/index.tsx
+++ b/apps/web/src/routes/_public/catalog/index.tsx
@@ -1,0 +1,253 @@
+import { Link } from "@/compat/link";
+import { EmptyState } from "@/components/library/empty-state";
+import { DefinitionCard } from "@/components/puzzles/definition-card";
+import { PuzzleViewProvider } from "@/components/puzzles/puzzle-view-provider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { gateway } from "@/gateway";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import type { FunctionReturnType } from "convex/server";
+import { Search } from "lucide-react";
+import * as React from "react";
+import { useTranslations } from "use-intl";
+
+type BrowseResult = FunctionReturnType<typeof gateway.catalog.publicBrowse>;
+
+const PAGE_SIZE = 20;
+// The default (unfiltered) first page — the loader prefetches EXACTLY these args so the
+// initial render is SSR'd (same pattern as the home page's globalStatsQuery).
+const defaultFirstPageQuery = convexQuery(gateway.catalog.publicBrowse, {
+  paginationOpts: { numItems: PAGE_SIZE, cursor: null },
+});
+
+// Piece-count buckets from the spec: <500 / 500 / 1000 / 1500+.
+const PIECE_BUCKETS = {
+  lt500: { pieceMax: 499 },
+  b500: { pieceMin: 500, pieceMax: 999 },
+  b1000: { pieceMin: 1000, pieceMax: 1499 },
+  b1500: { pieceMin: 1500 },
+} as const;
+type PieceBucket = keyof typeof PIECE_BUCKETS;
+
+export const Route = createFileRoute("/_public/catalog/")({
+  head: () => ({
+    meta: [
+      { title: "Puzzle catalogue — JigSwap" },
+      {
+        name: "description",
+        content:
+          "Browse the JigSwap community puzzle catalogue: ratings, reviews and swap availability for jigsaw puzzles.",
+      },
+      { property: "og:title", content: "Puzzle catalogue — JigSwap" },
+      {
+        property: "og:description",
+        content:
+          "Browse the JigSwap community puzzle catalogue: ratings, reviews and swap availability for jigsaw puzzles.",
+      },
+    ],
+  }),
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(defaultFirstPageQuery);
+  },
+  component: CatalogListPage,
+});
+
+function CatalogListPage() {
+  const t = useTranslations("publicCatalog");
+  const { convexClient } = Route.useRouteContext();
+
+  // Toolbar state. `searchInput` is the raw keystrokes; `searchTerm` is the debounced value the
+  // query actually uses.
+  const [searchInput, setSearchInput] = React.useState("");
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [brand, setBrand] = React.useState<string | undefined>(undefined);
+  const [bucket, setBucket] = React.useState<PieceBucket | undefined>(
+    undefined,
+  );
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => setSearchTerm(searchInput.trim()), 300);
+    return () => clearTimeout(handle);
+  }, [searchInput]);
+
+  const filterArgs = React.useMemo(
+    () => ({
+      ...(searchTerm.length >= 1 ? { searchTerm } : {}),
+      ...(brand ? { brand } : {}),
+      ...(bucket ? PIECE_BUCKETS[bucket] : {}),
+    }),
+    [searchTerm, brand, bucket],
+  );
+
+  // First page: a plain reactive query (SSR'd for the unfiltered default via the loader).
+  const { data: firstPage } = useQuery(
+    convexQuery(gateway.catalog.publicBrowse, {
+      paginationOpts: { numItems: PAGE_SIZE, cursor: null },
+      ...filterArgs,
+    }),
+  );
+
+  // Older pages accumulate in local state; a filter change resets them. We reset during render
+  // (the sanctioned "adjust state when a value changes" pattern) rather than in an effect, which
+  // would trip the react-hooks/set-state-in-effect rule.
+  const [extraPages, setExtraPages] = React.useState<BrowseResult[]>([]);
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const filterKey = JSON.stringify(filterArgs);
+  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setExtraPages([]);
+  }
+
+  const { data: brands } = useQuery(convexQuery(gateway.catalog.allBrands, {}));
+
+  const lastPage = extraPages.at(-1) ?? firstPage;
+  const cards = [
+    ...(firstPage?.page ?? []),
+    ...extraPages.flatMap((p) => p.page),
+  ];
+
+  const loadMore = async () => {
+    if (!lastPage || lastPage.isDone) return;
+    setLoadingMore(true);
+    try {
+      const next = await convexClient.query(gateway.catalog.publicBrowse, {
+        paginationOpts: {
+          numItems: PAGE_SIZE,
+          cursor: lastPage.continueCursor,
+        },
+        ...filterArgs,
+      });
+      setExtraPages((pages) => [...pages, next]);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const clearSearch = () => {
+    setSearchInput("");
+    setSearchTerm("");
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-[1200px] px-6 py-10">
+      <h1 className="font-heading text-3xl font-bold tracking-tight">
+        {t("title")}
+      </h1>
+      <p className="text-muted-foreground mt-1">{t("subtitle")}</p>
+
+      {/* Toolbar: search + brand + piece bucket. One row on >=sm, stacked on mobile. */}
+      <div className="mt-6 flex flex-col gap-2.5 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+          <Input
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder={t("searchPlaceholder")}
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={brand ?? "all"}
+          onValueChange={(v) => setBrand(v === "all" ? undefined : v)}
+        >
+          <SelectTrigger className="w-full sm:w-44">
+            <SelectValue placeholder={t("allBrands")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("allBrands")}</SelectItem>
+            {(brands ?? [])
+              .filter((b): b is string => !!b)
+              .map((b) => (
+                <SelectItem key={b} value={b}>
+                  {b}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={bucket ?? "all"}
+          onValueChange={(v) =>
+            setBucket(v === "all" ? undefined : (v as PieceBucket))
+          }
+        >
+          <SelectTrigger className="w-full sm:w-48">
+            <SelectValue placeholder={t("allPieces")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("allPieces")}</SelectItem>
+            <SelectItem value="lt500">{t("piecesLt500")}</SelectItem>
+            <SelectItem value="b500">{t("pieces500")}</SelectItem>
+            <SelectItem value="b1000">{t("pieces1000")}</SelectItem>
+            <SelectItem value="b1500">{t("pieces1500")}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Grid */}
+      <div className="mt-8">
+        {firstPage === undefined ? (
+          <div className="grid grid-cols-2 gap-[18px] md:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-[3/4] w-full rounded-xl" />
+            ))}
+          </div>
+        ) : cards.length === 0 ? (
+          searchTerm ? (
+            <EmptyState
+              title={t("noResults", { query: searchTerm })}
+              sub={t("noResultsSub")}
+              action={
+                <Button variant="ghost" onClick={clearSearch}>
+                  {t("clearSearch")}
+                </Button>
+              }
+            />
+          ) : (
+            <EmptyState title={t("empty")} sub={t("emptySub")} />
+          )
+        ) : (
+          <>
+            <PuzzleViewProvider
+              viewMode="grid"
+              className="grid grid-cols-2 gap-[18px] md:grid-cols-3 lg:grid-cols-4"
+            >
+              {cards.map((card) => (
+                <DefinitionCard key={card._id} card={card} />
+              ))}
+            </PuzzleViewProvider>
+            {lastPage && !lastPage.isDone && (
+              <div className="mt-8 flex justify-center">
+                <Button
+                  variant="outline"
+                  onClick={() => void loadMore()}
+                  disabled={loadingMore}
+                >
+                  {t("loadMore")}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Conversion tail for logged-out visitors (members get redirected off /catalog/$id anyway,
+          and this static CTA is harmless if they browse the list). */}
+      <div className="mt-12 flex justify-center">
+        <Button variant="brand" asChild>
+          <Link href="/sign-up">{t("joinCta")}</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/routes/_public/catalog/index.tsx
+++ b/apps/web/src/routes/_public/catalog/index.tsx
@@ -108,6 +108,12 @@ function CatalogListPage() {
     setPrevFilterKey(filterKey);
     setExtraPages([]);
   }
+  // Mirror the current filterKey into a ref so an in-flight loadMore can read the LATEST value
+  // after its await (the handler's closed-over `filterKey` is stale by then).
+  const filterKeyRef = React.useRef(filterKey);
+  React.useEffect(() => {
+    filterKeyRef.current = filterKey;
+  }, [filterKey]);
 
   const { data: brands } = useQuery(convexQuery(gateway.catalog.allBrands, {}));
 
@@ -119,6 +125,10 @@ function CatalogListPage() {
 
   const loadMore = async () => {
     if (!lastPage || lastPage.isDone) return;
+    // Capture the filter this page is being fetched under. If the filter changes mid-flight, the
+    // awaited page (and its continueCursor) belong to the OLD filter — drop it rather than append a
+    // foreign page onto the reset list.
+    const requestedFilterKey = filterKey;
     setLoadingMore(true);
     try {
       const next = await convexClient.query(gateway.catalog.publicBrowse, {
@@ -128,6 +138,7 @@ function CatalogListPage() {
         },
         ...filterArgs,
       });
+      if (requestedFilterKey !== filterKeyRef.current) return;
       setExtraPages((pages) => [...pages, next]);
     } finally {
       setLoadingMore(false);

--- a/apps/web/src/routes/robots[.]txt.ts
+++ b/apps/web/src/routes/robots[.]txt.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+// Served dynamically (not a public/ static file) so the Sitemap line can carry the request's own
+// origin — no hardcoded production domain in the repo. Private member teasers are excluded from
+// crawling via their per-page noindex meta (Phase 1), not here.
+export const Route = createFileRoute("/robots.txt")({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const origin = new URL(request.url).origin;
+        const body = [
+          "User-agent: *",
+          "Allow: /",
+          `Sitemap: ${origin}/sitemap.xml`,
+          "",
+        ].join("\n");
+        return new Response(body, {
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -1,6 +1,9 @@
 import { gateway } from "@/gateway";
 import { createFileRoute } from "@tanstack/react-router";
 import { ConvexHttpClient } from "convex/browser";
+import type { FunctionReturnType } from "convex/server";
+
+type SitemapEntries = FunctionReturnType<typeof gateway.catalog.sitemapEntries>;
 
 // Catalog URLs ONLY (Phase 5 spec): public member profiles are indexable but never sitemap-listed;
 // private member teasers carry noindex. Data comes from the unauthenticated listSitemapEntries
@@ -13,7 +16,14 @@ export const Route = createFileRoute("/sitemap.xml")({
         const convex = new ConvexHttpClient(
           import.meta.env.VITE_CONVEX_URL as string,
         );
-        const entries = await convex.query(gateway.catalog.sitemapEntries, {});
+        // Never 500 a public SEO route: if Convex is unreachable, still emit a valid sitemap with
+        // at least the /catalog root, so crawlers keep the catalogue indexed.
+        let entries: SitemapEntries = [];
+        try {
+          entries = await convex.query(gateway.catalog.sitemapEntries, {});
+        } catch {
+          entries = [];
+        }
         const urls = [
           `  <url><loc>${origin}/catalog</loc></url>`,
           ...entries.map(

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -1,0 +1,31 @@
+import { gateway } from "@/gateway";
+import { createFileRoute } from "@tanstack/react-router";
+import { ConvexHttpClient } from "convex/browser";
+
+// Catalog URLs ONLY (Phase 5 spec): public member profiles are indexable but never sitemap-listed;
+// private member teasers carry noindex. Data comes from the unauthenticated listSitemapEntries
+// query via a plain HTTP client (same pattern as lib/require-admin.ts, minus auth).
+export const Route = createFileRoute("/sitemap.xml")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const origin = new URL(request.url).origin;
+        const convex = new ConvexHttpClient(
+          import.meta.env.VITE_CONVEX_URL as string,
+        );
+        const entries = await convex.query(gateway.catalog.sitemapEntries, {});
+        const urls = [
+          `  <url><loc>${origin}/catalog</loc></url>`,
+          ...entries.map(
+            (e) =>
+              `  <url><loc>${origin}/catalog/${e.id}</loc><lastmod>${new Date(e.updatedAt).toISOString()}</lastmod></url>`,
+          ),
+        ].join("\n");
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+        return new Response(xml, {
+          headers: { "Content-Type": "application/xml; charset=utf-8" },
+        });
+      },
+    },
+  },
+});

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as catalog_findPuzzleByBarcode from "../catalog/findPuzzleByBarcod
 import type * as catalog_getAllBrands from "../catalog/getAllBrands.js";
 import type * as catalog_getAllTags from "../catalog/getAllTags.js";
 import type * as catalog_getChangeProposal from "../catalog/getChangeProposal.js";
+import type * as catalog_getPublicDefinitionView from "../catalog/getPublicDefinitionView.js";
 import type * as catalog_getPuzzleById from "../catalog/getPuzzleById.js";
 import type * as catalog_getPuzzleCategories from "../catalog/getPuzzleCategories.js";
 import type * as catalog_getPuzzleSuggestions from "../catalog/getPuzzleSuggestions.js";
@@ -365,6 +366,7 @@ declare const fullApi: ApiFromModules<{
   "catalog/getAllBrands": typeof catalog_getAllBrands;
   "catalog/getAllTags": typeof catalog_getAllTags;
   "catalog/getChangeProposal": typeof catalog_getChangeProposal;
+  "catalog/getPublicDefinitionView": typeof catalog_getPublicDefinitionView;
   "catalog/getPuzzleById": typeof catalog_getPuzzleById;
   "catalog/getPuzzleCategories": typeof catalog_getPuzzleCategories;
   "catalog/getPuzzleSuggestions": typeof catalog_getPuzzleSuggestions;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -287,6 +287,7 @@ import type * as social_knownFollowers from "../social/knownFollowers.js";
 import type * as social_listFollowees from "../social/listFollowees.js";
 import type * as social_listFollowers from "../social/listFollowers.js";
 import type * as social_listIncomingFollowRequests from "../social/listIncomingFollowRequests.js";
+import type * as social_listPublicPuzzleReviews from "../social/listPublicPuzzleReviews.js";
 import type * as social_listPuzzleComments from "../social/listPuzzleComments.js";
 import type * as social_listPuzzleReviews from "../social/listPuzzleReviews.js";
 import type * as social_postPuzzleComment from "../social/postPuzzleComment.js";
@@ -608,6 +609,7 @@ declare const fullApi: ApiFromModules<{
   "social/listFollowees": typeof social_listFollowees;
   "social/listFollowers": typeof social_listFollowers;
   "social/listIncomingFollowRequests": typeof social_listIncomingFollowRequests;
+  "social/listPublicPuzzleReviews": typeof social_listPublicPuzzleReviews;
   "social/listPuzzleComments": typeof social_listPuzzleComments;
   "social/listPuzzleReviews": typeof social_listPuzzleReviews;
   "social/postPuzzleComment": typeof social_postPuzzleComment;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as catalog_adapters_systemClock from "../catalog/adapters/systemCl
 import type * as catalog_approveChangeProposal from "../catalog/approveChangeProposal.js";
 import type * as catalog_approvePuzzleDefinition from "../catalog/approvePuzzleDefinition.js";
 import type * as catalog_backfillCategories from "../catalog/backfillCategories.js";
+import type * as catalog_browsePublicCatalog from "../catalog/browsePublicCatalog.js";
 import type * as catalog_createCatalogCategory from "../catalog/createCatalogCategory.js";
 import type * as catalog_disablePuzzleDefinition from "../catalog/disablePuzzleDefinition.js";
 import type * as catalog_editChangeProposal from "../catalog/editChangeProposal.js";
@@ -358,6 +359,7 @@ declare const fullApi: ApiFromModules<{
   "catalog/approveChangeProposal": typeof catalog_approveChangeProposal;
   "catalog/approvePuzzleDefinition": typeof catalog_approvePuzzleDefinition;
   "catalog/backfillCategories": typeof catalog_backfillCategories;
+  "catalog/browsePublicCatalog": typeof catalog_browsePublicCatalog;
   "catalog/createCatalogCategory": typeof catalog_createCatalogCategory;
   "catalog/disablePuzzleDefinition": typeof catalog_disablePuzzleDefinition;
   "catalog/editChangeProposal": typeof catalog_editChangeProposal;

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -60,6 +60,7 @@ import type * as catalog_listMyFavorites from "../catalog/listMyFavorites.js";
 import type * as catalog_listPendingChangeProposals from "../catalog/listPendingChangeProposals.js";
 import type * as catalog_listPendingPuzzleDefinitions from "../catalog/listPendingPuzzleDefinitions.js";
 import type * as catalog_listProposalsForDefinition from "../catalog/listProposalsForDefinition.js";
+import type * as catalog_listSitemapEntries from "../catalog/listSitemapEntries.js";
 import type * as catalog_mappers from "../catalog/mappers.js";
 import type * as catalog_myFavoritePuzzleIds from "../catalog/myFavoritePuzzleIds.js";
 import type * as catalog_proposeDefinitionChange from "../catalog/proposeDefinitionChange.js";
@@ -383,6 +384,7 @@ declare const fullApi: ApiFromModules<{
   "catalog/listPendingChangeProposals": typeof catalog_listPendingChangeProposals;
   "catalog/listPendingPuzzleDefinitions": typeof catalog_listPendingPuzzleDefinitions;
   "catalog/listProposalsForDefinition": typeof catalog_listProposalsForDefinition;
+  "catalog/listSitemapEntries": typeof catalog_listSitemapEntries;
   "catalog/mappers": typeof catalog_mappers;
   "catalog/myFavoritePuzzleIds": typeof catalog_myFavoritePuzzleIds;
   "catalog/proposeDefinitionChange": typeof catalog_proposeDefinitionChange;

--- a/packages/backend/convex/catalog/browsePublicCatalog.ts
+++ b/packages/backend/convex/catalog/browsePublicCatalog.ts
@@ -1,0 +1,114 @@
+import type { PublicCatalogCardView } from "@jigswap/contracts";
+import { type PaginationResult, paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import type { Doc } from "../_generated/dataModel";
+import { query } from "../_generated/server";
+import {
+  publicAvailabilityOf,
+  ratingBreakdownOf,
+} from "../library/definitionAggregates";
+
+// UNAUTHENTICATED paginated catalog list for the public /catalog page: approved definitions only
+// (the standard leak gate), newest first, optionally narrowed by a search term (search index,
+// status-filtered at the index), brand, and a piece-count range. Each page row is enriched with
+// the card aggregates (rating summary + public availability count).
+//
+// Sort is newest-first ONLY: sorting by rating would require a denormalized per-definition rating
+// (a computed aggregate can't order a paginated index scan) — deliberately deferred.
+export const browsePublicCatalog = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    searchTerm: v.optional(v.string()),
+    brand: v.optional(v.string()),
+    pieceMin: v.optional(v.number()),
+    pieceMax: v.optional(v.number()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<PaginationResult<PublicCatalogCardView>> => {
+    const term = args.searchTerm?.toLowerCase().trim() ?? "";
+
+    // brand/piece narrowing shared by both branches (status is handled per-branch: at the search
+    // index for the search branch, as a filter for the plain branch).
+    const matchesFacets = (p: Doc<"puzzles">): boolean =>
+      (args.brand === undefined || p.brand === args.brand) &&
+      (args.pieceMin === undefined || p.pieceCount >= args.pieceMin) &&
+      (args.pieceMax === undefined || p.pieceCount <= args.pieceMax);
+
+    const result =
+      term.length > 0
+        ? await ctx.db
+            .query("puzzles")
+            .withSearchIndex("by_searchable_text", (q) =>
+              q.search("searchableText", term).eq("status", "approved"),
+            )
+            .filter((q) =>
+              q.and(
+                args.brand === undefined
+                  ? q.eq(q.field("status"), "approved") // no-op placeholder keeps the AND non-empty
+                  : q.eq(q.field("brand"), args.brand),
+                args.pieceMin === undefined
+                  ? q.eq(q.field("status"), "approved")
+                  : q.gte(q.field("pieceCount"), args.pieceMin),
+                args.pieceMax === undefined
+                  ? q.eq(q.field("status"), "approved")
+                  : q.lte(q.field("pieceCount"), args.pieceMax),
+              ),
+            )
+            .paginate(args.paginationOpts)
+        : await ctx.db
+            .query("puzzles")
+            .order("desc") // newest first by _creationTime
+            .filter((q) =>
+              q.and(
+                q.eq(q.field("status"), "approved"),
+                args.brand === undefined
+                  ? q.eq(q.field("status"), "approved")
+                  : q.eq(q.field("brand"), args.brand),
+                args.pieceMin === undefined
+                  ? q.eq(q.field("status"), "approved")
+                  : q.gte(q.field("pieceCount"), args.pieceMin),
+                args.pieceMax === undefined
+                  ? q.eq(q.field("status"), "approved")
+                  : q.lte(q.field("pieceCount"), args.pieceMax),
+              ),
+            )
+            .paginate(args.paginationOpts);
+
+    // Belt-and-braces: the branches above already gate status/facets, but the enrichment below is
+    // the last line of defence against a future filter regression leaking a pending row.
+    const rows = result.page.filter(
+      (p) => p.status === "approved" && matchesFacets(p),
+    );
+
+    // Shared owner-visibility cache so each distinct owner across the page resolves once.
+    const visibilityCache = new Map<string, "public" | "private">();
+    const page: PublicCatalogCardView[] = await Promise.all(
+      rows.map(async (puzzle) => {
+        const rating = await ratingBreakdownOf(ctx, puzzle._id);
+        const owned = await ctx.db
+          .query("ownedPuzzles")
+          .withIndex("by_puzzle", (q) => q.eq("puzzleId", puzzle._id))
+          .collect();
+        const availability = await publicAvailabilityOf(
+          ctx,
+          owned,
+          visibilityCache,
+        );
+        return {
+          _id: puzzle._id,
+          title: puzzle.title,
+          brand: puzzle.brand,
+          pieceCount: puzzle.pieceCount,
+          difficulty: puzzle.difficulty,
+          image: puzzle.image ? await ctx.storage.getUrl(puzzle.image) : null,
+          rating: { value: rating.rating, count: rating.count },
+          availableToSwap: availability.total,
+        };
+      }),
+    );
+
+    return { ...result, page };
+  },
+});

--- a/packages/backend/convex/catalog/getPublicDefinitionView.ts
+++ b/packages/backend/convex/catalog/getPublicDefinitionView.ts
@@ -1,0 +1,66 @@
+import type { PublicDefinitionDetailView } from "@jigswap/contracts";
+import { v } from "convex/values";
+import { query } from "../_generated/server";
+import {
+  categoryNameOf,
+  completionStatsOf,
+  publicAvailabilityOf,
+  ratingBreakdownOf,
+} from "../library/definitionAggregates";
+
+// UNAUTHENTICATED catalog detail for the public /catalog/$id page. Approved-only (the standard
+// catalog leak gate) and strictly member-free: catalog facts, the community rating breakdown,
+// completion stats, and the PUBLIC availability aggregate — never owner identities, copy rows,
+// prices, or locations. The availability number intentionally differs from the member-facing
+// getPuzzleDefinitionView (no circle reachability, no viewer-own exclusion); see
+// publicAvailabilityOf. Members never see this page — the web route redirects them to /puzzles/$id.
+export const getPublicDefinitionView = query({
+  args: { puzzleId: v.id("puzzles") },
+  handler: async (ctx, args): Promise<PublicDefinitionDetailView | null> => {
+    const puzzle = await ctx.db.get(args.puzzleId);
+    if (!puzzle || puzzle.status !== "approved") return null;
+
+    const image = puzzle.image
+      ? ((await ctx.storage.getUrl(puzzle.image)) ?? undefined)
+      : undefined;
+    const categoryRow = puzzle.category
+      ? await ctx.db.get(puzzle.category)
+      : null;
+
+    const rating = await ratingBreakdownOf(ctx, args.puzzleId);
+
+    const owned = await ctx.db
+      .query("ownedPuzzles")
+      .withIndex("by_puzzle", (q) => q.eq("puzzleId", args.puzzleId))
+      .collect();
+    const communityOwners = new Set(
+      owned.map((c) => c.ownerId as unknown as string),
+    ).size;
+    const availability = await publicAvailabilityOf(ctx, owned);
+    const { totalCompletions, avgCompletionDays } = await completionStatsOf(
+      ctx,
+      args.puzzleId,
+      owned,
+    );
+
+    return {
+      definition: {
+        title: puzzle.title,
+        description: puzzle.description,
+        brand: puzzle.brand,
+        artist: puzzle.artist,
+        series: puzzle.series,
+        pieceCount: puzzle.pieceCount,
+        image,
+        difficulty: puzzle.difficulty,
+        categoryName: categoryNameOf(categoryRow),
+        tags: puzzle.tags ?? [],
+        shape: puzzle.shape,
+        dimensions: puzzle.dimensions,
+      },
+      rating,
+      stats: { communityOwners, totalCompletions, avgCompletionDays },
+      availability,
+    };
+  },
+});

--- a/packages/backend/convex/catalog/listSitemapEntries.ts
+++ b/packages/backend/convex/catalog/listSitemapEntries.ts
@@ -1,0 +1,16 @@
+import { query } from "../_generated/server";
+
+// UNAUTHENTICATED feed for the /sitemap.xml server route: every approved definition's id +
+// updatedAt (for <lastmod>). Catalog URLs ONLY — member profiles are deliberately not
+// sitemap-listed (Phase 5 spec). A full collect() is fine at the current catalog scale; if the
+// catalog ever grows past ~10k definitions, page this and stream the sitemap instead.
+export const listSitemapEntries = query({
+  args: {},
+  handler: async (ctx): Promise<{ id: string; updatedAt: number }[]> => {
+    const puzzles = await ctx.db
+      .query("puzzles")
+      .filter((q) => q.eq(q.field("status"), "approved"))
+      .collect();
+    return puzzles.map((p) => ({ id: p._id, updatedAt: p.updatedAt }));
+  },
+});

--- a/packages/backend/convex/library/definitionAggregates.ts
+++ b/packages/backend/convex/library/definitionAggregates.ts
@@ -1,0 +1,176 @@
+// Shared aggregate helpers over a puzzle DEFINITION, used by BOTH the auth-gated member detail
+// (getPuzzleDefinitionView) and the unauthenticated public catalog reads. Moved verbatim from
+// getPuzzleDefinitionView.ts so the two views can't drift on the shared math.
+
+import type { CopyOfferSwapType } from "@jigswap/contracts";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import { profileVisibilityOf } from "../social/privacy";
+
+const MS_PER_DAY = 86_400_000;
+
+/** Round to 1 decimal place. */
+export const round1 = (n: number): number => Math.round(n * 10) / 10;
+
+/** Whole-day solve duration: prefer (endDate - startDate) rounded to whole days; else fall back to
+ * completionTimeMinutes / 1440 rounded; else null when neither is recorded. */
+export const finishDaysOf = (c: {
+  startDate: number;
+  endDate?: number;
+  completionTimeMinutes?: number;
+}): number | null => {
+  if (c.endDate != null) {
+    return Math.round((c.endDate - c.startDate) / MS_PER_DAY);
+  }
+  if (c.completionTimeMinutes != null) {
+    return Math.round(c.completionTimeMinutes / 1440);
+  }
+  return null;
+};
+
+/** A copy is "open" iff at least one exchange-availability flag is set (identical to browseOwnedPuzzles). */
+export const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
+  copy.availability.forTrade ||
+  copy.availability.forSale ||
+  copy.availability.forLend;
+
+/** Availability priority -> swapType: forTrade -> "swap", forLend -> "lend", forSale -> "sale". */
+export const swapTypeOf = (copy: Doc<"ownedPuzzles">): CopyOfferSwapType => {
+  if (copy.availability.forTrade) return "swap";
+  if (copy.availability.forLend) return "lend";
+  return "sale";
+};
+
+/** The adminCategories name is localized `{ en, nl }`; the detail pages want a single string (English).
+ * Defensive against legacy/raw string shapes. */
+export const categoryNameOf = (
+  row: Doc<"adminCategories"> | null,
+): string | undefined => {
+  if (!row) return undefined;
+  const name = row.name as unknown;
+  if (typeof name === "string") return name;
+  if (name && typeof name === "object" && "en" in name) {
+    const en = (name as { en?: unknown }).en;
+    if (typeof en === "string") return en;
+  }
+  return undefined;
+};
+
+export interface RatingBreakdown {
+  rating: number;
+  count: number;
+  breakdown: [number, number, number, number, number];
+  percentages: [number, number, number, number, number];
+}
+
+/** Community rating distribution over DEFINITION-level reviews (puzzleComments with a rating and
+ * copyId == null). breakdown index 0..4 == [5★..1★]. */
+export const ratingBreakdownOf = async (
+  ctx: QueryCtx,
+  puzzleId: Id<"puzzles">,
+): Promise<RatingBreakdown> => {
+  const comments = await ctx.db
+    .query("puzzleComments")
+    .withIndex("by_puzzle", (q) => q.eq("puzzleId", puzzleId))
+    .collect();
+  const ratedReviews = comments.filter(
+    (c) => c.rating != null && c.copyId == null,
+  );
+  const breakdown: [number, number, number, number, number] = [0, 0, 0, 0, 0];
+  let ratingSum = 0;
+  for (const c of ratedReviews) {
+    const r = c.rating as number;
+    ratingSum += r;
+    const bucket = 5 - r; // r=5 -> 0, r=1 -> 4
+    if (bucket >= 0 && bucket <= 4) breakdown[bucket] += 1;
+  }
+  const ratingCount = ratedReviews.length;
+  const pct = (n: number): number =>
+    ratingCount > 0 ? Math.round((n / ratingCount) * 100) : 0;
+  return {
+    rating: ratingCount > 0 ? round1(ratingSum / ratingCount) : 0,
+    count: ratingCount,
+    breakdown,
+    percentages: [
+      pct(breakdown[0]),
+      pct(breakdown[1]),
+      pct(breakdown[2]),
+      pct(breakdown[3]),
+      pct(breakdown[4]),
+    ],
+  };
+};
+
+/** Completion aggregate for a definition: count of finished solves + average whole-day duration.
+ * A solve is recorded against the definition (puzzleId) OR against a copy (ownedPuzzleId only);
+ * both are counted, deduped by _id. `ownedCopies` is the definition's ownedPuzzles rows (the caller
+ * already has them). */
+export const completionStatsOf = async (
+  ctx: QueryCtx,
+  puzzleId: Id<"puzzles">,
+  ownedCopies: Doc<"ownedPuzzles">[],
+): Promise<{ totalCompletions: number; avgCompletionDays: number | null }> => {
+  const byDefinition = await ctx.db
+    .query("completions")
+    .withIndex("by_puzzle", (q) => q.eq("puzzleId", puzzleId))
+    .collect();
+  const byCopy = (
+    await Promise.all(
+      ownedCopies.map((copy) =>
+        ctx.db
+          .query("completions")
+          .withIndex("by_owned_puzzle", (q) => q.eq("ownedPuzzleId", copy._id))
+          .collect(),
+      ),
+    )
+  ).flat();
+  const deduped = new Map<string, (typeof byDefinition)[number]>();
+  for (const c of [...byDefinition, ...byCopy]) {
+    deduped.set(c._id as unknown as string, c);
+  }
+  const completed = [...deduped.values()].filter((c) => c.isCompleted);
+  const finishDaysList = completed
+    .map(finishDaysOf)
+    .filter((d): d is number => d != null);
+  return {
+    totalCompletions: completed.length,
+    avgCompletionDays:
+      finishDaysList.length > 0
+        ? round1(
+            finishDaysList.reduce((s, d) => s + d, 0) / finishDaysList.length,
+          )
+        : null,
+  };
+};
+
+/** PUBLIC availability aggregate: open copies whose owner's profile is PUBLIC, each counted once
+ * under its priority swap type. No circle reachability and no viewer exclusion — there is no
+ * viewer. This count is intentionally NOT equal to the member-facing stats.availableToSwap (which
+ * adds circle-shared copies and excludes the viewer's own copies); the asymmetry is by design per
+ * the Phase 5 spec — do not "fix" it. Pass a shared `visibilityCache` when aggregating many
+ * definitions in one request (the list page) so each owner is resolved once. */
+export const publicAvailabilityOf = async (
+  ctx: QueryCtx,
+  ownedCopies: Doc<"ownedPuzzles">[],
+  visibilityCache: Map<string, "public" | "private"> = new Map(),
+): Promise<{
+  total: number;
+  byType: { swap: number; lend: number; sale: number };
+}> => {
+  const ownerIsPublic = async (ownerId: Id<"users">): Promise<boolean> => {
+    const key = ownerId as unknown as string;
+    let cached = visibilityCache.get(key);
+    if (cached === undefined) {
+      cached = await profileVisibilityOf(ctx, ownerId);
+      visibilityCache.set(key, cached);
+    }
+    return cached === "public";
+  };
+  const byType = { swap: 0, lend: 0, sale: 0 };
+  for (const copy of ownedCopies.filter(isOpen)) {
+    if (await ownerIsPublic(copy.ownerId)) {
+      byType[swapTypeOf(copy)] += 1;
+    }
+  }
+  return { total: byType.swap + byType.lend + byType.sale, byType };
+};

--- a/packages/backend/convex/library/getPuzzleDefinitionView.ts
+++ b/packages/backend/convex/library/getPuzzleDefinitionView.ts
@@ -1,5 +1,4 @@
 import type {
-  CopyOfferSwapType,
   CopyOfferView,
   PuzzleDefinitionDetailView,
 } from "@jigswap/contracts";
@@ -9,57 +8,13 @@ import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
 import { profileVisibilityOf } from "../social/privacy";
 import { collectCircleSharedCopies } from "./circleSharedCopies";
-
-const MS_PER_DAY = 86_400_000;
-
-// Round to 1 decimal place.
-const round1 = (n: number): number => Math.round(n * 10) / 10;
-
-// Whole-day solve duration: prefer (endDate - startDate) rounded to whole days; else fall back to
-// completionTimeMinutes / 1440 rounded; else null when neither is recorded. Mirrors getCopyInstanceView.
-const finishDaysOf = (c: {
-  startDate: number;
-  endDate?: number;
-  completionTimeMinutes?: number;
-}): number | null => {
-  if (c.endDate != null) {
-    return Math.round((c.endDate - c.startDate) / MS_PER_DAY);
-  }
-  if (c.completionTimeMinutes != null) {
-    return Math.round(c.completionTimeMinutes / 1440);
-  }
-  return null;
-};
-
-// A copy is "open" iff at least one exchange-availability flag is set (identical to browseOwnedPuzzles).
-const isOpen = (copy: Doc<"ownedPuzzles">): boolean =>
-  copy.availability.forTrade ||
-  copy.availability.forSale ||
-  copy.availability.forLend;
-
-// Availability priority -> swapType, matching the contract: forTrade -> "swap", forLend -> "lend",
-// forSale -> "sale" (first set wins). A reachable available copy always has at least one flag set.
-const swapTypeOf = (copy: Doc<"ownedPuzzles">): CopyOfferSwapType => {
-  if (copy.availability.forTrade) return "swap";
-  if (copy.availability.forLend) return "lend";
-  return "sale";
-};
-
-// The category name is a localized object `{ en, nl }` on adminCategories; the catalog reads carry it
-// whole. Here the detail page wants a single string, so we pick English. Defensive against legacy/raw
-// string shapes.
-const categoryNameOf = (
-  row: Doc<"adminCategories"> | null,
-): string | undefined => {
-  if (!row) return undefined;
-  const name = row.name as unknown;
-  if (typeof name === "string") return name;
-  if (name && typeof name === "object" && "en" in name) {
-    const en = (name as { en?: unknown }).en;
-    if (typeof en === "string") return en;
-  }
-  return undefined;
-};
+import {
+  categoryNameOf,
+  completionStatsOf,
+  isOpen,
+  ratingBreakdownOf,
+  swapTypeOf,
+} from "./definitionAggregates";
 
 // Auth-gated catalog detail read for a puzzle DEFINITION (not a single copy). Aggregates the
 // community's review-rating distribution, ownership/completion stats, the viewer's own ownership, and
@@ -94,40 +49,7 @@ export const getPuzzleDefinitionView = query({
     };
 
     // --- rating (over `puzzleComments` that carry a rating — these ARE the reviews) ------------
-    const comments = await ctx.db
-      .query("puzzleComments")
-      .withIndex("by_puzzle", (q) => q.eq("puzzleId", args.puzzleId))
-      .collect();
-    // Community rating draws on DEFINITION-level reviews only; copy-scoped comments (copyId set) are
-    // a copy owner's private rating and never feed the shared community score.
-    const ratedReviews = comments.filter(
-      (c) => c.rating != null && c.copyId == null,
-    );
-    // breakdown index 0..4 == [5★,4★,3★,2★,1★].
-    const breakdown: [number, number, number, number, number] = [0, 0, 0, 0, 0];
-    let ratingSum = 0;
-    for (const c of ratedReviews) {
-      const r = c.rating as number;
-      ratingSum += r;
-      const bucket = 5 - r; // r=5 -> 0, r=1 -> 4
-      if (bucket >= 0 && bucket <= 4) breakdown[bucket] += 1;
-    }
-    const ratingCount = ratedReviews.length;
-    const pct = (n: number): number =>
-      ratingCount > 0 ? Math.round((n / ratingCount) * 100) : 0;
-    const percentages: [number, number, number, number, number] = [
-      pct(breakdown[0]),
-      pct(breakdown[1]),
-      pct(breakdown[2]),
-      pct(breakdown[3]),
-      pct(breakdown[4]),
-    ];
-    const rating = {
-      rating: ratingCount > 0 ? round1(ratingSum / ratingCount) : 0,
-      count: ratingCount,
-      breakdown,
-      percentages,
-    };
+    const rating = await ratingBreakdownOf(ctx, args.puzzleId);
 
     // --- ownedPuzzles for this definition (drives owners count, viewer ownership, copies) -------
     const owned = await ctx.db
@@ -140,41 +62,11 @@ export const getPuzzleDefinitionView = query({
     );
 
     // --- completions of the definition (totalCompletions, avgCompletionDays) --------------------
-    // A solve can be recorded against the puzzle DEFINITION (puzzleId) OR against a specific COPY
-    // of it (ownedPuzzleId, with no puzzleId — that's how "mark my copy complete" stores it). Count
-    // both so completing your own copy still shows in the catalogue total; dedupe by _id in case a
-    // row carries both FKs.
-    const byDefinition = await ctx.db
-      .query("completions")
-      .withIndex("by_puzzle", (q) => q.eq("puzzleId", args.puzzleId))
-      .collect();
-    const byCopy = (
-      await Promise.all(
-        owned.map((copy) =>
-          ctx.db
-            .query("completions")
-            .withIndex("by_owned_puzzle", (q) =>
-              q.eq("ownedPuzzleId", copy._id),
-            )
-            .collect(),
-        ),
-      )
-    ).flat();
-    const dedupedCompletions = new Map<string, (typeof byDefinition)[number]>();
-    for (const c of [...byDefinition, ...byCopy]) {
-      dedupedCompletions.set(c._id as unknown as string, c);
-    }
-    const completions = [...dedupedCompletions.values()];
-    const completed = completions.filter((c) => c.isCompleted);
-    const finishDaysList = completed
-      .map(finishDaysOf)
-      .filter((d): d is number => d != null);
-    const avgCompletionDays =
-      finishDaysList.length > 0
-        ? round1(
-            finishDaysList.reduce((s, d) => s + d, 0) / finishDaysList.length,
-          )
-        : null;
+    const { totalCompletions, avgCompletionDays } = await completionStatsOf(
+      ctx,
+      args.puzzleId,
+      owned,
+    );
 
     // --- reachability gate (replicated from browseOwnedPuzzles/circleSharedCopies) --------------
     // An available copy is shown iff its owner's profile is PUBLIC, OR the copy is shared into a
@@ -285,7 +177,7 @@ export const getPuzzleDefinitionView = query({
       rating,
       stats: {
         communityOwners: distinctOwners.size,
-        totalCompletions: completed.length,
+        totalCompletions,
         avgCompletionDays,
         availableToSwap,
       },

--- a/packages/backend/convex/publicCatalog.test.ts
+++ b/packages/backend/convex/publicCatalog.test.ts
@@ -21,7 +21,7 @@ const mkUser = (
     email: `${clerkId}@example.com`,
     name,
     username: clerkId,
-    avatar: `https://avatars/${clerkId}.png`,
+    avatar: `https://avatars/${clerkId.replace("clerk_", "")}.png`,
     location: "Utrecht",
     shareAvatarPublicly: extra.shareAvatarPublicly,
     isActive: true,
@@ -233,5 +233,75 @@ describe("getPublicDefinitionView", () => {
     expect(raw).not.toContain("clerk_");
     expect(raw).not.toContain("Utrecht");
     expect(raw).not.toContain("condition");
+  });
+});
+
+describe("listPublicPuzzleReviews", () => {
+  test("names public-profile authors, anonymizes private-profile authors", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const reviews = await t.query(
+      api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
+      { puzzleId: approved },
+    );
+    // Newest first: rev-priya (private author), then rev-pia (public author).
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0].author).toBeNull(); // Priya: private profile -> "A JigSwap member"
+    expect(reviews[0].text).toBe("Tough edges!");
+    expect(reviews[1].author?.name).toBe("Pia Public");
+    // Pia consented (shareAvatarPublicly: true) -> avatar included.
+    expect(reviews[1].author?.avatar).toBe("https://avatars/pia.png");
+  });
+
+  test("withholds the avatar without shareAvatarPublicly consent, even for public profiles", async () => {
+    const t = convexTest(schema, modules);
+    const { approved, paul } = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("puzzleComments", {
+        aggregateId: "rev-paul",
+        puzzleId: approved,
+        authorId: paul,
+        text: "Great fit.",
+        rating: 4,
+        createdAt: NOW + 10,
+      });
+    });
+
+    const reviews = await t.query(
+      api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
+      { puzzleId: approved },
+    );
+    const paulsReview = reviews.find((r) => r.text === "Great fit.");
+    expect(paulsReview?.author?.name).toBe("Paul Public");
+    expect(paulsReview?.author?.avatar).toBeNull();
+  });
+
+  test("returns [] for a non-approved definition (reviews must not leak)", async () => {
+    const t = convexTest(schema, modules);
+    const { pending } = await seed(t);
+
+    expect(
+      await t.query(
+        api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
+        { puzzleId: pending },
+      ),
+    ).toEqual([]);
+  });
+
+  test("payload never carries username/location/bio/member ids", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const raw = JSON.stringify(
+      await t.query(
+        api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
+        { puzzleId: approved },
+      ),
+    );
+    expect(raw).not.toContain("clerk_"); // usernames equal clerk ids in the seed
+    expect(raw).not.toContain("Utrecht");
+    expect(raw).not.toContain("authorId");
+    expect(raw).not.toContain("email");
   });
 });

--- a/packages/backend/convex/publicCatalog.test.ts
+++ b/packages/backend/convex/publicCatalog.test.ts
@@ -1,0 +1,237 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const NOW = 1_000_000;
+
+const mkUser = (
+  ctx: MutationCtx,
+  clerkId: string,
+  name: string,
+  extra: { shareAvatarPublicly?: boolean } = {},
+) =>
+  ctx.db.insert("users", {
+    clerkId,
+    email: `${clerkId}@example.com`,
+    name,
+    username: clerkId,
+    avatar: `https://avatars/${clerkId}.png`,
+    location: "Utrecht",
+    shareAvatarPublicly: extra.shareAvatarPublicly,
+    isActive: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+
+const mkProfile = (
+  ctx: MutationCtx,
+  memberId: Id<"users">,
+  visibility: "public" | "private",
+) =>
+  ctx.db.insert("profiles", {
+    aggregateId: `prof-${memberId}`,
+    memberId,
+    displayName: "X",
+    visibility,
+    updatedAt: NOW,
+  });
+
+const mkCopy = (
+  ctx: MutationCtx,
+  slug: string,
+  puzzleId: Id<"puzzles">,
+  ownerId: Id<"users">,
+  availability: { forTrade: boolean; forSale: boolean; forLend: boolean },
+) =>
+  ctx.db.insert("ownedPuzzles", {
+    aggregateId: `copy-${slug}`,
+    puzzleId,
+    ownerId,
+    condition: "good",
+    availability,
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+
+// Seed: an approved + a pending definition, three owners (public/public/private profiles) with
+// open + closed copies, and reviews by a public- and a private-profile author.
+const seed = async (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const pia = await mkUser(ctx, "clerk_pia", "Pia Public", {
+      shareAvatarPublicly: true,
+    });
+    const paul = await mkUser(ctx, "clerk_paul", "Paul Public"); // no avatar consent
+    const priya = await mkUser(ctx, "clerk_priya", "Priya Private");
+    await mkProfile(ctx, pia, "public");
+    await mkProfile(ctx, paul, "public");
+    await mkProfile(ctx, priya, "private");
+
+    const approved = await ctx.db.insert("puzzles", {
+      aggregateId: "def-approved",
+      title: "Mountain Vista",
+      brand: "Ravensburger",
+      pieceCount: 1000,
+      difficulty: "hard",
+      tags: ["nature"],
+      searchableText: "mountain vista ravensburger",
+      status: "approved",
+      submittedBy: pia,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const pending = await ctx.db.insert("puzzles", {
+      aggregateId: "def-pending",
+      title: "Secret Ocean",
+      brand: "Clementoni",
+      pieceCount: 500,
+      searchableText: "secret ocean clementoni",
+      status: "pending",
+      submittedBy: pia,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    // Copies of the approved puzzle:
+    //  pia (public):   open forTrade  -> counts as "swap"
+    //  paul (public):  open forLend   -> counts as "lend"
+    //  paul (public):  closed         -> not counted (but still an owner)
+    //  priya (private): open forTrade -> NOT counted publicly
+    await mkCopy(ctx, "pia-trade", approved, pia, {
+      forTrade: true,
+      forSale: false,
+      forLend: false,
+    });
+    await mkCopy(ctx, "paul-lend", approved, paul, {
+      forTrade: false,
+      forSale: false,
+      forLend: true,
+    });
+    await mkCopy(ctx, "paul-closed", approved, paul, {
+      forTrade: false,
+      forSale: false,
+      forLend: false,
+    });
+    await mkCopy(ctx, "priya-trade", approved, priya, {
+      forTrade: true,
+      forSale: false,
+      forLend: false,
+    });
+
+    // Definition-level reviews (copyId == null): one by a public profile, one by a private one.
+    await ctx.db.insert("puzzleComments", {
+      aggregateId: "rev-pia",
+      puzzleId: approved,
+      authorId: pia,
+      text: "Lovely gradient sky.",
+      rating: 5,
+      createdAt: NOW + 1,
+    });
+    await ctx.db.insert("puzzleComments", {
+      aggregateId: "rev-priya",
+      puzzleId: approved,
+      authorId: priya,
+      text: "Tough edges!",
+      rating: 3,
+      createdAt: NOW + 2,
+    });
+    // A review on the PENDING puzzle must never surface publicly.
+    await ctx.db.insert("puzzleComments", {
+      aggregateId: "rev-pending",
+      puzzleId: pending,
+      authorId: pia,
+      text: "Should not leak.",
+      rating: 4,
+      createdAt: NOW + 3,
+    });
+
+    return { pia, paul, priya, approved, pending };
+  });
+
+describe("getPublicDefinitionView", () => {
+  test("returns catalog facts + aggregates for an approved definition, unauthenticated", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const view = await t.query(
+      api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+      { puzzleId: approved },
+    );
+    expect(view).not.toBeNull();
+    expect(view?.definition.title).toBe("Mountain Vista");
+    expect(view?.definition.brand).toBe("Ravensburger");
+    expect(view?.definition.pieceCount).toBe(1000);
+    // Rating over the two definition reviews: (5+3)/2 = 4.
+    expect(view?.rating.rating).toBe(4);
+    expect(view?.rating.count).toBe(2);
+    // 3 distinct owners overall.
+    expect(view?.stats.communityOwners).toBe(3);
+  });
+
+  test("availability counts only OPEN copies of PUBLIC-profile owners, with per-type breakdown", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const view = await t.query(
+      api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+      { puzzleId: approved },
+    );
+    // pia's forTrade (swap) + paul's forLend (lend). priya's open copy is private-owner; paul's
+    // closed copy is not open. NOTE: this intentionally differs from the member-facing count.
+    expect(view?.availability).toEqual({
+      total: 2,
+      byType: { swap: 1, lend: 1, sale: 0 },
+    });
+  });
+
+  test("public availability is intentionally asymmetric to the member-facing count (private owner + closed copy excluded)", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const view = await t.query(
+      api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+      { puzzleId: approved },
+    );
+    // There are 3 OPEN copies of this definition (pia swap, paul lend, priya swap) plus 1 closed.
+    // The public view counts only the 2 open copies of PUBLIC-profile owners — it deliberately
+    // excludes priya's open copy (private owner). This asymmetry is by design (publicAvailabilityOf
+    // has no circle reachability and no viewer): the public total (2) must be LESS than the raw
+    // open-copy total (3), proving the private owner's copy never leaks into the public count.
+    expect(view?.availability.total).toBe(2);
+    expect(view?.availability.total).toBeLessThan(3);
+  });
+
+  test("returns null for a non-approved definition", async () => {
+    const t = convexTest(schema, modules);
+    const { pending } = await seed(t);
+
+    expect(
+      await t.query(
+        api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+        { puzzleId: pending },
+      ),
+    ).toBeNull();
+  });
+
+  test("payload leaks no member identity or copy-level data", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const view = await t.query(
+      api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+      { puzzleId: approved },
+    );
+    const raw = JSON.stringify(view);
+    expect(raw).not.toContain("ownerId");
+    expect(raw).not.toContain("Pia Public");
+    expect(raw).not.toContain("Priya Private");
+    expect(raw).not.toContain("clerk_");
+    expect(raw).not.toContain("Utrecht");
+    expect(raw).not.toContain("condition");
+  });
+});

--- a/packages/backend/convex/publicCatalog.test.ts
+++ b/packages/backend/convex/publicCatalog.test.ts
@@ -277,6 +277,36 @@ describe("listPublicPuzzleReviews", () => {
     expect(paulsReview?.author?.avatar).toBeNull();
   });
 
+  test("anonymizes an author with NO profile row (fail-closed), while still naming an explicit-public author", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+    // A member who never opened profile settings has no `profiles` row. profileVisibilityOf would
+    // default them to "public", but the indexable public surface must fail closed and anonymize them.
+    await t.run(async (ctx) => {
+      const norow = await mkUser(ctx, "clerk_norow", "Nora NoRow");
+      await ctx.db.insert("puzzleComments", {
+        aggregateId: "rev-norow",
+        puzzleId: approved,
+        authorId: norow,
+        text: "No profile row here.",
+        rating: 2,
+        createdAt: NOW + 20,
+      });
+    });
+
+    const reviews = await t.query(
+      api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
+      { puzzleId: approved },
+    );
+    const norowReview = reviews.find((r) => r.text === "No profile row here.");
+    expect(norowReview?.author).toBeNull(); // fail-closed: no row -> "A JigSwap member"
+    // The explicit-public author is still named — the reveal path is unbroken.
+    const piaReview = reviews.find((r) => r.text === "Lovely gradient sky.");
+    expect(piaReview?.author?.name).toBe("Pia Public");
+    // Nora's real name never leaves the server on this indexable surface.
+    expect(JSON.stringify(reviews)).not.toContain("Nora NoRow");
+  });
+
   test("returns [] for a non-approved definition (reviews must not leak)", async () => {
     const t = convexTest(schema, modules);
     const { pending } = await seed(t);

--- a/packages/backend/convex/publicCatalog.test.ts
+++ b/packages/backend/convex/publicCatalog.test.ts
@@ -305,3 +305,90 @@ describe("listPublicPuzzleReviews", () => {
     expect(raw).not.toContain("email");
   });
 });
+
+describe("browsePublicCatalog", () => {
+  const firstPage = { numItems: 20, cursor: null };
+
+  test("lists approved definitions only, newest first, with card aggregates", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+
+    const result = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage },
+    );
+    expect(result.page).toHaveLength(1); // pending stays hidden
+    const card = result.page[0];
+    expect(card.title).toBe("Mountain Vista");
+    expect(card.rating).toEqual({ value: 4, count: 2 });
+    expect(card.availableToSwap).toBe(2); // public-owner open copies only
+  });
+
+  test("search term restricts via the search index (approved-only)", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+
+    const hit = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage, searchTerm: "mountain" },
+    );
+    expect(hit.page.map((p) => p.title)).toEqual(["Mountain Vista"]);
+
+    // The pending puzzle's terms must not surface.
+    const miss = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage, searchTerm: "secret ocean" },
+    );
+    expect(miss.page).toHaveLength(0);
+  });
+
+  test("brand and piece-count filters narrow the list", async () => {
+    const t = convexTest(schema, modules);
+    const { pia } = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("puzzles", {
+        aggregateId: "def-small",
+        title: "Tiny Meadow",
+        brand: "Jumbo",
+        pieceCount: 300,
+        searchableText: "tiny meadow jumbo",
+        status: "approved",
+        submittedBy: pia,
+        createdAt: NOW + 5,
+        updatedAt: NOW + 5,
+      });
+    });
+
+    const byBrand = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage, brand: "Jumbo" },
+    );
+    expect(byBrand.page.map((p) => p.title)).toEqual(["Tiny Meadow"]);
+
+    const byPieces = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage, pieceMin: 1000, pieceMax: 1499 },
+    );
+    expect(byPieces.page.map((p) => p.title)).toEqual(["Mountain Vista"]);
+
+    const under500 = await t.query(
+      api.catalog.browsePublicCatalog.browsePublicCatalog,
+      { paginationOpts: firstPage, pieceMax: 499 },
+    );
+    expect(under500.page.map((p) => p.title)).toEqual(["Tiny Meadow"]);
+  });
+
+  test("card payload leaks no owner or member data", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+
+    const raw = JSON.stringify(
+      await t.query(api.catalog.browsePublicCatalog.browsePublicCatalog, {
+        paginationOpts: firstPage,
+      }),
+    );
+    expect(raw).not.toContain("ownerId");
+    expect(raw).not.toContain("submittedBy");
+    expect(raw).not.toContain("clerk_");
+  });
+});

--- a/packages/backend/convex/publicCatalog.test.ts
+++ b/packages/backend/convex/publicCatalog.test.ts
@@ -392,3 +392,16 @@ describe("browsePublicCatalog", () => {
     expect(raw).not.toContain("clerk_");
   });
 });
+
+describe("listSitemapEntries", () => {
+  test("returns approved definition ids + updatedAt only", async () => {
+    const t = convexTest(schema, modules);
+    const { approved } = await seed(t);
+
+    const entries = await t.query(
+      api.catalog.listSitemapEntries.listSitemapEntries,
+      {},
+    );
+    expect(entries).toEqual([{ id: approved, updatedAt: NOW }]);
+  });
+});

--- a/packages/backend/convex/social/listPublicPuzzleReviews.ts
+++ b/packages/backend/convex/social/listPublicPuzzleReviews.ts
@@ -1,0 +1,37 @@
+import type { PublicPuzzleReviewView } from "@jigswap/contracts";
+import { v } from "convex/values";
+import { query } from "../_generated/server";
+import { projectPublicAuthor } from "./privacy";
+
+// UNAUTHENTICATED read of the community reviews on a catalog definition, for the public
+// /catalog/$id page. Sibling of listPuzzleReviews (the auth-gated member read, which always names
+// authors via toMemberView); this one projects each author through projectPublicAuthor instead —
+// named iff their profile is public, null (rendered as "A JigSwap member") otherwise.
+//
+// Leak gates: reviews of a non-approved definition return [] (mirrors every public catalog read),
+// and copy-scoped comments (copyId set) are excluded — community reviews only. Newest first.
+export const listPublicPuzzleReviews = query({
+  args: { puzzleId: v.id("puzzles") },
+  handler: async (ctx, args): Promise<PublicPuzzleReviewView[]> => {
+    const puzzle = await ctx.db.get(args.puzzleId);
+    if (!puzzle || puzzle.status !== "approved") return [];
+
+    const rows = (
+      await ctx.db
+        .query("puzzleComments")
+        .withIndex("by_puzzle", (q) => q.eq("puzzleId", args.puzzleId))
+        .order("desc")
+        .collect()
+    ).filter((row) => row.copyId == null);
+
+    return Promise.all(
+      rows.map(async (row): Promise<PublicPuzzleReviewView> => ({
+        id: row.aggregateId ?? row._id,
+        author: await projectPublicAuthor(ctx, row.authorId),
+        text: row.text,
+        rating: row.rating ?? null,
+        createdAt: row.createdAt,
+      })),
+    );
+  },
+});

--- a/packages/backend/convex/social/privacy.ts
+++ b/packages/backend/convex/social/privacy.ts
@@ -106,3 +106,28 @@ export const projectMemberIdentity = async (
 
   return { anonymous: true, anonRef: anonRefOf(targetId, salt) };
 };
+
+/** The public projection of a review author: name + (consent-gated) avatar, or null. */
+export type PublicAuthorView = { name: string; avatar: string | null } | null;
+
+/**
+ * UNAUTHENTICATED identity projection for public (logged-out, indexable) surfaces — the public
+ * catalog's review authors. There is no viewer, so projectMemberIdentity's self/mutual-follower
+ * reveals cannot apply: reveal iff the member's profile is PUBLIC, else null (the UI renders a
+ * generic "A JigSwap member"). Deliberately far narrower than toMemberView — no username, bio,
+ * location, or member id ever leaves the server for a public page, and the avatar additionally
+ * requires the member's explicit `shareAvatarPublicly` consent (the existing flag for public
+ * marketing surfaces).
+ */
+export const projectPublicAuthor = async (
+  ctx: QueryCtx,
+  memberId: Id<"users">,
+): Promise<PublicAuthorView> => {
+  const user = await ctx.db.get(memberId);
+  if (!user) return null;
+  if ((await profileVisibilityOf(ctx, memberId)) !== "public") return null;
+  return {
+    name: user.name,
+    avatar: user.shareAvatarPublicly === true ? (user.avatar ?? null) : null,
+  };
+};

--- a/packages/backend/convex/social/privacy.ts
+++ b/packages/backend/convex/social/privacy.ts
@@ -113,11 +113,18 @@ export type PublicAuthorView = { name: string; avatar: string | null } | null;
 /**
  * UNAUTHENTICATED identity projection for public (logged-out, indexable) surfaces — the public
  * catalog's review authors. There is no viewer, so projectMemberIdentity's self/mutual-follower
- * reveals cannot apply: reveal iff the member's profile is PUBLIC, else null (the UI renders a
- * generic "A JigSwap member"). Deliberately far narrower than toMemberView — no username, bio,
- * location, or member id ever leaves the server for a public page, and the avatar additionally
+ * reveals cannot apply: reveal iff the member has an EXPLICITLY public profile, else null (the UI
+ * renders a generic "A JigSwap member"). Deliberately far narrower than toMemberView — no username,
+ * bio, location, or member id ever leaves the server for a public page, and the avatar additionally
  * requires the member's explicit `shareAvatarPublicly` consent (the existing flag for public
  * marketing surfaces).
+ *
+ * FAIL-CLOSED on a missing profile row: unlike `profileVisibilityOf` (which defaults absent rows to
+ * "public" — correct for the in-app auth-gated surfaces it gates), this indexable surface reads the
+ * profile row directly and reveals ONLY when it exists and is explicitly `visibility: "public"`. A
+ * member who never opened profile settings has no row and is anonymized here, so a real display name
+ * reaches a Google-indexable page only after an affirmative public choice — not by lazy-creation
+ * default. Profiles are created lazily (setProfileVisibility / arrangeShelf), so this matters.
  */
 export const projectPublicAuthor = async (
   ctx: QueryCtx,
@@ -125,7 +132,11 @@ export const projectPublicAuthor = async (
 ): Promise<PublicAuthorView> => {
   const user = await ctx.db.get(memberId);
   if (!user) return null;
-  if ((await profileVisibilityOf(ctx, memberId)) !== "public") return null;
+  const profile = await ctx.db
+    .query("profiles")
+    .withIndex("by_member", (q) => q.eq("memberId", memberId))
+    .unique();
+  if (profile?.visibility !== "public") return null;
   return {
     name: user.name,
     avatar: user.shareAvatarPublicly === true ? (user.avatar ?? null) : null,

--- a/packages/contracts/src/catalog/index.ts
+++ b/packages/contracts/src/catalog/index.ts
@@ -1,1 +1,2 @@
+export * from "./public";
 export * from "./views";

--- a/packages/contracts/src/catalog/public.ts
+++ b/packages/contracts/src/catalog/public.ts
@@ -1,0 +1,66 @@
+// View DTOs for the UNAUTHENTICATED public catalog surfaces (/catalog, /catalog/$id). These are
+// deliberately narrower than the member-facing views: no owner identities, no copy-level data,
+// no member ids ever cross the wire to a logged-out visitor.
+
+import type { PuzzleDifficulty } from "./views";
+
+/** Aggregate availability over open copies whose OWNER'S PROFILE IS PUBLIC (no circle reachability —
+ * there is no viewer). Each copy counts once under its priority swap type (trade→swap, lend, sale). */
+export interface PublicAvailabilityView {
+  total: number;
+  byType: { swap: number; lend: number; sale: number };
+}
+
+/** One card in the public catalog list. `image` is the resolved box-art URL. */
+export interface PublicCatalogCardView {
+  _id: string;
+  title: string;
+  brand?: string;
+  pieceCount: number;
+  difficulty?: PuzzleDifficulty;
+  image: string | null;
+  rating: { value: number; count: number };
+  /** PublicAvailabilityView.total, denormalized for the card's "N to swap" badge. */
+  availableToSwap: number;
+}
+
+/** The public catalog detail view — catalog facts + community aggregates, nothing member-level. */
+export interface PublicDefinitionDetailView {
+  definition: {
+    title: string;
+    description?: string;
+    brand?: string;
+    artist?: string;
+    series?: string;
+    pieceCount: number;
+    image?: string;
+    difficulty?: PuzzleDifficulty;
+    categoryName?: string;
+    tags: string[];
+    shape?: "rectangular" | "panoramic" | "round" | "shaped";
+    dimensions?: { width: number; height: number; unit: "cm" | "in" };
+  };
+  rating: {
+    rating: number;
+    count: number;
+    /** index 0..4 == [5★,4★,3★,2★,1★] — matches the member-facing detail view. */
+    breakdown: [number, number, number, number, number];
+    percentages: [number, number, number, number, number];
+  };
+  stats: {
+    communityOwners: number;
+    totalCompletions: number;
+    avgCompletionDays: number | null;
+  };
+  availability: PublicAvailabilityView;
+}
+
+/** A community review as shown on the public catalog page. `author` is null when the author's
+ * profile is private — the UI renders a generic "A JigSwap member". */
+export interface PublicPuzzleReviewView {
+  id: string;
+  author: { name: string; avatar: string | null } | null;
+  text: string;
+  rating: number | null;
+  createdAt: number;
+}

--- a/packages/gateway/src/operations.ts
+++ b/packages/gateway/src/operations.ts
@@ -54,6 +54,11 @@ export const gateway = {
     allTags: api.catalog.getAllTags.getAllTags,
     puzzleCategories: api.catalog.getPuzzleCategories.getPuzzleCategories,
     puzzleSuggestions: api.catalog.getPuzzleSuggestions.getPuzzleSuggestions,
+    // Unauthenticated public-catalog reads (the /catalog pages; approved-only, member-free).
+    publicBrowse: api.catalog.browsePublicCatalog.browsePublicCatalog,
+    publicDefinitionView:
+      api.catalog.getPublicDefinitionView.getPublicDefinitionView,
+    sitemapEntries: api.catalog.listSitemapEntries.listSitemapEntries,
   },
 
   // Personal Library: a member's owned copies and their organisation. Writes go through the
@@ -292,6 +297,8 @@ export const gateway = {
     // Same `puzzleComments` table + post-comment use case as the copy-keyed variants above.
     postPuzzleReview: api.social.postPuzzleReview.postPuzzleReview,
     listPuzzleReviews: api.social.listPuzzleReviews.listPuzzleReviews,
+    listPublicPuzzleReviews:
+      api.social.listPublicPuzzleReviews.listPublicPuzzleReviews,
   },
 
   // Insights: read-side aggregate stats. globalStats is platform-wide; the rest are the signed-in


### PR DESCRIPTION
## Summary

Phase 5 of the friend-discovery feature set (stacked on #52) — and the friend-finding effort's SEO play: public, unauthenticated puzzle pages that a logged-out visitor (or a search crawler) can browse, each a conversion landing page.

- **Public routes** under `_public/catalog`: a search-first **list** (`/catalog`) and a **detail** page (`/catalog/$id`), both server-rendered for first paint. "Browse puzzles" joins the marketing nav.
- **Four unauthenticated Convex queries** — `getPublicDefinitionView`, `listPublicPuzzleReviews`, `browsePublicCatalog` (paginated + search/brand/piece-bucket filters), `listSitemapEntries`. This is the platform's first fully-public data surface, so leak-prevention is the headline: every payload is a whitelist of catalog/product facts + integer aggregates. **No owner id/name/location/avatar, copy id/condition/price/photo, clerkId, or email can cross the wire** (asserted by stringify-and-assert-absence tests; the sign-off reviewer reasoned through unusual data states, not just the seeds). Every query filters `status === "approved"` (the search-index branch uses a genuine filterField, not a bypassable `.filter`).
- **Availability** shown as an aggregate only — "N copies available to swap" with per-type chips and generic non-identifying avatars ("Join to see who"), counting only open copies of public-profile owners (a deliberate, documented asymmetry vs. the member-facing count). Zero availability omits the panel.
- **Review anonymization** (`projectPublicAuthor`): an author is named (+ consent-gated avatar) **only** with an explicit public profile; everyone else shows as "A JigSwap member". Hardened in review to **fail-closed** — a member who never opened profile settings (no profile row) is anonymized rather than inheriting the default-public convention, so a real name reaches a Google-indexable page only after an affirmative public choice.
- **Bidirectional redirects:** unauthenticated `/puzzles/$id` → `/catalog/$id` (member-shared links work for everyone); authenticated `/catalog/$id` → the richer dashboard page. Loop-safe (each hop flips the gating auth predicate); scoped so static siblings like `/puzzles/add` still hit the sign-in wall.
- **SEO plumbing:** per-route title + meta description, OpenGraph incl. `og:image` from box art, request-origin-derived `robots.txt` and `sitemap.xml` (catalog URLs only — member profiles deliberately excluded per the Phase 1–4 privacy decision). A permanent note in the member review composer says reviews appear on public pages.
- A shared `definitionAggregates` seam means the member and public views can't drift on the rating/availability math (extracted behavior-preserving: the auth-gated view's 13 tests unchanged).

## Review & sign-off

Per-task spec+quality reviews plus a combined web/SEO review (which caught the `/puzzles/add` redirect bug, fixed); final sign-offs **APPROVED** by Backend Architect (after the fail-closed privacy hardening — his one withhold) and Senior Developer.

## Verification

- Backend: 662 tests (15 in the public-catalog suite incl. the leak-absence, availability-asymmetry, and no-profile-row-anonymization assertions); domain: 1140 (unchanged)
- type-check all projects, lint 0 errors (two react-hooks lint traps caught and avoided this phase), **SSR build passes** (exercises the catalog routes + robots/sitemap server routes), format:check, locale parity (37 new `publicCatalog` keys en/nl/source) — all green, uncached
- No runtime browser verification here; robots.txt was curl-verified end-to-end and the flows are covered by convex-test + code-trace review. Manual smoke recommended: a logged-out `/catalog` + `/catalog/$id`, the redirects both directions, and a sitemap fetch against a live deployment.

## Deferred / accepted

- "Top rated" sort deferred (needs a denormalized per-definition rating field to sort a paginated query correctly) — honestly absent, no dead UI.
- Meta descriptions are English-only (`head()` runs outside the intl tree).
- Minor accepted notes: soft-404 returns HTTP 200 on de-listed detail URLs; filtered-to-empty shows the cold-start copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)