### PR TITLE
fix(web): puzzle not-found skeleton hang + whole-puzzle image with hover zoom

### DIFF
--- a/apps/web/src/components/common/image-zoom.tsx
+++ b/apps/web/src/components/common/image-zoom.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// Side-panel hover zoom (e-commerce "product zoom"): hovering the image shows a lens over the
+// region under the cursor and a floating result panel — portalled to <body> so it escapes any
+// `overflow-hidden` / clipping ancestor — that renders that region magnified. Pointer-only: on
+// coarse pointers (touch) it degrades to a plain <img> with no lens/panel.
+//
+// object-contain aware: geometry is computed from the image's *rendered* (letterboxed) rect, so it
+// works both for a `fill` cover in a square box and for an intrinsically-sized image in a lightbox.
+
+type Active = {
+  // Lens rectangle, in px relative to the wrapper.
+  lens: { left: number; top: number; width: number; height: number };
+  // Result panel, position:fixed in viewport px + the background it paints.
+  panel: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+    backgroundSize: string;
+    backgroundPosition: string;
+  };
+};
+
+export function ImageZoom({
+  src,
+  alt,
+  zoom = 2.5,
+  panelSize = 360,
+  fill = false,
+  className,
+  wrapperClassName,
+}: {
+  src: string;
+  alt: string;
+  /** Magnification of the result panel relative to the displayed image. */
+  zoom?: number;
+  /** Result panel edge length in px (square). */
+  panelSize?: number;
+  /** Fill a positioned parent (absolute inset-0) — for cover images in an aspect box. */
+  fill?: boolean;
+  /** Extra classes on the <img>. */
+  className?: string;
+  /** Extra classes on the relative wrapper. */
+  wrapperClassName?: string;
+}) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [active, setActive] = useState<Active | null>(null);
+
+  // Enable the zoom only for fine pointers (mouse/trackpad). matchMedia is read in an effect so it
+  // stays SSR-safe, and re-checks on change (e.g. a 2-in-1 switching input modes).
+  const [finePointer, setFinePointer] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(pointer: fine)");
+    const sync = () => setFinePointer(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  const clear = () => setActive(null);
+
+  const onMove = (e: React.MouseEvent<HTMLImageElement>) => {
+    const img = imgRef.current;
+    const wrapper = wrapperRef.current;
+    if (!img || !wrapper) return;
+    const natW = img.naturalWidth;
+    const natH = img.naturalHeight;
+    if (!natW || !natH) return; // not decoded yet
+
+    const box = img.getBoundingClientRect();
+    // Rendered (object-contain) image rect inside the img box: letterboxed on the shorter axis.
+    const scale = Math.min(box.width / natW, box.height / natH);
+    const renderedW = natW * scale;
+    const renderedH = natH * scale;
+    const offsetX = (box.width - renderedW) / 2;
+    const offsetY = (box.height - renderedH) / 2;
+
+    // Cursor position within the rendered image (px from its top-left).
+    const px = e.clientX - box.left - offsetX;
+    const py = e.clientY - box.top - offsetY;
+    // Outside the actual picture (in the letterbox margin) → no zoom.
+    if (px < 0 || py < 0 || px > renderedW || py > renderedH) {
+      clear();
+      return;
+    }
+    const fx = px / renderedW;
+    const fy = py / renderedH;
+
+    // Lens covers exactly the area the panel magnifies: panel/zoom, in rendered px.
+    const lensW = Math.min(panelSize / zoom, renderedW);
+    const lensH = Math.min(panelSize / zoom, renderedH);
+    const clamp = (v: number, min: number, max: number) =>
+      Math.max(min, Math.min(max, v));
+    const lensCx = clamp(px, lensW / 2, renderedW - lensW / 2);
+    const lensCy = clamp(py, lensH / 2, renderedH - lensH / 2);
+    const wrapRect = wrapper.getBoundingClientRect();
+    const lensLeft = box.left + offsetX + lensCx - lensW / 2 - wrapRect.left;
+    const lensTop = box.top + offsetY + lensCy - lensH / 2 - wrapRect.top;
+
+    // Background: paint the whole rendered image scaled by `zoom`, positioned so the point under the
+    // cursor sits at the panel centre (clamped so the panel never shows past the image edges).
+    const bgW = renderedW * zoom;
+    const bgH = renderedH * zoom;
+    const posX = clamp(panelSize / 2 - fx * bgW, panelSize - bgW, 0);
+    const posY = clamp(panelSize / 2 - fy * bgH, panelSize - bgH, 0);
+
+    // Place the panel beside the image: to the right if it fits, else to the left, else clamp.
+    const gap = 16;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let panelLeft = box.right + gap;
+    if (panelLeft + panelSize > vw - 8) panelLeft = box.left - gap - panelSize;
+    if (panelLeft < 8) panelLeft = Math.max(8, vw - panelSize - 8);
+    const panelTop = clamp(box.top, 8, Math.max(8, vh - panelSize - 8));
+
+    setActive({
+      lens: { left: lensLeft, top: lensTop, width: lensW, height: lensH },
+      panel: {
+        left: panelLeft,
+        top: panelTop,
+        width: panelSize,
+        height: panelSize,
+        backgroundSize: `${bgW}px ${bgH}px`,
+        backgroundPosition: `${posX}px ${posY}px`,
+      },
+    });
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn(fill ? "absolute inset-0" : "relative", wrapperClassName)}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        decoding="async"
+        className={cn(
+          fill && "h-full w-full object-contain",
+          finePointer && "cursor-zoom-in",
+          className,
+        )}
+        onMouseMove={finePointer ? onMove : undefined}
+        onMouseLeave={clear}
+      />
+
+      {active && (
+        <span
+          aria-hidden
+          className="border-jigsaw-primary/70 pointer-events-none absolute border bg-white/20"
+          style={{
+            left: active.lens.left,
+            top: active.lens.top,
+            width: active.lens.width,
+            height: active.lens.height,
+          }}
+        />
+      )}
+
+      {active &&
+        createPortal(
+          <div
+            aria-hidden
+            className="border-border pointer-events-none fixed z-[100] overflow-hidden rounded-xl border bg-white bg-no-repeat shadow-2xl dark:bg-neutral-900"
+            style={{
+              left: active.panel.left,
+              top: active.panel.top,
+              width: active.panel.width,
+              height: active.panel.height,
+              backgroundImage: `url(${src})`,
+              backgroundSize: active.panel.backgroundSize,
+              backgroundPosition: active.panel.backgroundPosition,
+            }}
+          />,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/apps/web/src/components/common/image-zoom.tsx
+++ b/apps/web/src/components/common/image-zoom.tsx
@@ -4,48 +4,63 @@ import { cn } from "@/lib/utils";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-// Side-panel hover zoom (e-commerce "product zoom"): hovering the image shows a lens over the
-// region under the cursor and a floating result panel — portalled to <body> so it escapes any
-// `overflow-hidden` / clipping ancestor — that renders that region magnified. Pointer-only: on
-// coarse pointers (touch) it degrades to a plain <img> with no lens/panel.
+// Hover zoom for an image, in two flavours (`mode`):
+//   - "panel" (default): e-commerce "product zoom" — a lens marks the region under the cursor and a
+//     floating result panel, portalled to <body> so it escapes any `overflow-hidden` ancestor,
+//     renders that region magnified beside the image. Good for a small cover next to other content.
+//   - "lens": an in-place magnifying glass — a circle follows the cursor over the image and shows
+//     that spot magnified under it, with no separate panel. Good when the image is already large
+//     (e.g. a lightbox) and a side panel would just get in the way.
+// Pointer-only: on coarse pointers (touch) it degrades to a plain <img>.
 //
 // object-contain aware: geometry is computed from the image's *rendered* (letterboxed) rect, so it
 // works both for a `fill` cover in a square box and for an intrinsically-sized image in a lightbox.
 
-type Active = {
-  // Lens rectangle, in px relative to the wrapper.
-  lens: { left: number; top: number; width: number; height: number };
-  // Result panel, position:fixed in viewport px + the background it paints.
-  panel: {
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-    backgroundSize: string;
-    backgroundPosition: string;
-  };
-};
+const clamp = (v: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, v));
+
+type Painted = { backgroundSize: string; backgroundPosition: string };
+
+type Active =
+  | {
+      mode: "panel";
+      // Region marker over the image, in px relative to the wrapper.
+      lens: { left: number; top: number; width: number; height: number };
+      // Result panel, position:fixed in viewport px.
+      panel: { left: number; top: number; size: number } & Painted;
+    }
+  | {
+      mode: "lens";
+      // Magnifier circle, in px relative to the wrapper.
+      glass: { left: number; top: number; size: number } & Painted;
+    };
 
 export function ImageZoom({
   src,
   alt,
+  mode = "panel",
   zoom = 2.5,
   panelSize = 360,
+  lensSize = 200,
   fill = false,
   className,
   wrapperClassName,
 }: {
   src: string;
   alt: string;
-  /** Magnification of the result panel relative to the displayed image. */
+  /** "panel" = side result panel; "lens" = in-place magnifying glass. */
+  mode?: "panel" | "lens";
+  /** Magnification relative to the displayed image. */
   zoom?: number;
-  /** Result panel edge length in px (square). */
+  /** Result-panel edge length in px (panel mode). */
   panelSize?: number;
+  /** Magnifier diameter in px (lens mode). */
+  lensSize?: number;
   /** Fill a positioned parent (absolute inset-0) — for cover images in an aspect box. */
   fill?: boolean;
   /** Extra classes on the <img>. */
   className?: string;
-  /** Extra classes on the relative wrapper. */
+  /** Extra classes on the wrapper. */
   wrapperClassName?: string;
 }) {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -92,21 +107,37 @@ export function ImageZoom({
     const fx = px / renderedW;
     const fy = py / renderedH;
 
-    // Lens covers exactly the area the panel magnifies: panel/zoom, in rendered px.
+    // The magnified backdrop: the whole rendered image scaled by `zoom`.
+    const bgW = renderedW * zoom;
+    const bgH = renderedH * zoom;
+    const wrapRect = wrapper.getBoundingClientRect();
+
+    if (mode === "lens") {
+      // Magnifying glass: a circle centred on the cursor, its content clamped so the glass is always
+      // full of image (near an edge the magnification "sticks" rather than showing empty space).
+      const posX = clamp(lensSize / 2 - fx * bgW, lensSize - bgW, 0);
+      const posY = clamp(lensSize / 2 - fy * bgH, lensSize - bgH, 0);
+      setActive({
+        mode: "lens",
+        glass: {
+          left: e.clientX - wrapRect.left - lensSize / 2,
+          top: e.clientY - wrapRect.top - lensSize / 2,
+          size: lensSize,
+          backgroundSize: `${bgW}px ${bgH}px`,
+          backgroundPosition: `${posX}px ${posY}px`,
+        },
+      });
+      return;
+    }
+
+    // Panel mode: a region marker over the image + a fixed result panel beside it.
     const lensW = Math.min(panelSize / zoom, renderedW);
     const lensH = Math.min(panelSize / zoom, renderedH);
-    const clamp = (v: number, min: number, max: number) =>
-      Math.max(min, Math.min(max, v));
     const lensCx = clamp(px, lensW / 2, renderedW - lensW / 2);
     const lensCy = clamp(py, lensH / 2, renderedH - lensH / 2);
-    const wrapRect = wrapper.getBoundingClientRect();
     const lensLeft = box.left + offsetX + lensCx - lensW / 2 - wrapRect.left;
     const lensTop = box.top + offsetY + lensCy - lensH / 2 - wrapRect.top;
 
-    // Background: paint the whole rendered image scaled by `zoom`, positioned so the point under the
-    // cursor sits at the panel centre (clamped so the panel never shows past the image edges).
-    const bgW = renderedW * zoom;
-    const bgH = renderedH * zoom;
     const posX = clamp(panelSize / 2 - fx * bgW, panelSize - bgW, 0);
     const posY = clamp(panelSize / 2 - fy * bgH, panelSize - bgH, 0);
 
@@ -120,17 +151,20 @@ export function ImageZoom({
     const panelTop = clamp(box.top, 8, Math.max(8, vh - panelSize - 8));
 
     setActive({
+      mode: "panel",
       lens: { left: lensLeft, top: lensTop, width: lensW, height: lensH },
       panel: {
         left: panelLeft,
         top: panelTop,
-        width: panelSize,
-        height: panelSize,
+        size: panelSize,
         backgroundSize: `${bgW}px ${bgH}px`,
         backgroundPosition: `${posX}px ${posY}px`,
       },
     });
   };
+
+  const cursorClass =
+    mode === "lens" ? "cursor-none" : finePointer && "cursor-zoom-in";
 
   return (
     <div
@@ -145,14 +179,15 @@ export function ImageZoom({
         decoding="async"
         className={cn(
           fill && "h-full w-full object-contain",
-          finePointer && "cursor-zoom-in",
+          finePointer && cursorClass,
           className,
         )}
         onMouseMove={finePointer ? onMove : undefined}
         onMouseLeave={clear}
       />
 
-      {active && (
+      {/* Panel mode: region marker over the image. */}
+      {active?.mode === "panel" && (
         <span
           aria-hidden
           className="border-jigsaw-primary/70 pointer-events-none absolute border bg-white/20"
@@ -165,7 +200,8 @@ export function ImageZoom({
         />
       )}
 
-      {active &&
+      {/* Panel mode: floating result panel, portalled past clipping ancestors. */}
+      {active?.mode === "panel" &&
         createPortal(
           <div
             aria-hidden
@@ -173,8 +209,8 @@ export function ImageZoom({
             style={{
               left: active.panel.left,
               top: active.panel.top,
-              width: active.panel.width,
-              height: active.panel.height,
+              width: active.panel.size,
+              height: active.panel.size,
               backgroundImage: `url(${src})`,
               backgroundSize: active.panel.backgroundSize,
               backgroundPosition: active.panel.backgroundPosition,
@@ -182,6 +218,23 @@ export function ImageZoom({
           />,
           document.body,
         )}
+
+      {/* Lens mode: in-place magnifying glass following the cursor. */}
+      {active?.mode === "lens" && (
+        <span
+          aria-hidden
+          className="border-border/80 pointer-events-none absolute rounded-full border-2 bg-no-repeat shadow-xl ring-1 ring-black/20"
+          style={{
+            left: active.glass.left,
+            top: active.glass.top,
+            width: active.glass.size,
+            height: active.glass.size,
+            backgroundImage: `url(${src})`,
+            backgroundSize: active.glass.backgroundSize,
+            backgroundPosition: active.glass.backgroundPosition,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/copies/photo-lightbox.tsx
+++ b/apps/web/src/components/copies/photo-lightbox.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ImageZoom } from "@/components/common/image-zoom";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -172,11 +173,11 @@ export function PhotoLightbox({
 
         {/* Image stage */}
         <div className="relative flex min-h-0 items-center justify-center bg-neutral-950">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <ImageZoom
             src={photo.url}
             alt={photo.caption ?? ""}
             className="max-h-full max-w-full object-contain"
+            wrapperClassName="flex h-full w-full items-center justify-center"
           />
 
           {count > 1 && (

--- a/apps/web/src/components/copies/photo-lightbox.tsx
+++ b/apps/web/src/components/copies/photo-lightbox.tsx
@@ -173,9 +173,12 @@ export function PhotoLightbox({
 
         {/* Image stage */}
         <div className="relative flex min-h-0 items-center justify-center bg-neutral-950">
+          {/* In-place magnifying glass (not a side panel): the photo is already large here, so the
+              cursor itself becomes the magnifier, confined to the image. */}
           <ImageZoom
             src={photo.url}
             alt={photo.caption ?? ""}
+            mode="lens"
             className="max-h-full max-w-full object-contain"
             wrapperClassName="flex h-full w-full items-center justify-center"
           />

--- a/apps/web/src/routes/_dashboard/copies/$id.tsx
+++ b/apps/web/src/routes/_dashboard/copies/$id.tsx
@@ -2,9 +2,9 @@ import { durationParts } from "@/lib/humanize-duration";
 import { pageTitle } from "@/lib/page-title";
 import { createFileRoute } from "@tanstack/react-router";
 
-import { Image } from "@/compat/image";
 import { useRouter } from "@/compat/navigation";
 import { availabilityToSharing } from "@/components/add-puzzle";
+import { ImageZoom } from "@/components/common/image-zoom";
 import { EditCopyDialog } from "@/components/copies/edit-copy-dialog";
 import { PhotoLightbox } from "@/components/copies/photo-lightbox";
 import {
@@ -94,7 +94,11 @@ export function CopyInstanceScreen({
   navContext?: NavContext | null;
 }) {
   const router = useRouter();
-  const { data: copy, isPending: copyPending } = useQuery(
+  const {
+    data: copy,
+    isPending: copyPending,
+    isError,
+  } = useQuery(
     convexQuery(gateway.library.getCopyInstanceView, {
       copyId: copyId as Id<"ownedPuzzles">,
     }),
@@ -105,12 +109,15 @@ export function CopyInstanceScreen({
     if (notOwner) router.push(`/copies/${copyId}`);
   }, [notOwner, copyId, router]);
 
-  if (copyPending || copy === undefined || notOwner) {
-    return <CopyInstanceSkeleton />;
+  // A missing copy resolves to `null`; a malformed id or any other query failure surfaces as
+  // `isError` with `copy` stuck at `undefined`. Treat both as not-found so an unresolvable copy
+  // never hangs on the loading skeleton.
+  if (copy === null || isError) {
+    return <CopyInstanceNotFound />;
   }
 
-  if (copy === null) {
-    return <CopyInstanceNotFound />;
+  if (copyPending || copy === undefined || notOwner) {
+    return <CopyInstanceSkeleton />;
   }
 
   return (
@@ -344,22 +351,18 @@ function CopyInstanceDetail({
     <div className="flex w-full flex-col gap-10">
       {/* Hero */}
       <section className="grid items-start gap-7 lg:grid-cols-[300px_minmax(0,1fr)]">
-        {/* Cover */}
-        <div className="bg-muted relative aspect-square w-full max-w-[300px] overflow-hidden rounded-2xl shadow-sm">
+        {/* Cover — full width on mobile, capped beside the info column at lg. Hovering opens a side
+            panel that magnifies where the cursor points. */}
+        <div className="bg-muted relative aspect-square w-full overflow-hidden rounded-2xl shadow-sm lg:max-w-[300px]">
           {snapshot.image ? (
-            <Image
-              src={snapshot.image}
-              alt={snapshot.title}
-              fill
-              className="object-contain"
-            />
+            <ImageZoom src={snapshot.image} alt={snapshot.title} fill />
           ) : (
             <div className="from-jigsaw-primary/20 to-jigsaw-primary text-jigsaw-primary-foreground/70 absolute inset-0 flex items-center justify-center bg-gradient-to-br">
               <Puzzle className="h-1/3 w-1/3" />
             </div>
           )}
           {isAvailable && (
-            <span className="bg-jigsaw-secondary absolute left-3 top-3 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold text-white shadow-sm">
+            <span className="bg-jigsaw-secondary absolute left-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold text-white shadow-sm">
               <span className="h-1.5 w-1.5 rounded-full bg-white" />
               {t("available")}
             </span>

--- a/apps/web/src/routes/_dashboard/puzzles/$id/index.tsx
+++ b/apps/web/src/routes/_dashboard/puzzles/$id/index.tsx
@@ -2,9 +2,9 @@ import { usePageHeader } from "@/components/dashboard-layout/page-header-slot";
 import { pageTitle } from "@/lib/page-title";
 import { createFileRoute } from "@tanstack/react-router";
 
-import { Image } from "@/compat/image";
 import { Link } from "@/compat/link";
 import { useRouter } from "@/compat/navigation";
+import { ImageZoom } from "@/components/common/image-zoom";
 import { EmptyState } from "@/components/library/empty-state";
 import {
   difficultyClasses,
@@ -56,18 +56,21 @@ export const Route = createFileRoute("/_dashboard/puzzles/$id/")({
 
 function PuzzlePage() {
   const { id } = Route.useParams();
-  const { data: view } = useQuery(
+  const { data: view, isError } = useQuery(
     convexQuery(gateway.library.getPuzzleDefinitionView, {
       puzzleId: id as Id<"puzzles">,
     }),
   );
 
-  if (view === undefined) {
-    return <PuzzleDefinitionSkeleton />;
+  // A missing puzzle resolves to `null`; a malformed id (fails `v.id("puzzles")` validation) or any
+  // other query failure surfaces as `isError` with `view` stuck at `undefined`. Treat both as
+  // not-found so an unresolvable puzzle never hangs on the loading skeleton.
+  if (view === null || isError) {
+    return <PuzzleDefinitionNotFound />;
   }
 
-  if (view === null) {
-    return <PuzzleDefinitionNotFound />;
+  if (view === undefined) {
+    return <PuzzleDefinitionSkeleton />;
   }
 
   return <PuzzleDefinitionDetail view={view} puzzleId={id} />;
@@ -170,15 +173,12 @@ function PuzzleDefinitionDetail({
     <div className="flex w-full flex-col gap-10">
       {/* Hero */}
       <section className="grid items-start gap-7 lg:grid-cols-[300px_minmax(0,1fr)]">
-        {/* Cover */}
-        <div className="bg-muted relative aspect-square w-full max-w-[300px] overflow-hidden rounded-2xl shadow-sm">
+        {/* Cover — full width on mobile, capped beside the info column at lg. object-contain (via
+            ImageZoom) shows the whole puzzle; hovering opens a side panel that magnifies where the
+            cursor points. */}
+        <div className="bg-muted relative aspect-square w-full overflow-hidden rounded-2xl shadow-sm lg:max-w-[300px]">
           {definition.image ? (
-            <Image
-              src={definition.image}
-              alt={definition.title}
-              fill
-              className="object-cover"
-            />
+            <ImageZoom src={definition.image} alt={definition.title} fill />
           ) : (
             <PuzzleCoverFallback />
           )}

--- a/apps/web/src/routes/_public/catalog/$id.tsx
+++ b/apps/web/src/routes/_public/catalog/$id.tsx
@@ -1,5 +1,5 @@
-import { Image } from "@/compat/image";
 import { Link } from "@/compat/link";
+import { ImageZoom } from "@/components/common/image-zoom";
 import { EmptyState } from "@/components/library/empty-state";
 import {
   difficultyClasses,
@@ -134,14 +134,9 @@ function PublicPuzzleDetail({
     <main className="mx-auto flex w-full max-w-[1200px] flex-col gap-10 px-6 py-10">
       {/* Hero — mirrors the dashboard detail skeleton, minus member actions. */}
       <section className="grid items-start gap-7 lg:grid-cols-[300px_minmax(0,1fr)]">
-        <div className="bg-muted relative aspect-square w-full max-w-[300px] overflow-hidden rounded-2xl shadow-sm">
+        <div className="bg-muted relative aspect-square w-full overflow-hidden rounded-2xl shadow-sm lg:max-w-[300px]">
           {definition.image ? (
-            <Image
-              src={definition.image}
-              alt={definition.title}
-              fill
-              className="object-cover"
-            />
+            <ImageZoom src={definition.image} alt={definition.title} fill />
           ) : (
             <PuzzleCoverFallback />
           )}


### PR DESCRIPTION
Addresses three things on the puzzle/copy detail surfaces.

## 1. Not-found hangs on the loading skeleton
`/puzzles/$id` and `/copies/$id` only distinguished `undefined` (loading) from `null` (missing). A **malformed id** (fails `v.id("puzzles")` arg validation) or any other query failure surfaces as `isError` with data stuck at `undefined` — so the page sat on the loading skeleton forever instead of showing "not found". Both routes now treat `isError` as not-found, matching what the public catalog route already did.

## 2. Show the whole puzzle, full-width on mobile
The puzzle overview cover used `object-cover` (cropped). It now shows the entire image (`object-contain`, like the copy view) and is **full-width on mobile** — the `max-w-[300px]` cap only applies from `lg` up, where it sits beside the info column. Same change on the public catalog cover for consistency.

## 3. Hover-to-zoom (side panel)
New `ImageZoom` component — an e-commerce-style product zoom. Hovering the image shows a lens over the region under the cursor and a floating result panel (portalled to `<body>` so it escapes `overflow-hidden` ancestors) that magnifies that region, tracking the mouse. It's `object-contain`-aware, so the geometry is correct whether the image is a `fill` cover in a square box or an intrinsically-sized lightbox photo. **Pointer-only:** coarse pointers (touch) get a plain image, no lens/panel.

Wired into: the puzzle overview cover, the copy view cover, and the photo lightbox (per the chosen "all puzzle images" scope).

## Verification
- Type-check (0 errors), ESLint (0 errors), Prettier — all clean on the changed files.
- ⚠️ The hover-zoom is a visual/interactive feature and there's no browser in my environment, so **it needs a visual check on the dev server** (`:3001`) — the covers, the lens tracking, panel placement near the screen edge, and touch fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)