### PR TITLE
fix(ci): teardown reference format + dispatchable stale-preview sweep

### DIFF
--- a/.github/workflows/convex-preview-teardown.yml
+++ b/.github/workflows/convex-preview-teardown.yml
@@ -53,10 +53,13 @@ jobs:
           deployments="$(curl -sSf "${auth[@]}" \
             "$CONVEX_API/projects/$project_id/list_deployments")"
 
-          # The preview created by `convex deploy --preview-name "$BRANCH_NAME"`
-          # carries the branch as its unique in-project reference. Local dev
-          # deployments in the response lack `reference`; select() skips them.
-          name="$(jq -r --arg ref "$BRANCH_NAME" \
+          # The preview created by `convex deploy --preview-name "$BRANCH_NAME"` gets the
+          # in-project reference `preview/<branch>` with slashes in the branch name replaced
+          # by dashes (observed live: branch fix/sidebar-separator-overflow -> reference
+          # preview/fix-sidebar-separator-overflow). Local dev deployments in the response
+          # lack `reference`; select() skips them.
+          expected_ref="preview/${BRANCH_NAME//\//-}"
+          name="$(jq -r --arg ref "$expected_ref" \
             '[.[] | select(.deploymentType == "preview" and .reference == $ref)][0].name // empty' \
             <<<"$deployments")"
 

--- a/.github/workflows/convex-preview-teardown.yml
+++ b/.github/workflows/convex-preview-teardown.yml
@@ -2,9 +2,14 @@ name: Convex Preview Teardown
 
 permissions:
   contents: read
+  # The sweep job derives its keep-set from the repo's open PRs.
+  pull-requests: read
 
-# Deletes a PR's Convex preview deployment when the PR is merged or closed
-# (docs/deployment/convex-preview-deployments.md → "Teardown on PR close").
+# Deletes a PR's Convex preview deployment when the PR is merged or closed, and
+# offers a manually dispatched SWEEP that reaps every preview whose branch has no
+# open PR (docs/deployment/convex-preview-deployments.md → "Teardown on PR close").
+# The sweep exists because auto-expiry proved unreliable in practice: the first
+# live teardown run found previews from branches merged weeks earlier.
 #
 # Uses the Convex Management API (https://docs.convex.dev/management-api) over curl:
 # the pinned Convex CLI has no `deployment delete`/`deployment list` commands
@@ -20,10 +25,18 @@ permissions:
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Only list the previews the sweep would delete, without deleting them"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   teardown:
     name: Delete preview deployment
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -72,3 +85,70 @@ jobs:
 
           curl -sSf -X POST "${auth[@]}" "$CONVEX_API/deployments/$name/delete"
           echo "::notice::Deleted preview deployment '$name' for branch '$BRANCH_NAME'"
