### PR TITLE
fix: notification preference integrity, email locale sync, catalogue image fit

### DIFF
--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1881,6 +1881,8 @@
       "ratingReceived": "Avg rating received",
       "time": "{hours}h {minutes}m",
       "timeMinutes": "{minutes}m",
+      "timeDays": "{days, plural, one {# day} other {# days}}",
+      "timeDaysHours": "{days}d {hours}h {minutes}m",
       "ratingNone": "—"
     },
     "trends": {

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1756,6 +1756,8 @@
       "finished": "Finished {date}",
       "time": "{hours}h {minutes}m",
       "timeMinutes": "{minutes}m",
+      "timeDays": "{days, plural, one {# day} other {# days}}",
+      "timeDaysHours": "{days}d {hours}h {minutes}m",
       "noTime": "No time recorded",
       "finish": "Finish solve",
       "edit": "Edit",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -110,7 +110,7 @@
       },
       "analytics": {
         "title": "Analyses",
-        "description": "Krijg inzicht in je oplossingspatronen, stel doelen en vergelijk met community trends."
+        "description": "Krijg inzicht in je voltooiingspatronen, stel doelen en vergelijk met community trends."
       }
     },
     "detailed": {
@@ -139,7 +139,7 @@
           "title": "Persoonlijke Analyses",
           "items": [
             "Bekijk voltooiingsstatistieken",
-            "Analyseer oplossingstijd trends",
+            "Analyseer voltooiingstijd-trends",
             "Stel persoonlijke doelen in en volg ze",
             "Exporteer je gegevens"
           ]
@@ -536,7 +536,7 @@
       "collection": "Aan collectie toevoegen"
     },
     "coachmark": {
-      "body": "Snelle acties zoals een oplossing vastleggen vind je in het ⋯ menu op elke puzzelkaart.",
+      "body": "Snelle acties zoals een voltooiing vastleggen vind je in het ⋯ menu op elke puzzelkaart.",
       "dismiss": "Tip verbergen"
     },
     "dividerManual": "of vul de gegevens zelf in",
@@ -1513,7 +1513,7 @@
       "statPieces": "stukjes gelegd",
       "statSwaps": "ruilen",
       "fastestLabel": "Snelste voltooiing",
-      "hardestLabel": "Moeilijkste oplossing",
+      "hardestLabel": "Moeilijkste voltooiing",
       "minutesValue": "{minutes} min",
       "piecesValue": "{count, number} stukjes",
       "privateBody": "Deze plank is privé — {name} deelt hun puzzels, voltooiingen en verhaal alleen met goedgekeurde volgers.",
@@ -1749,7 +1749,7 @@
       "title": "Voltooiingen",
       "subtitle": "Je oplosgeschiedenis van al je puzzels.",
       "empty": "Nog geen voltooiingen",
-      "emptyHint": "Leg een oplossing vast vanuit een van je puzzels om je geschiedenis bij te houden.",
+      "emptyHint": "Leg een voltooiing vast vanuit een van je puzzels om je geschiedenis bij te houden.",
       "inProgress": "Bezig",
       "completed": "Voltooid",
       "started": "Gestart {date}",
@@ -1759,7 +1759,7 @@
       "timeDays": "{days, plural, one {# dag} other {# dagen}}",
       "timeDaysHours": "{days}d {hours} u {minutes} m",
       "noTime": "Geen tijd vastgelegd",
-      "finish": "Oplossing afronden",
+      "finish": "Voltooiing afronden",
       "edit": "Bewerken",
       "editWindowClosed": "Deze voltooiing kan niet meer worden bewerkt (het venster van 24 uur is gesloten).",
       "yourReview": "Jouw review",
@@ -1780,7 +1780,7 @@
       "piecesMissing": "miste stukjes",
       "new": {
         "title": "Voltooiing vastleggen",
-        "subtitle": "Kies een puzzel om een oplossing tegen te registreren.",
+        "subtitle": "Kies een puzzel om een voltooiing voor te registreren.",
         "noPuzzles": "Nog geen puzzels",
         "noPuzzlesHint": "Voeg eerst puzzels toe aan je bibliotheek en log hier dan een voltooiing."
       },
