### PR TITLE
fix(web): stop sidebar separator overflowing the sidebar width

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -362,7 +362,15 @@ function SidebarSeparator({
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      // Base Separator sets horizontal width via the `data-[orientation=horizontal]:w-full`
+      // variant. A plain `w-auto` is a different tailwind-merge key, so it wouldn't override
+      // the variant (which also wins on CSS specificity) — the separator would stay 100% wide
+      // and `mx-2` would push it past the sidebar edge, causing horizontal scroll. Overriding
+      // with the matching variant lets tailwind-merge drop `w-full` so the margins fit.
+      className={cn(
+        "bg-sidebar-border mx-2 data-[orientation=horizontal]:w-auto",
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Problem

The admin sidebar had a horizontal scrollbar. The culprit was `SidebarSeparator`, which rendered at 100% width **plus** `mx-2` margins — its margin-box exceeded `SidebarContent`'s width, and `SidebarContent`'s `overflow-auto` turned that into a scrollbar.

Production DOM confirmed it — both width classes survived in the class list:
```
class="... data-[orientation=horizontal]:w-full ... mx-2 w-auto"
```

## Root cause

This is a latent inconsistency inherited from shadcn:
- Base `Separator` sets horizontal width via the **variant** `data-[orientation=horizontal]:w-full`.
- `SidebarSeparator` tried to neutralize it with a **plain** `w-auto`.

`tailwind-merge` treats those as different keys (different modifiers), so it keeps **both**. The variant selector (`.class[data-orientation=horizontal]`) also outranks the plain class on CSS specificity, so `width: 100%` won.

## Fix

Override with the matching variant `data-[orientation=horizontal]:w-auto`. Now tailwind-merge dedupes and drops `w-full`, so the separator shrinks to fit inside its `mx-2` margins — no overflow.

Verified the class resolution with tailwind-merge directly: the fixed override removes `data-[orientation=horizontal]:w-full` from the output; the current one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)