+
+  sweep:
+    name: Sweep stale preview deployments
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CONVEX_API: https://api.convex.dev/v1
+      TEAM_SLUG: ${{ vars.CONVEX_TEAM_SLUG }}
+      PROJECT_SLUG: ${{ vars.CONVEX_PROJECT_SLUG }}
+      DRY_RUN: ${{ inputs.dryRun }}
+      HAS_CONFIG: ${{ secrets.CONVEX_MANAGEMENT_TOKEN != '' && vars.CONVEX_TEAM_SLUG != '' && vars.CONVEX_PROJECT_SLUG != '' }}
+    steps:
+      - name: Skip when the management token or slugs are not configured
+        if: env.HAS_CONFIG != 'true'
+        run: echo "::notice::CONVEX_MANAGEMENT_TOKEN / CONVEX_TEAM_SLUG / CONVEX_PROJECT_SLUG not configured — skipping sweep (see docs/deployment/convex-preview-deployments.md)"
+
+      - name: Delete previews whose branch has no open PR
+        if: env.HAS_CONFIG == 'true'
+        env:
+          CONVEX_MANAGEMENT_TOKEN: ${{ secrets.CONVEX_MANAGEMENT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          auth=(-H "Authorization: Bearer $CONVEX_MANAGEMENT_TOKEN")
+
+          # Keep-set: the expected preview reference for every OPEN PR's head branch,
+          # using the same forward mapping the close-triggered teardown uses. This
+          # sidesteps the dashed-reference ambiguity (a reference cannot be reversed
+          # into a branch name). `set -e` aborts the job if the PR listing fails, so
+          # a GitHub hiccup can never be mistaken for "no open PRs — delete everything".
+          keep="$(gh pr list --repo "$REPO" --state open --limit 200 \
+            --json headRefName --jq '.[].headRefName' \
+            | while IFS= read -r branch; do echo "preview/${branch//\//-}"; done)"
+          echo "Keeping previews for open PRs:"
+          echo "${keep:-  (none)}"
+
+          # Slugs -> numeric project id (the other project endpoints take the id).
+          project_id="$(curl -sSf "${auth[@]}" \
+            "$CONVEX_API/teams/$TEAM_SLUG/projects/$PROJECT_SLUG" | jq -r '.id')"
+
+          deployments="$(curl -sSf "${auth[@]}" \
+            "$CONVEX_API/projects/$project_id/list_deployments")"
+
+          doomed="$(jq -r --arg keep "$keep" '
+            ($keep | split("\n") | map(select(length > 0))) as $keepset
+            | [.[] | select(.deploymentType == "preview")
+                   | select(.reference as $r | $keepset | index($r) | not)]
+            | map("\(.name)\t\(.reference)")[]' <<<"$deployments")"
+
+          if [ -z "$doomed" ]; then
+            echo "::notice::No stale preview deployments — nothing to sweep"
+            exit 0
+          fi
+
+          count="$(wc -l <<<"$doomed")"
+          if [ "$DRY_RUN" != "false" ]; then
+            echo "::notice::Dry run — $count stale preview(s) WOULD be deleted (re-dispatch with dryRun unchecked to delete):"
+            printf '%s\n' "$doomed"
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r name reference; do
+            curl -sSf -X POST "${auth[@]}" "$CONVEX_API/deployments/$name/delete"
+            echo "Deleted $name ($reference)"
+          done <<<"$doomed"
+          echo "::notice::Swept $count stale preview deployment(s)"

--- a/docs/deployment/convex-preview-deployments.md
+++ b/docs/deployment/convex-preview-deployments.md
@@ -105,8 +105,20 @@ until expiry. It calls the
 [Convex Management API](https://docs.convex.dev/management-api) directly (the CLI
 has no `deployment delete` — see
 [convex-backend#455](https://github.com/get-convex/convex-backend/issues/455)):
-slug → project id → list deployments → delete the preview whose `reference` is the
-PR branch. Auto-expiry remains the fallback for anything the teardown misses.
+slug → project id → list deployments → delete the preview whose `reference` matches
+the PR branch (references are `preview/<branch>` with slashes replaced by dashes).
+Auto-expiry is nominally the fallback for anything the teardown misses, but it has
+proven unreliable in practice — hence the sweep below.
+
+### Sweeping stale previews
+
+The same workflow has a manual **sweep** (Actions → Convex Preview Teardown → Run
+workflow): it deletes every preview deployment whose branch has no open PR. The
+keep-set is computed from open PRs with the same branch→reference mapping, so a
+reference never needs to be reverse-parsed. `dryRun` is checked by default and only
+lists what would be deleted — eyeball that list, then re-dispatch with `dryRun`
+unchecked to actually delete. If listing open PRs fails, the job aborts rather than
+treating the failure as "no open PRs".
 
 ### One-time owner setup (teardown)
 


### PR DESCRIPTION
## Summary
- **Reference-format fix**: the teardown's first live run (scrap PR #59) authenticated and listed deployments fine but matched nothing — Convex preview references are `preview/<branch>` with `/` replaced by `-`, not the bare branch name. The workflow now builds the expected reference before matching (verified against live-observed references).
- **Stale-preview sweep** (`workflow_dispatch` on the same workflow): deletes every preview whose branch has no open PR. Keep-set is computed from open PRs with the same forward branch→reference mapping (no reverse-parsing of dashed references). `dryRun` defaults to **true** and only lists candidates; the job aborts if the open-PR listing fails so a GitHub hiccup can't become "delete everything". Added because auto-expiry proved unreliable — the live run found 15 previews, many from branches merged well past the expiry window.
- jq selection + tab-split loop validated against fixtures (keeps open-PR previews, ignores prod/dev/local deployments, empty keep-set dooms all previews).

## Test plan
- [x] Reference construction checked against two live-observed references (run 29252518178)
- [x] Sweep jq/shell logic fixture-tested; YAML parses; prettier clean
- [ ] Post-merge: dispatch sweep with dryRun (expect ~15 candidates listed), eyeball, re-dispatch with dryRun unchecked
- [ ] Post-merge: close a scrap PR and confirm "Deleted preview deployment …"

🤖 Generated with [Claude Code](https://claude.com/claude-code)