@@ -1792,22 +1792,22 @@
       "deleteError": "Voltooiing kon niet worden verwijderd"
     },
     "logSolve": {
-      "trigger": "Oplossing vastleggen",
-      "title": "Oplossing vastleggen",
+      "trigger": "Voltooiing vastleggen",
+      "title": "Voltooiing vastleggen",
       "description": "Leg een voltooiing vast voor {puzzle}.",
       "startDate": "Startdatum",
       "endDate": "Einddatum",
-      "endDateHint": "Laat leeg om deze oplossing als bezig te markeren.",
+      "endDateHint": "Laat leeg om deze voltooiing als bezig te markeren.",
       "hours": "Uren",
       "minutes": "Minuten",
       "timeLabel": "Oplostijd",
       "notes": "Notities",
-      "notesPlaceholder": "Iets memorabels over deze oplossing?",
-      "submit": "Oplossing opslaan",
-      "saved": "Oplossing vastgelegd",
-      "savedInProgress": "Oplossing gestart",
-      "finished": "Oplossing afgerond",
-      "saveError": "Kon de oplossing niet opslaan. Probeer het opnieuw.",
+      "notesPlaceholder": "Iets memorabels over deze voltooiing?",
+      "submit": "Voltooiing opslaan",
+      "saved": "Voltooiing vastgelegd",
+      "savedInProgress": "Voltooiing gestart",
+      "finished": "Voltooiing afgerond",
+      "saveError": "Kon de voltooiing niet opslaan. Probeer het opnieuw.",
       "allPiecesPresent": "Alle stukjes waren aanwezig",
       "updateCopyPiecesTitle": "Dit exemplaar bijwerken?",
       "updateCopyPiecesBody": "Je gaf aan dat er stukjes ontbreken. Wil je het aantal ontbrekende stukjes van dit exemplaar ook bijwerken?",
@@ -1867,7 +1867,7 @@
     "subtitle": "Je puzzel- en ruilactiviteit in één oogopslag.",
     "nav": "Inzichten",
     "loading": "Je inzichten laden...",
-    "empty": "Nog geen gegevens — leg een oplossing vast om inzichten te zien.",
+    "empty": "Nog geen gegevens — leg een voltooiing vast om inzichten te zien.",
     "stats": {
       "completions": "Voltooiingen",
       "solveTime": "Totale oplostijd",
@@ -1885,10 +1885,10 @@
     },
     "trends": {
       "title": "Voltooiingstrends",
-      "description": "Voltooide oplossingen per maand over de laatste 12 maanden.",
+      "description": "Voltooiingen per maand over de laatste 12 maanden.",
       "count": "Voltooiingen",
       "minutes": "Oplosminuten",
-      "empty": "Nog geen voltooide oplossingen."
+      "empty": "Nog geen voltooiingen."
     },
     "breakdown": {
       "title": "Collectie-uitsplitsing",
@@ -1915,7 +1915,7 @@
     },
     "export": {
       "title": "Mijn gegevens exporteren",
-      "description": "Download een JSON-kopie van je puzzels, oplossingen, collecties, doelen en ruilen.",
+      "description": "Download een JSON-kopie van je puzzels, voltooiingen, collecties, doelen en ruilen.",
       "button": "Mijn gegevens exporteren",
       "preparing": "Voorbereiden...",
       "success": "Je gegevens zijn gedownload.",
@@ -2434,7 +2434,7 @@
       "helpfulSend": "Feedback versturen",
       "landingEyebrow": "Documentatie",
       "landingTitle": "JigSwap-handleiding",
-      "landingLead": "Alles wat je nodig hebt om je collectie op te bouwen, oplossingen vast te leggen en puzzels te ruilen met de community.",
+      "landingLead": "Alles wat je nodig hebt om je collectie op te bouwen, voltooiingen vast te leggen en puzzels te ruilen met de community.",
       "skipToContent": "Naar inhoud springen",
       "navSheetTitle": "Documentatienavigatie",
       "navSheetDescription": "Blader door de JigSwap-documentatie op onderwerp.",
@@ -2556,7 +2556,7 @@
       },
       "completionNew": {
         "title": "Voltooiing vastleggen",
-        "subtitle": "Kies een puzzel om een oplossing tegen te registreren.",
+        "subtitle": "Kies een puzzel om een voltooiing voor te registreren.",
         "description": "Nieuwe voltooiing vastleggen"
       },
       "goals": {
@@ -2755,7 +2755,7 @@
     },
     "actions": {
       "edit": "Bewerken",
-      "logSolve": "Oplossing vastleggen",
+      "logSolve": "Voltooiing vastleggen",
       "delete": "Verwijderen",
       "requestSwap": "Ruil aanvragen",
       "message": "Bericht",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -139,7 +139,7 @@
           "title": "Persoonlijke Analyses",
           "items": [
             "Bekijk voltooiingsstatistieken",
-            "Analyseer voltooiingstijd-trends",
+            "Analyseer oplostijd-trends",
             "Stel persoonlijke doelen in en volg ze",
             "Exporteer je gegevens"
           ]

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1756,6 +1756,8 @@
       "finished": "Voltooid {date}",
       "time": "{hours} u {minutes} m",
       "timeMinutes": "{minutes} m",
+      "timeDays": "{days, plural, one {# dag} other {# dagen}}",
+      "timeDaysHours": "{days}d {hours} u {minutes} m",
       "noTime": "Geen tijd vastgelegd",
       "finish": "Oplossing afronden",
       "edit": "Bewerken",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -1881,6 +1881,8 @@
       "ratingReceived": "Gem. ontvangen beoordeling",
       "time": "{hours}u {minutes}m",
       "timeMinutes": "{minutes}m",
+      "timeDays": "{days, plural, one {# dag} other {# dagen}}",
+      "timeDaysHours": "{days}d {hours}u {minutes}m",
       "ratingNone": "—"
     },
     "trends": {

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1881,6 +1881,8 @@
       "ratingReceived": "Avg rating received",
       "time": "{hours}h {minutes}m",
       "timeMinutes": "{minutes}m",
+      "timeDays": "{days, plural, one {# day} other {# days}}",
+      "timeDaysHours": "{days}d {hours}h {minutes}m",
       "ratingNone": "—"
     },
     "trends": {

--- a/apps/web/locales/source.json
+++ b/apps/web/locales/source.json
@@ -1756,6 +1756,8 @@
       "finished": "Finished {date}",
       "time": "{hours}h {minutes}m",
       "timeMinutes": "{minutes}m",
+      "timeDays": "{days, plural, one {# day} other {# days}}",
+      "timeDaysHours": "{days}d {hours}h {minutes}m",
       "noTime": "No time recorded",
       "finish": "Finish solve",
       "edit": "Edit",

--- a/apps/web/src/components/dashboard-layout/shell.tsx
+++ b/apps/web/src/components/dashboard-layout/shell.tsx
@@ -26,6 +26,7 @@ import {
   usePageHeaderContent,
 } from "./page-header-slot";
 import { ShellPreferencesProvider, useShellPreferences } from "./preferences";
+import { SyncPreferredLanguage } from "./sync-preferred-language";
 import { TopBar } from "./top-bar";
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
@@ -34,6 +35,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
     <ShellPreferencesProvider>
       <PageHeaderSlotProvider>
+        <SyncPreferredLanguage />
         {/* Mobile scrolls the document itself (no height cap, no overflow clip
             below md) so the browser's address bar auto-hides on scroll-down and
             returns on scroll-up — the regular-website behaviour. The mobile top

--- a/apps/web/src/components/dashboard-layout/sync-preferred-language.tsx
+++ b/apps/web/src/components/dashboard-layout/sync-preferred-language.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCurrentMember } from "@/components/dashboard-home/use-current-member";
+import { gateway } from "@/gateway";
+import { useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { useLocale } from "use-intl";
+
+// Emails localize from `users.preferredLanguage` (hardcoded "en" at account
+// creation, otherwise only ever written by the profile editor's language
+// field). The app's actual UI language instead lives in the `jigswap-intl`
+// cookie (apps/web/src/lib/i18n.ts) set by whichever language switcher the
+// member used, so the two silently diverge and outbound emails never match
+// what the member reads the app in. Mounted once in the dashboard shell, this
+// null-rendering component reconciles them: whenever the signed-in member is
+// known and their `preferredLanguage` differs from the active `useLocale()`,
+// it pushes the app locale into the backend. Switcher-agnostic (works no
+// matter which UI wrote the cookie) and self-healing — accounts created
+// before this fix converge to the correct locale on their next app load.
+export function SyncPreferredLanguage() {
+  const locale = useLocale();
+  const { member } = useCurrentMember();
+  const { mutateAsync: updateProfile } = useMutation({
+    mutationFn: useConvexMutation(gateway.identity.updateProfile),
+  });
+
+  // Remembers the last locale we attempted to sync so a slow reactive
+  // round-trip (member.preferredLanguage hasn't caught up to the write yet)
+  // can't fire the mutation twice for the same mismatch. A failed sync isn't
+  // retried until the locale changes again or the component remounts.
+  const lastSyncedLocale = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!member) return;
+    if (member.preferredLanguage === locale) return;
+    if (lastSyncedLocale.current === locale) return;
+    lastSyncedLocale.current = locale;
+    // Fire-and-forget: only preferredLanguage is sent (bio/location are
+    // optional args the backend patch leaves untouched when absent), and a
+    // sync failure must never surface to the user.
+    updateProfile({ preferredLanguage: locale }).catch(() => {});
+  }, [locale, member, updateProfile]);
+
+  return null;
+}

--- a/apps/web/src/components/insights/stat-cards.tsx
+++ b/apps/web/src/components/insights/stat-cards.tsx
@@ -23,8 +23,15 @@ export function StatCards({ stats }: { stats: PersonalStats }) {
   const t = useTranslations("insights.stats");
 
   const formatTime = (minutes: number): string => {
-    const h = Math.floor(minutes / 60);
-    const m = minutes % 60;
+    const days = Math.floor(minutes / 1440);
+    const rest = minutes % 1440;
+    const h = Math.floor(rest / 60);
+    const m = rest % 60;
+    if (days > 0) {
+      return h === 0 && m === 0
+        ? t("timeDays", { days })
+        : t("timeDaysHours", { days, hours: h, minutes: m });
+    }
     return h > 0
       ? t("time", { hours: h, minutes: m })
       : t("timeMinutes", { minutes: m });

--- a/apps/web/src/components/notifications/channel-matrix.tsx
+++ b/apps/web/src/components/notifications/channel-matrix.tsx
@@ -90,12 +90,12 @@ export function ChannelMatrix({
   );
 
   return (
-    <>
+    <div className="@container/matrix">
       {/* Desktop matrix */}
       <div
         role="grid"
         aria-label={t("matrixLabel")}
-        className="hidden overflow-hidden rounded-lg border sm:block"
+        className="hidden overflow-hidden rounded-lg border @2xl/matrix:block"
       >
         <div
           role="row"
@@ -243,7 +243,7 @@ export function ChannelMatrix({
       </div>
 
       {/* Mobile: stacked per-category groups with labelled switches */}
-      <div className="divide-border divide-y sm:hidden">
+      <div className="divide-border divide-y @2xl/matrix:hidden">
         {NOTIFICATION_CATEGORIES.map((category) => {
           const visible = category.types.filter((type) =>
             visibleTypes.includes(type),
@@ -370,6 +370,6 @@ export function ChannelMatrix({
           );
         })}
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/notifications/notification-preferences-panel.tsx
+++ b/apps/web/src/components/notifications/notification-preferences-panel.tsx
@@ -89,8 +89,8 @@ export function NotificationPreferencesPanel() {
   };
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[300px_minmax(0,1fr)] lg:gap-10">
-      <aside className="flex flex-col gap-6 lg:sticky lg:top-2 lg:self-start">
+    <div className="@container/prefs grid gap-6 @4xl/prefs:grid-cols-[300px_minmax(0,1fr)] @4xl/prefs:gap-10">
+      <aside className="flex flex-col gap-6 @4xl/prefs:sticky @4xl/prefs:top-2 @4xl/prefs:self-start">
         <PushDeviceSection />
         <p className="text-muted-foreground max-w-prose text-sm">
           {t("channelsNote")}

--- a/apps/web/src/components/puzzles/definition-card.tsx
+++ b/apps/web/src/components/puzzles/definition-card.tsx
@@ -46,6 +46,7 @@ export function DefinitionCard({ card }: { card: CatalogCard }) {
       }}
       badges={badges}
       imageHref={`/catalog/${card._id}`}
+      imageFit="contain"
     />
   );
 }

--- a/apps/web/src/components/puzzles/puzzle-card.tsx
+++ b/apps/web/src/components/puzzles/puzzle-card.tsx
@@ -42,6 +42,7 @@ export function PuzzleCard({ puzzle }: PuzzleCardProps) {
         imageUrl: puzzle.image,
       }}
       imageHref={`/puzzles/${puzzle._id}`}
+      imageFit="contain"
       actions={
         // The grid columns are ~212px wide, so the row must fit two buttons
         // without overflowing the card (which is `overflow-hidden`). The primary

--- a/apps/web/src/routes/_dashboard/completions/index.tsx
+++ b/apps/web/src/routes/_dashboard/completions/index.tsx
@@ -152,8 +152,15 @@ function CompletionsPage() {
 
   const formatTime = (minutes?: number): string => {
     if (minutes === undefined) return t("noTime");
-    const h = Math.floor(minutes / 60);
-    const m = minutes % 60;
+    const days = Math.floor(minutes / 1440);
+    const rest = minutes % 1440;
+    const h = Math.floor(rest / 60);
+    const m = rest % 60;
+    if (days > 0) {
+      return h === 0 && m === 0
+        ? t("timeDays", { days })
+        : t("timeDaysHours", { days, hours: h, minutes: m });
+    }
     return h > 0
       ? t("time", { hours: h, minutes: m })
       : t("timeMinutes", { minutes: m });

--- a/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
@@ -12,8 +12,11 @@ and `packages/backend/convex/notifications/getMyPreferences.ts`):
 
 - `set()` seeds a missing type entry from `emptyChannelToggles()` (all-off), so the
   first email/push enable on an untouched type silently disables its in-app delivery.
+  Note: that seeding always wrote FULL triples with an explicit `inApp: false` — never
+  partial entries.
 - `allows()` gives stored entries absolute precedence with `stored[channel] === true`,
-  so the corrupted entries (absent `inApp` key) read as off.
+  so a channel key absent from a stored entry reads as off instead of falling back to
+  its default (a latent hazard for channels added after a row was written).
 - `getMyPreferences` returns RAW stored toggles: types absent from older rows render
   as all-off in the matrix while deliveries follow defaults — and clicking in-app on
   is a domain no-op, matching the reported "can only enable in-app after email/push".
@@ -21,8 +24,12 @@ and `packages/backend/convex/notifications/getMyPreferences.ts`):
 Fix (domain + one query; no migration):
 
 - `allows()` falls back PER CHANNEL: `stored[type]?.[channel] ?? defaultToggles()[type][channel]`.
-  Deliberate disables always wrote an explicit `false`, so an absent channel key only
-  exists via the seeding bug — this heals corrupted rows retroactively.
+  The fallback's genuine role is type-level absence (untouched types, or types added
+  after the row was written) and forward-compat for channels added later. Rows already
+  corrupted pre-fix carry an explicit `inApp: false` indistinguishable from a deliberate
+  email-only configuration, so NO migration can repair them without clobbering
+  legitimate choices — accepted loss, mitigated because the in-app toggle now works and
+  affected members can re-enable themselves.
 - `set()` seeds missing entries from `defaultToggles()[type]`.
 - New `resolvedToggles()` on the aggregate: full 21-type map, stored values winning
   per channel over defaults. `getMyPreferences` returns it in both branches (stored
@@ -51,5 +58,6 @@ implementation report for a later product decision; do not change them.
 
 ## Out of scope
 
-Data migration (fix 1 heals in place); changing other image surfaces; per-switcher
-locale wiring (the shell sync covers all of them).
+Data migration — corrupted rows are indistinguishable from deliberate email-only
+configs; self-service repair via the now-working toggle. Changing other image
+surfaces; per-switcher locale wiring (the shell sync covers all of them).

--- a/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
@@ -1,0 +1,55 @@
+# Notification Preference Integrity, Email Locale Sync, Catalogue Image Fit
+
+**Date:** 2026-07-14
+**Status:** Approved
+
+Three small fixes, one PR off main (post-#64).
+
+## Fix 1 — preference toggles: absent ≠ off
+
+Bugs (verified in `packages/domain/src/notifications/domain/notification-preference.ts`
+and `packages/backend/convex/notifications/getMyPreferences.ts`):
+
+- `set()` seeds a missing type entry from `emptyChannelToggles()` (all-off), so the
+  first email/push enable on an untouched type silently disables its in-app delivery.
+- `allows()` gives stored entries absolute precedence with `stored[channel] === true`,
+  so the corrupted entries (absent `inApp` key) read as off.
+- `getMyPreferences` returns RAW stored toggles: types absent from older rows render
+  as all-off in the matrix while deliveries follow defaults — and clicking in-app on
+  is a domain no-op, matching the reported "can only enable in-app after email/push".
+
+Fix (domain + one query; no migration):
+
+- `allows()` falls back PER CHANNEL: `stored[type]?.[channel] ?? defaultToggles()[type][channel]`.
+  Deliberate disables always wrote an explicit `false`, so an absent channel key only
+  exists via the seeding bug — this heals corrupted rows retroactively.
+- `set()` seeds missing entries from `defaultToggles()[type]`.
+- New `resolvedToggles()` on the aggregate: full 21-type map, stored values winning
+  per channel over defaults. `getMyPreferences` returns it in both branches (stored
+  row → rehydrated aggregate; no row → default aggregate).
+- TDD: failing specs reproduce both bugs first; mutation gate ≥95 on the file;
+  backend test: a stored row missing newer types yields the resolved map.
+
+## Fix 2 — email locale never reaches the backend
+
+`users.preferredLanguage` is hardcoded `"en"` on creation and only written by
+`updateUserProfile`; the app's language lives in the `jigswap-intl` cookie. Emails
+localize from `preferredLanguage` → everyone gets English.
+
+Fix: a `SyncPreferredLanguage` null-component mounted in the dashboard shell — when
+authenticated and `useLocale()` differs from the member's `preferredLanguage`, call
+`gateway.users.updateProfile({ preferredLanguage: locale })` once per mismatch
+(guard against loops/spam with a ref). Switcher-agnostic; self-heals existing users
+on next app load.
+
+## Fix 3 — catalogue puzzle images contained
+
+`PuzzleCardShell` already supports `imageFit: "cover" | "contain"` (default cover);
+only my-puzzles passes `contain`. Pass `imageFit="contain"` at the puzzle-catalogue
+call sites (browse / puzzles listing). Enumerate remaining `cover` surfaces in the
+implementation report for a later product decision; do not change them.
+
+## Out of scope
+
+Data migration (fix 1 heals in place); changing other image surfaces; per-switcher
+locale wiring (the shell sync covers all of them).

--- a/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
@@ -45,7 +45,7 @@ localize from `preferredLanguage` → everyone gets English.
 
 Fix: a `SyncPreferredLanguage` null-component mounted in the dashboard shell — when
 authenticated and `useLocale()` differs from the member's `preferredLanguage`, call
-`gateway.users.updateProfile({ preferredLanguage: locale })` once per mismatch
+`gateway.identity.updateProfile({ preferredLanguage: locale })` once per mismatch
 (guard against loops/spam with a ref). Switcher-agnostic; self-heals existing users
 on next app load.
 

--- a/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
@@ -86,3 +86,21 @@ vastleggen", "Voltooiing afronden", "Moeilijkste voltooiing", "Voltooiingen
 per maand" — never a blind replace). `en.json`/`source.json` untouched except
 where a key is display-shared. Only genuinely solve-related strings change;
 unrelated uses of "oplossing" (if any) stay.
+
+## Fix 6 — preferences panel/matrix adapt to CONTAINER width
+
+The `NotificationPreferencesPanel` + `ChannelMatrix` render both on the
+dedicated page and inside the Clerk profile modal; their viewport breakpoints
+(`lg:` aside split, `sm:` matrix desktop/stacked split) overflow the narrow
+modal on wide screens. Fix with Tailwind v4 container queries (pattern already
+in the repo, `card.tsx`):
+
+- Panel root: named container `@container/prefs`; the aside grid + sticky
+  variants move from `lg:` to `@4xl/prefs:` (~56rem actual width).
+- Matrix: own named container `@container/matrix`; the desktop-grid vs stacked
+  split moves from `sm:`/`sm:hidden` to `@2xl/matrix:` (~42rem — what the
+  switch columns + labels genuinely need). Jump-to links already resolve the
+  visible branch at click time — unchanged.
+- Accepted consequence: layouts respond to actual available space (e.g. a
+  ~1024px window with the sidebar gets single-column on the dedicated page
+  until the aside genuinely fits).

--- a/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-14-notification-fixes-design.md
@@ -61,3 +61,28 @@ implementation report for a later product decision; do not change them.
 Data migration — corrupted rows are indistinguishable from deliberate email-only
 configs; self-service repair via the now-working toggle. Changing other image
 surfaces; per-switcher locale wiring (the shell sync covers all of them).
+
+## Fix 4 — completion duration semantics (added same day)
+
+- `Completion.resolveDuration` (record/finish/edit paths): when no explicit
+  duration is given and `startDate.getTime() === endDate.getTime()` (date-only
+  inputs → same local midnight), derive 1 day (1440 minutes) instead of
+  `undefined`. Larger spans keep deriving the actual difference.
+- `SolveDuration.ofMinutes`: round BEFORE validating so a tiny positive span
+  yields 1 minute, never a stored 0 (current order can store 0 for <30s spans).
+  `between` inherits the fix.
+- Display (`completions/index.tsx` `formatTime` and any sibling formatter):
+  day-aware — whole days render as "N day(s)" (nl "dag(en)"), day+hour+minute
+  composition for mixed spans; sub-day formatting unchanged. New locale keys in
+  en/nl/source.
+- Existing rows are not migrated; a stray 1-minute row is user-editable.
+
+## Fix 5 — nl terminology: voltooiing, not oplossing
+
+Align the solve-logging/completions/insights/export strings in `nl.json`
+(~20 occurrences of "oplossing*") to the "voltooiing*" family the marketing
+pages already use. Per-string grammatical rewrites (e.g. "Voltooiing
+vastleggen", "Voltooiing afronden", "Moeilijkste voltooiing", "Voltooiingen
+per maand" — never a blind replace). `en.json`/`source.json` untouched except
+where a key is display-shared. Only genuinely solve-related strings change;
+unrelated uses of "oplossing" (if any) stay.

--- a/packages/backend/convex/getMyPreferences.test.ts
+++ b/packages/backend/convex/getMyPreferences.test.ts
@@ -1,0 +1,59 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+// Bundle every Convex module for the in-memory runtime, excluding test files.
+const modules = import.meta.glob(["./**/*.{js,ts}", "!./**/*.test.{js,ts}"]);
+
+const seedMember = (t: ReturnType<typeof convexTest>) =>
+  t.run(async (ctx) => {
+    const now = Date.now();
+    return ctx.db.insert("users", {
+      clerkId: "clerk_alice",
+      email: "alice@example.com",
+      name: "clerk_alice",
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+const asMember = (t: ReturnType<typeof convexTest>) =>
+  t.withIdentity({ subject: "clerk_alice" });
+
+describe("getMyPreferences", () => {
+  test("resolves a stored row that only has one type entry into the full resolved map", async () => {
+    const t = convexTest(schema, modules);
+    const memberId = await seedMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notificationPreferences", {
+        aggregateId: "pref_alice",
+        memberId,
+        // Only one type stored, and (synthetically) only its email channel: pins the per-channel
+        // fallback mechanism for absent keys; persisted entries have always been full triples.
+        toggles: { trade_request: { email: true } },
+        updatedAt: Date.now(),
+      });
+    });
+
+    const prefs = await asMember(t).query(
+      api.notifications.getMyPreferences.getMyPreferences,
+      {},
+    );
+
+    expect(Object.keys(prefs)).toHaveLength(21);
+    // The stored email wins; the absent inApp key falls back to its default (true).
+    expect(prefs.trade_request).toEqual({
+      inApp: true,
+      email: true,
+      push: false,
+    });
+    // A type never in the stored row resolves to the plain default triple.
+    expect(prefs.goal_achieved).toEqual({
+      inApp: true,
+      email: false,
+      push: false,
+    });
+  });
+});

--- a/packages/backend/convex/notifications/adapters/convexNotificationPreferenceRepository.ts
+++ b/packages/backend/convex/notifications/adapters/convexNotificationPreferenceRepository.ts
@@ -13,7 +13,10 @@ import type { MutationCtx } from "../../_generated/server";
 // (`notificationPreferences`). One row per member, keyed by `memberId`. `toggles` is the resolved
 // type->channel->enabled map, plain JSON, stored as-is (v.any) so the mapping is a direct copy.
 
-const toDomain = (
+// Exported so read-only queries (which get a QueryCtx, not the MutationCtx this adapter's
+// `findByMember` requires) can still rehydrate a row into the aggregate without duplicating the
+// mapping (see notifications/getMyPreferences.ts).
+export const toDomain = (
   row: Doc<"notificationPreferences">,
 ): NotificationPreference => {
   const state: NotificationPreferenceState = {

--- a/packages/backend/convex/notifications/getMyPreferences.ts
+++ b/packages/backend/convex/notifications/getMyPreferences.ts
@@ -6,11 +6,14 @@ import {
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../identity/requireMember";
+import { toDomain } from "./adapters/convexNotificationPreferenceRepository";
 
-// Read side: the caller's notification preference toggles (type -> channel -> enabled). If the
-// member has no stored preference yet, returns the sensible defaults (all types on inApp; email/
-// push off) WITHOUT persisting — reads stay side-effect-free; the row is materialised lazily on
-// the first toggle (updateNotificationPreference) or the first NotifyMember.
+// Read side: the caller's resolved notification preferences (type -> {inApp, email, push}), the
+// same per-channel stored-over-default merge `allows` uses for delivery. Every NOTIFICATION_TYPES
+// member is present: types absent from an older stored row (untouched, or added after the row was
+// written) resolve to their defaults; explicit stored values (including false) always win. Reads
+// stay side-effect-free — the row is materialised lazily on the first toggle
+// (updateNotificationPreference) or NotifyMember.
 export const getMyPreferences = query({
   args: {},
   handler: async (ctx) => {
@@ -22,7 +25,9 @@ export const getMyPreferences = query({
       )
       .unique();
 
-    if (row) return row.toggles;
+    // `toDomain` is the repository's mapper, reused here directly: this is a `query` (QueryCtx),
+    // while the repository itself is typed against MutationCtx for its write-capable `save`.
+    if (row) return toDomain(row).resolvedToggles();
 
     // No stored preference: derive the defaults in the domain so this query and NotifyMember agree.
     const fresh = NotificationPreference.createDefault(
@@ -30,6 +35,6 @@ export const getMyPreferences = query({
       toMemberId(memberId as string),
       new Date(),
     );
-    return fresh.toState().toggles;
+    return fresh.resolvedToggles();
   },
 });

--- a/packages/backend/convex/solvingMutations.test.ts
+++ b/packages/backend/convex/solvingMutations.test.ts
@@ -330,7 +330,7 @@ describe("solving.recordCompletion", () => {
     expect(row?.endDate).toBeUndefined();
   });
 
-  test("same-day completion (startDate == endDate, no explicit time) succeeds with undefined duration", async () => {
+  test("same-day completion (startDate == endDate, no explicit time) counts one day (1440 minutes)", async () => {
     const t = convexTest(schema, modules);
     const { copyAggregateId } = await seed(t);
     const today = Date.now();
@@ -340,7 +340,7 @@ describe("solving.recordCompletion", () => {
     )) as string;
     const row = await completionRow(t, completionId);
     expect(row?.isCompleted).toBe(true);
-    expect(row?.completionTimeMinutes).toBeUndefined();
+    expect(row?.completionTimeMinutes).toBe(1440);
   });
 });
 

--- a/packages/domain/src/notifications/domain/notification-preference.spec.ts
+++ b/packages/domain/src/notifications/domain/notification-preference.spec.ts
@@ -111,17 +111,89 @@ describe("NotificationPreference with a sparse (rehydrated) toggle map", () => {
     expect(pref.allows("puzzle_approved", "inApp")).toBe(false);
   });
 
-  it("seeds an all-off channel map when first toggling an absent type", () => {
+  it("seeds a type from its defaults when first toggling an absent type", () => {
     const pref = sparse();
     pref.enable("trade_request", "email", LATER);
     expect(pref.allows("trade_request", "email")).toBe(true);
-    // The freshly-seeded type's other channels stay off by default.
-    expect(pref.allows("trade_request", "inApp")).toBe(false);
+    // The freshly-seeded type keeps its default in-app delivery; only email was toggled on.
+    expect(pref.allows("trade_request", "inApp")).toBe(true);
     expect(pref.allows("trade_request", "push")).toBe(false);
-    // The persisted shape is the FULL resolved map (explicit falses), not just the toggled channel.
+    // The persisted shape is the FULL resolved map (defaults + the toggle), not just the toggled channel.
     expect(pref.toState().toggles.trade_request).toEqual({
+      inApp: true,
+      email: true,
+      push: false,
+    });
+  });
+
+  it("enabling email on an untouched type preserves its default in-app delivery", () => {
+    const pref = sparse();
+    pref.enable("trade_request", "email", LATER);
+    // Before this fix, seeding from an all-off map meant enabling email silently disabled inApp.
+    expect(pref.allows("trade_request", "inApp")).toBe(true);
+  });
+
+  it("a stored entry missing a channel key falls back to that channel's default", () => {
+    // Pins the fallback MECHANISM for absent keys (forward-compat for channels added after a row
+    // was written); persisted entries have always been full triples, so this shape is synthetic.
+    const pref = NotificationPreference.rehydrate({
+      id,
+      memberId: alice,
+      toggles: { trade_request: { email: true } },
+      updatedAt: NOW,
+    });
+    expect(pref.allows("trade_request", "inApp")).toBe(true);
+    expect(pref.allows("trade_request", "email")).toBe(true);
+    expect(pref.allows("trade_request", "push")).toBe(false);
+  });
+
+  it("an explicit stored false always wins over the default (deliberate opt-outs are never overridden)", () => {
+    const pref = NotificationPreference.rehydrate({
+      id,
+      memberId: alice,
+      toggles: { trade_request: { inApp: false, email: true, push: false } },
+      updatedAt: NOW,
+    });
+    expect(pref.allows("trade_request", "inApp")).toBe(false);
+    expect(pref.resolvedToggles().trade_request).toEqual({
       inApp: false,
       email: true,
+      push: false,
+    });
+  });
+});
+
+describe("NotificationPreference.resolvedToggles", () => {
+  it("covers every type with explicit triples, stored values winning", () => {
+    const pref = NotificationPreference.rehydrate({
+      id,
+      memberId: alice,
+      toggles: {
+        // Synthetic partial entry: no inApp key -- pins the per-channel fallback to the default.
+        trade_request: { email: true },
+      },
+      updatedAt: NOW,
+    });
+    const resolved = pref.resolvedToggles();
+
+    expect(Object.keys(resolved)).toHaveLength(NOTIFICATION_TYPES.length);
+    for (const type of NOTIFICATION_TYPES) {
+      expect(resolved[type]).toEqual({
+        inApp: pref.allows(type, "inApp"),
+        email: pref.allows(type, "email"),
+        push: pref.allows(type, "push"),
+      });
+    }
+    // The stored channel wins; the absent channel falls back to its default.
+    expect(resolved.trade_request).toEqual({
+      inApp: true,
+      email: true,
+      push: false,
+    });
+    // A type entirely absent from the stored map resolves to plain defaults.
+    expect(resolved.goal_achieved).toEqual({
+      inApp: true,
+      email: false,
       push: false,
     });
   });

--- a/packages/domain/src/notifications/domain/notification-preference.ts
+++ b/packages/domain/src/notifications/domain/notification-preference.ts
@@ -7,6 +7,10 @@ import { NOTIFICATION_TYPES, NotificationType } from "./notification-type";
 // The set of channels enabled for a single notification type. A missing channel means disabled.
 export type ChannelToggles = Readonly<Partial<Record<Channel, boolean>>>;
 
+// A channel toggle map with every channel explicitly resolved -- what `defaultToggles` and
+// `resolvedToggles` always produce (no absent keys to fall back on).
+type ResolvedChannelToggles = Readonly<Record<Channel, boolean>>;
+
 // The persistable shape: per (type, channel) enablement, plus the member it belongs to. We store
 // only the toggles that differ from "off" is NOT assumed — we store the full resolved map so the
 // 4a-backend mapper is a plain serialise; `allows` reads it directly without re-deriving defaults.
@@ -20,8 +24,8 @@ export interface NotificationPreferenceState {
 
 // Build the sensible default toggle map: every type enabled on inApp, email/push off. This is the
 // policy a member with no stored preference gets (the application layer materialises one of these).
-const defaultToggles = (): Record<NotificationType, ChannelToggles> => {
-  const map = {} as Record<NotificationType, ChannelToggles>;
+const defaultToggles = (): Record<NotificationType, ResolvedChannelToggles> => {
+  const map = {} as Record<NotificationType, ResolvedChannelToggles>;
   for (const type of NOTIFICATION_TYPES) {
     map[type] = { inApp: true, email: false, push: false };
   }
@@ -58,15 +62,29 @@ export class NotificationPreference {
     });
   }
 
-  // Does this member accept a notification of `type` on `channel`? A type absent from the stored
-  // map falls back to that type's default toggles (see `defaultToggles`) -- absent means "never
-  // asked", not "opted out". An explicitly stored value, even a disabled one, always wins.
+  // Does this member accept a notification of `type` on `channel`? Falls back PER CHANNEL: absent
+  // keys arise from type-level absence (untouched types, or types added after the row was written)
+  // or channels added later; an explicit stored value (including false) always wins.
   allows(type: NotificationType, channel: Channel): boolean {
-    const stored = this.state.toggles[type];
-    if (stored) {
-      return stored[channel] === true;
+    return (
+      this.state.toggles[type]?.[channel] ?? defaultToggles()[type][channel]
+    );
+  }
+
+  // The full 21-type read model: every NOTIFICATION_TYPES member resolved to its complete
+  // {inApp, email, push} triple, via the same per-channel stored-over-default merge as `allows`.
+  // This is the READ-side truth the preferences UI renders; `allows` is the delivery-side
+  // equivalent.
+  resolvedToggles(): Readonly<Record<NotificationType, ChannelToggles>> {
+    const resolved = {} as Record<NotificationType, ChannelToggles>;
+    for (const type of NOTIFICATION_TYPES) {
+      const triple = {} as Record<Channel, boolean>;
+      for (const channel of CHANNELS) {
+        triple[channel] = this.allows(type, channel);
+      }
+      resolved[type] = triple;
     }
-    return defaultToggles()[type][channel] === true;
+    return resolved;
   }
 
   // Turn a (type, channel) delivery on. Records PreferenceChanged only when it actually changed.
@@ -108,7 +126,7 @@ export class NotificationPreference {
     if (this.allows(type, channel) === enabled) {
       return;
     }
-    const current = this.state.toggles[type] ?? this.emptyChannelToggles();
+    const current = this.state.toggles[type] ?? defaultToggles()[type];
     const nextForType: ChannelToggles = { ...current, [channel]: enabled };
     this.state = {
       ...this.state,
@@ -118,14 +136,6 @@ export class NotificationPreference {
     this.record(
       new PreferenceChanged(this.state.memberId, type, channel, enabled, now),
     );
-  }
-
-  private emptyChannelToggles(): ChannelToggles {
-    const map: Partial<Record<Channel, boolean>> = {};
-    for (const channel of CHANNELS) {
-      map[channel] = false;
-    }
-    return map;
   }
 
   private record(event: DomainEvent): void {

--- a/packages/domain/src/solving/domain/completion.spec.ts
+++ b/packages/domain/src/solving/domain/completion.spec.ts
@@ -386,6 +386,14 @@ describe("Completion.edit", () => {
     expect(recorded.value.toState().completionTimeMinutes).toBe(15);
   });
 
+  it("edits to equal end/start without explicit minutes and counts one day (1440 minutes)", () => {
+    const recorded = recordValid();
+    if (!recorded.isOk) throw new Error("setup failed");
+    const outcome = recorded.value.edit(ALICE, { endDate: START }, END);
+    expect(outcome.isOk).toBe(true);
+    expect(recorded.value.toState().completionTimeMinutes).toBe(1440);
+  });
+
   it("recomputes duration when only the explicit minutes change", () => {
     const recorded = recordValid(); // span 90
     if (!recorded.isOk) throw new Error("setup failed");

--- a/packages/domain/src/solving/domain/completion.spec.ts
+++ b/packages/domain/src/solving/domain/completion.spec.ts
@@ -92,12 +92,12 @@ describe("Completion.record", () => {
     if (result.isErr) expect(result.error.code).toBe("InvalidTimeRange");
   });
 
-  it("allows equal start/end (same-day) and leaves completionTimeMinutes undefined", () => {
+  it("allows equal start/end (same-day) and counts one day (1440 minutes)", () => {
     const result = recordValid({ endDate: START });
     expect(result.isOk).toBe(true);
     if (!result.isOk) return;
     expect(result.value.isCompleted).toBe(true);
-    expect(result.value.toState().completionTimeMinutes).toBeUndefined();
+    expect(result.value.toState().completionTimeMinutes).toBe(1440);
   });
 
   it("allows equal start/end with an explicit positive time and stores that time", () => {
@@ -114,10 +114,33 @@ describe("Completion.record", () => {
       expect(result.value.toState().completionTimeMinutes).toBe(45);
   });
 
+  it("derives a multi-day span in minutes rather than the one-day fallback", () => {
+    const result = recordValid({
+      endDate: new Date("2026-06-03T10:00:00Z"), // 2 days after START
+    });
+    expect(result.isOk).toBe(true);
+    if (result.isOk)
+      expect(result.value.toState().completionTimeMinutes).toBe(2880);
+  });
+
   it("rejects more than five photos", () => {
     const result = recordValid({ photos: photos(6) });
     expect(result.isErr).toBe(true);
     if (result.isErr) expect(result.error.code).toBe("TooManyPhotos");
+  });
+
+  it("rejects an explicit negative completionTimeMinutes with InvalidDuration", () => {
+    const result = recordValid({ completionTimeMinutes: -5 });
+    expect(result.isErr).toBe(true);
+    if (result.isErr) expect(result.error.code).toBe("InvalidDuration");
+  });
+
+  it("rejects a derived sub-30-second span with InvalidDuration", () => {
+    const result = recordValid({
+      endDate: new Date(START.getTime() + 10_000), // 10s span, no explicit minutes
+    });
+    expect(result.isErr).toBe(true);
+    if (result.isErr) expect(result.error.code).toBe("InvalidDuration");
   });
 
   it("records PuzzleReviewed when a review is supplied", () => {
@@ -172,6 +195,21 @@ describe("Completion.finish", () => {
     const outcome = started.value.finish(new Date("2026-06-01T09:00:00Z"), NOW);
     expect(outcome.isErr).toBe(true);
     if (outcome.isErr) expect(outcome.error.code).toBe("InvalidTimeRange");
+  });
+
+  it("finishes with equal end/start (same-day) and counts one day (1440 minutes)", () => {
+    const started = Completion.start({
+      id: ID,
+      userId: ALICE,
+      startDate: START,
+      now: NOW,
+    });
+    if (!started.isOk) throw new Error("setup failed");
+    started.value.pullEvents();
+
+    const outcome = started.value.finish(START, NOW);
+    expect(outcome.isOk).toBe(true);
+    expect(started.value.toState().completionTimeMinutes).toBe(1440);
   });
 
   it("accepts an equal end/start when an explicit duration is supplied", () => {

--- a/packages/domain/src/solving/domain/completion.ts
+++ b/packages/domain/src/solving/domain/completion.ts
@@ -18,6 +18,9 @@ export const MAX_PHOTOS = 5;
 // Edits are only allowed within this window after the completion was recorded (documented rule).
 export const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+// A date-only same-day completion (start == end, no explicit duration) counts as one day.
+const MINUTES_PER_DAY = 1440;
+
 // Input to start(): an in-progress solve (no end yet).
 export interface StartCompletionProps {
   readonly id: CompletionId;
@@ -353,10 +356,10 @@ export class Completion {
 
   // --- internals ---
 
-  // Reconcile a supplied duration with the start/end span. Returns the resolved minutes (or
-  // undefined when the span is zero and no explicit minutes were given — duration is then unknown).
-  // An explicit minutes value must be a positive number. An explicit end-before-start is rejected
-  // before this helper is called, so the only "no duration" case is start == end.
+  // Reconcile a supplied duration with the start/end span. Returns the resolved minutes. An
+  // explicit minutes value must be a positive number. An explicit end-before-start is rejected
+  // before this helper is called, so the only span-derived cases are start < end (actual span)
+  // and start == end (date-only same-day completion, no explicit time given).
   private static resolveDuration(
     start: Date,
     end: Date,
@@ -372,8 +375,9 @@ export class Completion {
       if (duration.isErr) return err(duration.error);
       return ok(duration.value.minutes);
     }
-    // start == end: duration is unknown (same-day solve with no explicit time).
-    return ok(undefined);
+    // start == end: date-only same-day completions count as one day (product decision,
+    // spec 2026-07-14 Fix 4).
+    return ok(MINUTES_PER_DAY);
   }
 
   private record(event: DomainEvent): void {

--- a/packages/domain/src/solving/domain/solve-duration.spec.ts
+++ b/packages/domain/src/solving/domain/solve-duration.spec.ts
@@ -14,6 +14,20 @@ describe("SolveDuration", () => {
     if (result.isOk) expect(result.value.minutes).toBe(90);
   });
 
+  it("rejects a sub-30-second span that would round down to zero", () => {
+    // Rounds to 0 before the fix's re-ordering — the positive-minutes invariant must reject it,
+    // never store a 0.
+    const result = SolveDuration.ofMinutes(0.2);
+    expect(result.isErr).toBe(true);
+    if (result.isErr) expect(result.error.code).toBe("InvalidDuration");
+  });
+
+  it("rounds a span at the half-minute boundary up to one minute", () => {
+    const result = SolveDuration.ofMinutes(0.6);
+    expect(result.isOk).toBe(true);
+    if (result.isOk) expect(result.value.minutes).toBe(1);
+  });
+
   it.each([0, -5, Number.NaN, Number.POSITIVE_INFINITY])(
     "rejects %p with InvalidDuration",
     (value) => {
@@ -29,6 +43,14 @@ describe("SolveDuration", () => {
     const result = SolveDuration.between(start, end);
     expect(result.isOk).toBe(true);
     if (result.isOk) expect(result.value.minutes).toBe(90);
+  });
+
+  it("rounds a 45-second span up to one minute", () => {
+    const start = new Date("2026-06-01T10:00:00Z");
+    const end = new Date("2026-06-01T10:00:45Z");
+    const result = SolveDuration.between(start, end);
+    expect(result.isOk).toBe(true);
+    if (result.isOk) expect(result.value.minutes).toBe(1);
   });
 
   it("rejects a zero-length span", () => {

--- a/packages/domain/src/solving/domain/solve-duration.ts
+++ b/packages/domain/src/solving/domain/solve-duration.ts
@@ -10,17 +10,22 @@ export class SolveDuration {
   private constructor(readonly minutes: number) {}
 
   static ofMinutes(minutes: number): Result<SolveDuration, SolvingError> {
-    if (!Number.isFinite(minutes) || minutes <= 0) {
+    if (!Number.isFinite(minutes)) {
       return err(SolvingError.invalidDuration());
     }
-    return ok(new SolveDuration(Math.round(minutes)));
+    // Round FIRST, then validate the rounded value — a sub-30-second span must be rejected, never
+    // silently stored as 0 (which would violate the positive-minutes invariant).
+    const rounded = Math.round(minutes);
+    if (rounded <= 0) {
+      return err(SolvingError.invalidDuration());
+    }
+    return ok(new SolveDuration(rounded));
   }
 
-  // Derive a duration from a start/end pair (end must be on or after start). A zero-length span
-  // is not a valid solve, so equal instants are rejected as an invalid duration.
+  // Derive a duration from a start/end pair (end must be on or after start). A zero-length (or
+  // negative) span isn't a valid solve; ofMinutes rejects it since it rounds to <= 0 minutes.
   static between(start: Date, end: Date): Result<SolveDuration, SolvingError> {
     const ms = end.getTime() - start.getTime();
-    if (ms <= 0) return err(SolvingError.invalidDuration());
     return SolveDuration.ofMinutes(ms / MS_PER_MINUTE);
   }
 


### PR DESCRIPTION
## Summary

Three fixes following up on #64 (spec: `docs/superpowers/specs/2026-07-14-notification-fixes-design.md`):

1. **Preference toggles: absent ≠ off.** The matrix rendered raw stored toggles, so notification types missing from older preference rows showed all-off while deliveries followed defaults — and enabling in-app was a silent no-op until email/push was toggled (which then *corrupted* the entry by seeding it all-off). Fixed three ways: `allows()` now falls back per channel to the type's default (explicit stored values — including deliberate opt-outs — always win), `set()` seeds missing entries from defaults, and `getMyPreferences` returns a fully resolved 21-type map via the new `resolvedToggles()`. 100% mutation score on the touched aggregate.
   - **Known, accepted limitation:** rows already corrupted pre-fix carry an explicit `inApp: false` indistinguishable from a deliberate email-only setup, so no migration can repair them safely. Affected members (and reviewers testing pre-fix) can simply flip in-app back on — the toggle now works.
2. **Dutch emails.** `users.preferredLanguage` was hardcoded `"en"` and never updated by the language switcher (the app's locale lives in the `jigswap-intl` cookie). A new `SyncPreferredLanguage` shell component reconciles the resolved locale into the member row once per mismatch — switcher-agnostic, SSR-safe, loop-guarded, and it self-heals existing accounts on next load. Notification emails then localize correctly.
3. **Catalogue image fit.** The public catalogue, the member `/puzzles` catalogue, and the `my-puzzles/add` picker (same component) now render box previews `object-contain`, matching my-puzzles. Other surfaces (browse, collections, completions picker, dashboard shelf) remain `cover` — flagged for a separate product decision.

## Test plan

- [x] Domain: 1163/1163; `notification-preference.ts` at 100% Stryker (suite 97.38%, gate 95)
- [x] Backend: 728/728 incl. new resolved-map test
- [x] Web: 153/153; type-check + lint clean across all 6 projects; prettier clean
- [ ] Preview: verify a previously-stuck in-app toggle now works; switch language to nl and confirm the member row updates + a triggered email renders in Dutch; eyeball the contained catalogue images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second batch: completion duration + Dutch terminology

4. **Same-day completions count as one day.** With no explicit duration, a completion whose start and end fall on the same date now stores 1440 minutes (was: unknown, and a near-instant start→finish could even store 0 via a round-after-validate bug in `SolveDuration`, now fixed: round first, reject non-positive). Duration display is day-aware ("1 day"/"1 dag", `2d 3h 15m`) on the completions page and insights stats. Domain files at 100% mutation score; record/finish/edit paths all pinned.
5. **Dutch says "voltooiing", not "oplossing".** All 23 solve-logging/completions/insights/export strings rewritten with per-string grammar (incl. fixing an awkward preposition). Deliberate vocabulary split, reviewer-analyzed: **voltooiing** = the completion event/record; **oplostijd** = elapsed solving time (verb-derived, idiomatic) — duration metrics stay in the oplostijd family. Flag for the native speaker: `oplosgeschiedenis` (completions subtitle) kept; say the word if you want `voltooiingsgeschiedenis`.


## Third batch: container-aware preferences layout

6. **The preferences panel + channel matrix now adapt to their CONTAINER, not the viewport** (Tailwind v4 container queries, mirroring the repo's existing `card.tsx` pattern). Inside the Clerk profile modal (~40rem) they render single-column with the stacked matrix — fixing the overflow there — while the dedicated page keeps the aside layout whenever the container genuinely fits it (≥56rem panel, ≥42rem matrix). Sticky-aside behavior verified safe under `container-type: inline-size`; jump-to links unaffected (they already resolve the visible branch at click time).
